### PR TITLE
Run solvers in background and add simulation controls

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/LBMReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/LBMReconstructionPageViewModel.cs
@@ -168,6 +168,14 @@ namespace ElectricalImpedanceTomography.ViewModels
             // TODO: implement
         }
 
+        public ReconstructionResult InverseSolveStep()
+        {
+            var result = _reconstructionService.SolveLbmInverse(1);
+            ReconstructionResult = result;
+            OnPropertyChanged(nameof(ReconstructionResult));
+            return result;
+        }
+
         public void OnReconstructionParametersChanged(object sender, EventArgs e)
         {
             if(sender is Picker picker)

--- a/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml
@@ -130,9 +130,9 @@
 
         <!-- buttons -->
         <Grid Grid.Row="2"
-              RowDefinitions="Auto" 
-              ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto" 
-              HorizontalOptions="Center" 
+              RowDefinitions="Auto"
+              ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
+              HorizontalOptions="Center"
               Padding="10"
               ColumnSpacing="10">
 
@@ -167,15 +167,22 @@
             <Button x:Name="StartStopButton"
                     Style="{StaticResource ButtonStyle}"
                     Grid.Column="4"
-                    Text="Stop"
+                    Text="Start"
                     Clicked="StartStopButtonClicked"/>
 
-            <Button Style="{StaticResource ButtonStyle}"
+            <Button x:Name="StopButton"
+                    Style="{StaticResource ButtonStyle}"
                     Grid.Column="5"
-                    Text="Step"
-                    Clicked="StepButtonClicked"/>
+                    Text="Stop"
+                    Clicked="StopButtonClicked"/>
+
             <Button Style="{StaticResource ButtonStyle}"
                     Grid.Column="6"
+                    Text="Step"
+                    Clicked="StepButtonClicked"/>
+
+            <Button Style="{StaticResource ButtonStyle}"
+                    Grid.Column="7"
                     Text="Edit Boundary Conditions"
                     Clicked="OnEditBoundaryConditions"/>
 

--- a/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml.cs
@@ -6,6 +6,8 @@ using SkiaSharp.Views.Maui.Controls;
 using Utility.Classes.Measurement;
 using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.FiniteElementMesh;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ElectricalImpedanceTomography.Views;
 
@@ -38,6 +40,9 @@ public partial class FEMReconstructionPage : ContentPage
     const float ElectrodeRadius = 6f;
 
     private bool _isSimulationRunning = false;
+    private bool _isPaused = false;
+    private Task? _simulationTask;
+    private CancellationTokenSource? _simulationCts;
 
     // Defining the modes
     private enum PotentialDisplayMode
@@ -401,13 +406,66 @@ public partial class FEMReconstructionPage : ContentPage
 
     private void StartStopButtonClicked(object sender, EventArgs e)
     {
-        _isSimulationRunning = !_isSimulationRunning;
-        // TODO: stop
+        if (_simulationTask == null || _simulationTask.IsCompleted)
+        {
+            _simulationCts = new CancellationTokenSource();
+            _isPaused = false;
+            _simulationTask = RunSimulationLoop(_simulationCts.Token);
+            StartStopButton.Text = "Pause";
+        }
+        else if (!_isPaused)
+        {
+            _isPaused = true;
+            StartStopButton.Text = "Resume";
+        }
+        else
+        {
+            _isPaused = false;
+            StartStopButton.Text = "Pause";
+        }
     }
 
-    private void StepButtonClicked(object sender, EventArgs e)
+    private void StopButtonClicked(object sender, EventArgs e)
     {
-        var result = _viewModel.InverseSolveStep();
+        _simulationCts?.Cancel();
+        _simulationTask = null;
+        _isPaused = false;
+        StartStopButton.Text = "Start";
+    }
+
+    private async void StepButtonClicked(object sender, EventArgs e)
+    {
+        await Task.Run(() => _viewModel.InverseSolveStep());
+        Dispatcher.Dispatch(() =>
+        {
+            PotentialCanvas.InvalidateSurface();
+            ConductivityCanvas.InvalidateSurface();
+            ReconstructionCanvas.InvalidateSurface();
+        });
+    }
+
+    private async Task RunSimulationLoop(CancellationToken token)
+    {
+        _isSimulationRunning = true;
+        while (!token.IsCancellationRequested)
+        {
+            if (_isPaused)
+            {
+                await Task.Delay(100, token);
+                continue;
+            }
+
+            await Task.Run(() => _viewModel.InverseSolveStep());
+
+            Dispatcher.Dispatch(() =>
+            {
+                PotentialCanvas.InvalidateSurface();
+                ConductivityCanvas.InvalidateSurface();
+                ReconstructionCanvas.InvalidateSurface();
+            });
+        }
+
+        _isSimulationRunning = false;
     }
 
     private async void OnEditBoundaryConditions(object sender, EventArgs e)
@@ -596,24 +654,33 @@ public partial class FEMReconstructionPage : ContentPage
         ReconstructionColorbar.InvalidateSurface();
     }
 
