### PR TITLE
Sync reconstruction boundary conditions with popup edits

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/FEMReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/FEMReconstructionPageViewModel.cs
@@ -53,6 +53,9 @@ namespace ElectricalImpedanceTomography.ViewModels
         private FEMMesh _mesh;
         private FEMMesh _reconstructedMesh;
 
+        [ObservableProperty]
+        private FEMBoundaryCondition? boundaryCondition;
+
         private bool _isSimulationRunning = false;
 
         private List<double[]> _simulatedMeasurements = [];
@@ -100,30 +103,40 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public FEMMesh SolveForward(FEMMesh mesh)
         {
-            var electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
-
-            foreach(var el in electrodes)
+            if (BoundaryCondition != null)
             {
-                el.IsExcitation = false;
-                el.IsGround = false;
-                el.Current = 0.0;
-                el.Potential = 0.0;
-                el.ZContact = 0.1;
-                el.Length = ElectrodeSurfaceLength;
-                el.ZContact = ContactImpedance;
+                var bcElectrodes = BoundaryCondition.GetElectrodes().Cast<FEMElectrode>().ToList();
+                mesh.SetElectrodes(bcElectrodes);
             }
+            else
+            {
+                var electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
 
-            if (ExcitationElectrodeId == GroundElectrodeId)
-                ExcitationElectrodeId++;
+                foreach (var el in electrodes)
+                {
+                    el.IsExcitation = false;
+                    el.IsGround = false;
+                    el.Current = 0.0;
+                    el.Potential = 0.0;
+                    el.ZContact = 0.1;
+                    el.Length = ElectrodeSurfaceLength;
+                    el.ZContact = ContactImpedance;
+                }
 
-            electrodes[ExcitationElectrodeId  % ElectrodeCount].IsExcitation = true;
-            electrodes[ExcitationElectrodeId % ElectrodeCount].Current = ExcitationCurrentAmplitude;
-            electrodes[GroundElectrodeId % ElectrodeCount].IsGround = true;
-            electrodes[GroundElectrodeId % ElectrodeCount].Current = -ExcitationCurrentAmplitude;
+                if (ExcitationElectrodeId == GroundElectrodeId)
+                    ExcitationElectrodeId++;
+
+                electrodes[ExcitationElectrodeId % ElectrodeCount].IsExcitation = true;
+                electrodes[ExcitationElectrodeId % ElectrodeCount].Current = ExcitationCurrentAmplitude;
+                electrodes[GroundElectrodeId % ElectrodeCount].IsGround = true;
+                electrodes[GroundElectrodeId % ElectrodeCount].Current = -ExcitationCurrentAmplitude;
+
+                mesh.SetElectrodes(electrodes);
+            }
 
             _reconstructionService.InitializeReconstruction(_mesh, reconstructionParameters);
 
-            var retMesh = _reconstructionService.SolveFemForward(mesh);;
+            var retMesh = _reconstructionService.SolveFemForward(mesh);
 
             _reconstructedMesh.SetPotentialDistribution(retMesh.PotentialDistribution);
 
@@ -134,28 +147,38 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             _reconstructionService.InitializeReconstruction(_mesh, reconstructionParameters);
 
-            var electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
-
-            foreach (var el in electrodes)
+            if (BoundaryCondition != null)
             {
-                el.IsExcitation = false;
-                el.IsGround = false;
-                el.Current = 0.0;
-                el.Potential = 0.0;
-                el.ZContact = 0.1;
-                el.Length = ElectrodeSurfaceLength;
-                el.ZContact = ContactImpedance;
+                var bcElectrodes = BoundaryCondition.GetElectrodes().Cast<FEMElectrode>().ToList();
+                _reconstructedMesh.SetElectrodes(bcElectrodes);
+                mesh.SetElectrodes(bcElectrodes);
             }
+            else
+            {
+                var electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
 
-            if (ExcitationElectrodeId == GroundElectrodeId)
-                ExcitationElectrodeId++;
+                foreach (var el in electrodes)
+                {
+                    el.IsExcitation = false;
+                    el.IsGround = false;
+                    el.Current = 0.0;
+                    el.Potential = 0.0;
+                    el.ZContact = 0.1;
+                    el.Length = ElectrodeSurfaceLength;
+                    el.ZContact = ContactImpedance;
+                }
 
-            electrodes[ExcitationElectrodeId % ElectrodeCount].IsExcitation = true;
-            electrodes[ExcitationElectrodeId % ElectrodeCount].Current = ExcitationCurrentAmplitude;
-            electrodes[GroundElectrodeId % ElectrodeCount].IsGround = true;
-            electrodes[GroundElectrodeId % ElectrodeCount].Current = -ExcitationCurrentAmplitude;
+                if (ExcitationElectrodeId == GroundElectrodeId)
+                    ExcitationElectrodeId++;
 
-            _reconstructedMesh.SetElectrodes(electrodes);
+                electrodes[ExcitationElectrodeId % ElectrodeCount].IsExcitation = true;
+                electrodes[ExcitationElectrodeId % ElectrodeCount].Current = ExcitationCurrentAmplitude;
+                electrodes[GroundElectrodeId % ElectrodeCount].IsGround = true;
+                electrodes[GroundElectrodeId % ElectrodeCount].Current = -ExcitationCurrentAmplitude;
+
+                _reconstructedMesh.SetElectrodes(electrodes);
+                mesh.SetElectrodes(electrodes);
+            }
 
             return _reconstructionService.SolveFemInverse(mesh,
                                                           maxIterCount: MaxIterationCount,
@@ -172,7 +195,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             double[] currentSimulatedMeasurement = _simulatedMeasurements[_simulatedMeasurementsIndex % ElectrodeCount];
 
             // TODO: create the appropirate boundary conditions
-            FEMBoundaryCondition bc = new(_mesh.GetElectrodes().Cast<FEMElectrode>().ToList());
+            FEMBoundaryCondition bc = BoundaryCondition ?? new FEMBoundaryCondition(_mesh.GetElectrodes().Cast<FEMElectrode>().ToList());
 
             ReconstructionResult reconstructionResult = _reconstructionService.InverseSolveStepFem(mesh: _mesh,
                                                                                                    measurement: currentSimulatedMeasurement,
@@ -182,6 +205,14 @@ namespace ElectricalImpedanceTomography.ViewModels
             _simulatedMeasurementsIndex++;
 
             return reconstructionResult;
+        }
+
+        public void ApplyBoundaryCondition(FEMBoundaryCondition bc)
+        {
+            BoundaryCondition = bc;
+            var electrodes = bc.GetElectrodes().Cast<FEMElectrode>().ToList();
+            _mesh.SetElectrodes(electrodes);
+            _reconstructedMesh.SetElectrodes(electrodes);
         }
     }
 }

--- a/ElectricalImpedanceTomography/ViewModels/LBMReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/LBMReconstructionPageViewModel.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using Utility.Classes;
 using Utility.Classes.Factories;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
+using Utility.Classes.Measurement;
 using Utility.Classes.ReconstructionParameters;
 namespace ElectricalImpedanceTomography.ViewModels
 {
@@ -39,6 +40,9 @@ namespace ElectricalImpedanceTomography.ViewModels
         private ReconstructionResult reconstructionResult;
 
         private LBMMesh _mesh;
+
+        [ObservableProperty]
+        private LBMBoundaryCondition? boundaryCondition;
 
         [ObservableProperty]
         private int gridSizeNx = 32;
@@ -98,34 +102,49 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public async void OnSolveForwardClicked(object sender, EventArgs e)
         {
-            var electrodes = _mesh.GetElectrodes().Cast<LBMElectrode>().ToList();
-
-            foreach(var el in electrodes)
+            if (BoundaryCondition != null)
             {
-                el.IsExcitation = false;
-                el.IsGround = false;
-                el.Current = 0.0;
-                el.Potential = 0.0;
+                // Use the user‐defined boundary condition
+                _mesh.SetElectrodes(BoundaryCondition.GetElectrodes());
             }
-
-            electrodes[0].IsExcitation = true;
-            electrodes[1].IsGround = true;
-            electrodes[0].Current = 3.0;
-            electrodes[1].Current = 1.0;
-
-            for (int i = 2; i < electrodes.Count; i++)
+            else
             {
-                if (electrodes[i].IsGround || electrodes[i].IsExcitation) { }
-                else electrodes[i].Potential = (i % 2 == 0) ? 2.0: 1.0;
-            }
-            _mesh.SetElectrodes(electrodes);
+                // Fall back to a simple default configuration
+                var electrodes = _mesh.GetElectrodes().Cast<LBMElectrode>().ToList();
 
+                foreach (var el in electrodes)
+                {
+                    el.IsExcitation = false;
+                    el.IsGround = false;
+                    el.Current = 0.0;
+                    el.Potential = 0.0;
+                }
+
+                electrodes[0].IsExcitation = true;
+                electrodes[1].IsGround = true;
+                electrodes[0].Current = 3.0;
+                electrodes[1].Current = 1.0;
+
+                for (int i = 2; i < electrodes.Count; i++)
+                {
+                    if (!(electrodes[i].IsGround || electrodes[i].IsExcitation))
+                        electrodes[i].Potential = (i % 2 == 0) ? 2.0 : 1.0;
+                }
+
+                _mesh.SetElectrodes(electrodes);
+            }
 
             _reconstructionService.InitializeReconstruction(_mesh, ReconstructionParameters);
 
             ReconstructionResult = await _reconstructionService.GetReconstructionResult();
 
             OnPropertyChanged(nameof(ReconstructionResult));
+        }
+
+        public void ApplyBoundaryCondition(LBMBoundaryCondition bc)
+        {
+            BoundaryCondition = bc;
+            _mesh.SetElectrodes(bc.GetElectrodes());
         }
 
         public void OnSolveInverseClicked(object sender, EventArgs e)