-    private void OnSolveForwardClicked(object s, EventArgs e)
+    private async void OnSolveForwardClicked(object s, EventArgs e)
     {
-        _mesh = (FEMMesh)_viewModel.SolveForward(_mesh).DeepCopy();
-        PotentialCanvas.InvalidateSurface();
-        PotentialColorbar.InvalidateSurface();
+        await Task.Run(() =>
+        {
+            _mesh = (FEMMesh)_viewModel.SolveForward(_mesh).DeepCopy();
+        });
+        Dispatcher.Dispatch(() =>
+        {
+            PotentialCanvas.InvalidateSurface();
+            PotentialColorbar.InvalidateSurface();
+        });
     }
 
-    private void OnSolveInverseClicked(object s, EventArgs e)
+    private async void OnSolveInverseClicked(object s, EventArgs e)
     {
-        _reconstructedMesh = (FEMMesh)_mesh.DeepCopy();
-        _reconstructedMesh = (FEMMesh)_viewModel.SolveInverse(_reconstructedMesh).DeepCopy();
-
-        var reconstrucionMeshElements = _reconstructedMesh.GetElements();
-
-        _minRecon = reconstrucionMeshElements.Min(el => el.Conductivity);
-        _maxRecon = reconstrucionMeshElements.Max(el => el.Conductivity);
-
-        ReconstructionCanvas.InvalidateSurface();
-        ReconstructionColorbar.InvalidateSurface();
+        await Task.Run(() =>
+        {
+            _reconstructedMesh = (FEMMesh)_mesh.DeepCopy();
+            _reconstructedMesh = (FEMMesh)_viewModel.SolveInverse(_reconstructedMesh).DeepCopy();
+            var reconstrucionMeshElements = _reconstructedMesh.GetElements();
+            _minRecon = reconstrucionMeshElements.Min(el => el.Conductivity);
+            _maxRecon = reconstrucionMeshElements.Max(el => el.Conductivity);
+        });
+        Dispatcher.Dispatch(() =>
+        {
+            ReconstructionCanvas.InvalidateSurface();
+            ReconstructionColorbar.InvalidateSurface();
+        });
     }
 }

--- a/ElectricalImpedanceTomography/Views/LBMReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/LBMReconstructionPage.xaml
@@ -52,7 +52,7 @@
             <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="2" CurrentPageName="LBMReconstructionPage"/>
             <Grid Grid.Row="1"
                   Grid.Column="0"
-                  ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
+                  ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
                   Padding="1"
                   ColumnSpacing="20"
                   HorizontalOptions="Center">
@@ -110,8 +110,28 @@
                         Margin="10"
                         Text="Solve Inverse"
                         Clicked="OnSolveInverseClicked"/>
-                <Button Style="{StaticResource ButtonStyle}"
+                <Button x:Name="StartStopButton"
                         Grid.Column="8"
+                        Style="{StaticResource ButtonStyle}"
+                        Padding="10"
+                        Margin="10"
+                        Text="Start"
+                        Clicked="StartStopButtonClicked"/>
+                <Button x:Name="StopButton"
+                        Grid.Column="9"
+                        Style="{StaticResource ButtonStyle}"
+                        Padding="10"
+                        Margin="10"
+                        Text="Stop"
+                        Clicked="StopButtonClicked"/>
+                <Button Grid.Column="10"
+                        Style="{StaticResource ButtonStyle}"
+                        Padding="10"
+                        Margin="10"
+                        Text="Step"
+                        Clicked="StepButtonClicked"/>
+                <Button Style="{StaticResource ButtonStyle}"
+                        Grid.Column="11"
                         Text="Edit Boundary Conditions"
                         Clicked="OnEditBoundaryConditions"/>
             </Grid>