--- a/ElectricalImpedanceTomography/Views/BoundaryConditionPopup.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/BoundaryConditionPopup.xaml.cs
@@ -30,14 +30,11 @@ namespace ElectricalImpedanceTomography.Views
         void OnCancelClicked(object sender, EventArgs e)
           => Close(null);
 
-        // TODO: save really
         void OnSaveClicked(object sender, EventArgs e)
         {
-            // push any list‐level changes back into the BoundaryCondition:
-            //_viewModel.SetBoundaryCondition(_viewModel.GetBoundaryCondition().Electrodes .ToList());
-
-            // re‐initialize ground/excitation indices:
-            //_viewModel.BoundaryCondition.Initialize(_viewModel.BoundaryCondition.Electrodes);
+            // Apply any edits from the popup back into the boundary condition
+            // instance before returning it to the caller.
+            _viewModel.BoundaryCondition.Initialize(_viewModel.Electrodes);
 
             // return the updated BC:
             Close(_viewModel.BoundaryCondition);

--- a/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml.cs
@@ -412,22 +412,16 @@ public partial class FEMReconstructionPage : ContentPage
 
     private async void OnEditBoundaryConditions(object sender, EventArgs e)
     {
-        // build the appropriate BoundaryCondition subclass:
+        // Build a boundary condition from the current mesh or use the one already set
         var electrodes = _viewModel.GetMesh().GetElectrodes().Cast<FEMElectrode>().ToList();
-
-        var bc = new FEMBoundaryCondition(electrodes);
-
+        var bc = _viewModel.BoundaryCondition ?? new FEMBoundaryCondition(electrodes);
 
         var popup = new BoundaryConditionsPopup(bc);
-        // ShowPopupAsync returns whatever you passed to Close(...)
         var result = await this.ShowPopupAsync(popup) as BoundaryCondition;
-        if (result != null)
+        if (result is FEMBoundaryCondition femBc)
         {
-            // user clicked SAVE
-            // apply it to your solver / view‐model:
-//            _viewModel.BoundaryCondition = result;
-            // re‐solve or redraw:
-  //          _viewModel.RunForwardSolve();
+            _viewModel.ApplyBoundaryCondition(femBc);
+            // refresh canvases to reflect any electrode role changes
             PotentialCanvas.InvalidateSurface();
             ConductivityCanvas.InvalidateSurface();
         }

--- a/ElectricalImpedanceTomography/Views/LBMReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/LBMReconstructionPage.xaml.cs
@@ -366,21 +366,19 @@ public partial class LBMReconstructionPage : ContentPage
 
     private async void OnEditBoundaryConditions(object sender, EventArgs e)
     {
-        // build the appropriate BoundaryCondition subclass:
+        // Build a boundary condition based on the current mesh or use the
+        // previously edited one if available.
         var electrodes = _viewModel.GetMesh().GetElectrodes().Cast<LBMElectrode>().ToList();
-
-        var bc = new LBMBoundaryCondition(electrodes);
+        var bc = _viewModel.BoundaryCondition ?? new LBMBoundaryCondition(electrodes);
 
         var popup = new BoundaryConditionsPopup(bc);
-        // ShowPopupAsync returns whatever you passed to Close(...)
         var result = await this.ShowPopupAsync(popup) as BoundaryCondition;
-        if (result != null)
+
+        if (result is LBMBoundaryCondition lbmBc)
         {
-            // user clicked SAVE
-            // apply it to your solver / view‐model:
-            //            _viewModel.BoundaryCondition = result;
-            // re‐solve or redraw:
-            //          _viewModel.RunForwardSolve();
+            // Apply updated boundary conditions to the view model and refresh the view
+            _viewModel.ApplyBoundaryCondition(lbmBc);
+            canvasView.InvalidateSurface();
         }
     }
 


### PR DESCRIPTION
## Summary
- reinitialize boundary conditions from popup edits before closing
- store and apply boundary conditions in LBM and FEM reconstruction view models
- refresh meshes when boundary conditions are saved on reconstruction pages

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce9b37acc83338db5bb5c8c1b1137