--- a/ElectricalImpedanceTomography/Views/LBMReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/LBMReconstructionPage.xaml.cs
@@ -5,6 +5,8 @@ using SkiaSharp.Views.Maui;
 using SkiaSharp.Views.Maui.Controls;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Utility.Classes.Measurement;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 
@@ -42,6 +44,10 @@ public partial class LBMReconstructionPage : ContentPage
     }
 
     private PotentialDisplayMode _potMode = PotentialDisplayMode.Default;
+
+    private Task? _simulationTask;
+    private CancellationTokenSource? _simulationCts;
+    private bool _isPaused = false;
 
     public LBMReconstructionPage()
 	{
@@ -488,20 +494,87 @@ public partial class LBMReconstructionPage : ContentPage
         DrawColorBar(e.Surface.Canvas, e.Info, _condMin, _condMax);
     #endregion
     
-    private void OnSolveForwardClicked(object sender, EventArgs e)
+    private async void OnSolveForwardClicked(object sender, EventArgs e)
     {
-        _viewModel.OnSolveForwardClicked(sender, e);
-        PotentialResultCanvas.InvalidateSurface();
-        CurrentAmplitudeCanvas.InvalidateSurface();
-        ConductivityCanvas.InvalidateSurface();
+        await Task.Run(() => _viewModel.OnSolveForwardClicked(sender, e));
+        Dispatcher.Dispatch(() =>
+        {
+            PotentialResultCanvas.InvalidateSurface();
+            CurrentAmplitudeCanvas.InvalidateSurface();
+            ConductivityCanvas.InvalidateSurface();
+        });
     }
 
-    private void OnSolveInverseClicked(object sender, EventArgs e)
+    private async void OnSolveInverseClicked(object sender, EventArgs e)
     {
-        _viewModel.OnSolveInverseClicked(sender, e);
-        PotentialResultCanvas.InvalidateSurface();
-        CurrentAmplitudeCanvas.InvalidateSurface();
-        ConductivityCanvas.InvalidateSurface();
+        await Task.Run(() => _viewModel.OnSolveInverseClicked(sender, e));
+        Dispatcher.Dispatch(() =>
+        {
+            PotentialResultCanvas.InvalidateSurface();
+            CurrentAmplitudeCanvas.InvalidateSurface();
+            ConductivityCanvas.InvalidateSurface();
+        });
+    }
+
+    private async void StepButtonClicked(object sender, EventArgs e)
+    {
+        await Task.Run(() => _viewModel.InverseSolveStep());
+        Dispatcher.Dispatch(() =>
+        {
+            PotentialResultCanvas.InvalidateSurface();
+            CurrentAmplitudeCanvas.InvalidateSurface();
+            ConductivityCanvas.InvalidateSurface();
+        });
+    }
+
+    private void StartStopButtonClicked(object sender, EventArgs e)
+    {
+        if (_simulationTask == null || _simulationTask.IsCompleted)
+        {
+            _simulationCts = new CancellationTokenSource();
+            _isPaused = false;
+            _simulationTask = RunSimulationLoop(_simulationCts.Token);
+            StartStopButton.Text = "Pause";
+        }
+        else if (!_isPaused)
+        {
+            _isPaused = true;
+            StartStopButton.Text = "Resume";
+        }
+        else
+        {
+            _isPaused = false;
+            StartStopButton.Text = "Pause";
+        }
+    }
+
+    private void StopButtonClicked(object sender, EventArgs e)
+    {
+        _simulationCts?.Cancel();
+        _simulationTask = null;
+        _isPaused = false;
+        StartStopButton.Text = "Start";
+    }
+
+    private async Task RunSimulationLoop(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            if (_isPaused)
+            {
+                await Task.Delay(100, token);
+                continue;
+            }
+
+            await Task.Run(() => _viewModel.InverseSolveStep());
+
+            Dispatcher.Dispatch(() =>
+            {
+                PotentialResultCanvas.InvalidateSurface();
+                CurrentAmplitudeCanvas.InvalidateSurface();
+                ConductivityCanvas.InvalidateSurface();
+            });
+        }
     }
 
     private async void OnEditBoundaryConditions(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- Run forward and inverse solves on background tasks to keep UI responsive
- Add start/pause/stop and step controls for FEM and LBM reconstruction pages
- Enable iterative inverse solve steps via new `InverseSolveStep` method

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f3dc271f4833389de9f384e821b7e