### PR TITLE
feat: add polygon-based mesh generation

### DIFF
--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -2,6 +2,7 @@
 using MIConvexHull;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
+using System.Linq;
 
 namespace Utility.Classes.Factories
 {
@@ -223,6 +224,123 @@ namespace Utility.Classes.Factories
             mesh.SetConductivityDistribution(new ConductivityDistribution(dict));
         }
 
+        /// <summary>
+        /// Create a FEM mesh based on an ordered list of perimeter points forming a single loop.
+        /// The algorithm connects every consecutive boundary point with the centroid, producing
+        /// a fan triangulation.  Electrodes are placed on equally spaced boundary vertices.
+        /// </summary>
+        public static FEMMesh CreatePolygonFEMMesh(IList<(double x, double y)> perimeter, int electrodeCount = 16)
+        {
+            ValidatePerimeter(perimeter);
+
+            var vertices = new List<Vertex>();
+            int vid = 0;
+
+            double cx = perimeter.Average(p => p.x);
+            double cy = perimeter.Average(p => p.y);
+            var center = new Vertex(vid++, cx, cy);
+            vertices.Add(center);
+
+            for (int i = 0; i < perimeter.Count; i++)
+            {
+                var p = perimeter[i];
+                vertices.Add(new Vertex(vid++, p.x, p.y)
+                {
+                    IsBoundary = true,
+                    BoundaryId = i
+                });
+            }
+
+            var elements = new List<FEMElement>();
+            int eid = 0;
+            for (int i = 0; i < perimeter.Count; i++)
+            {
+                var v2 = vertices[i + 1];
+                var v3 = vertices[i + 2 > perimeter.Count ? 1 : i + 2];
+                elements.Add(new FEMElement(eid++, center, v2, v3));
+            }
+
+            var mesh = new FEMMesh(vertices, elements);
+
+            var boundaryVerts = vertices.Skip(1).ToList();
+            electrodeCount = Math.Min(electrodeCount, boundaryVerts.Count);
+            int step = Math.Max(boundaryVerts.Count / electrodeCount, 1);
+
+            var electrodes = new List<FEMElectrode>();
+            for (int e = 0; e < electrodeCount; e++)
+            {
+                var v = boundaryVerts[e * step];
+                v.IsElectrode = true;
+                v.ElectrodeId = e;
+
+                var el = new FEMElectrode(
+                    id: e,
+                    meshId: v.GlobalId,
+                    current: 0.0,
+                    zContact: 0.1,
+                    voltage: 1.0);
+                el.VertexIds.Add(v.GlobalId);
+                electrodes.Add(el);
+            }
+
+            mesh.SetElectrodes(electrodes);
+
+            foreach (var element in elements)
+            {
+                var V1 = element.Vertices[0];
+                var V2 = element.Vertices[1];
+                var V3 = element.Vertices[2];
+                V1.Neighbors.Add(V2); V1.Neighbors.Add(V3);
+                V2.Neighbors.Add(V1); V2.Neighbors.Add(V3);
+                V3.Neighbors.Add(V1); V3.Neighbors.Add(V2);
+            }
+
+            foreach (var element in elements)
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    var v = element.Vertices[i];
+                    for (int j = 0; j < v.Neighbors.Count; j++)
+                    {
+                        for (int k = j + 1; k < v.Neighbors.Count; k++)
+                        {
+                            if (v.Neighbors[j].GlobalId == v.Neighbors[k].GlobalId)
+                            {
+                                v.Neighbors.RemoveAt(k);
+                                k--;
+                            }
+                        }
+                    }
+                }
+            }
+
+            mesh.Initialize();
+            return mesh;
+        }
+
+        /// <summary>
+        /// Convenience wrapper that builds a rectangular FEM mesh from corner points.
+        /// </summary>
+        public static FEMMesh CreateRectangularFEMMesh(double width, double height, int electrodeCount = 16)
+        {
+            var hw = width / 2.0;
+            var hh = height / 2.0;
+            var pts = new List<(double x, double y)>
+            {
+                (-hw, -hh),
+                ( hw, -hh),
+                ( hw,  hh),
+                (-hw,  hh)
+            };
+            return CreatePolygonFEMMesh(pts, electrodeCount);
+        }
+
+        /// <summary>
+        /// Create a FEM mesh from an arbitrary thorax-shaped perimeter.
+        /// </summary>
+        public static FEMMesh CreateThoraxFEMMesh(IList<(double x, double y)> perimeter, int electrodeCount = 16)
+            => CreatePolygonFEMMesh(perimeter, electrodeCount);
+
         private class TriVertex : IVertex
         {
             public double[] Position { get; }
@@ -238,6 +356,62 @@ namespace Utility.Classes.Factories
         #endregion
 
         #region Lattice Boltzmann Mesh Generation
+        public static LBMMesh CreateLBMMeshFromPerimeter(int nx, int ny, IList<(double x, double y)> perimeter, int electrodeCount = 16)
+        {
+            ValidatePerimeter(perimeter);
+            var mesh = new LBMMesh(nx, ny, electrodeCount: 0);
+
+            for (int y = 0; y < ny; y++)
+            {
+                for (int x = 0; x < nx; x++)
+                {
+                    var el = mesh.GetElementAt(x, y);
+                    bool inside = IsPointInPolygon(x + 0.5, y + 0.5, perimeter);
+                    el.IsWall = !inside;
+                    el.IsElectrode = false;
+                }
+            }
+
+            var electrodes = new List<LBMElectrode>();
+            int count = Math.Min(electrodeCount, perimeter.Count);
+            if (count > 0)
+            {
+                int step = Math.Max(perimeter.Count / count, 1);
+                for (int e = 0; e < count; e++)
+                {
+                    var p = perimeter[e * step];
+                    int ix = (int)Math.Round(p.x);
+                    int iy = (int)Math.Round(p.y);
+                    if (ix < 0 || ix >= nx || iy < 0 || iy >= ny) continue;
+                    var cell = mesh.GetElementAt(ix, iy);
+                    cell.IsWall = false;
+                    cell.IsElectrode = true;
+                    electrodes.Add(new LBMElectrode(id: e, gridId: cell.Id, current: 0.0, potential: 0.0, contactImpedance: 0.0));
+                }
+            }
+
+            mesh.SetElectrodes(electrodes);
+
+            var cd = mesh.GetElements().ToDictionary(e => e.Id, e => e.Conductivity);
+            mesh.SetConductivityDistribution(new ConductivityDistribution(cd));
+
+            return mesh;
+        }
+
+        public static LBMMesh CreateRectangularLBMMesh(int nx, int ny, int electrodeCount = 16)
+        {
+            var pts = new List<(double x, double y)>
+            {
+                (1,1),
+                (nx - 2, 1),
+                (nx - 2, ny - 2),
+                (1, ny - 2)
+            };
+            return CreateLBMMeshFromPerimeter(nx, ny, pts, electrodeCount);
+        }
+
+        public static LBMMesh CreateThoraxLBMMesh(int nx, int ny, IList<(double x, double y)> perimeter, int electrodeCount = 16)
+            => CreateLBMMeshFromPerimeter(nx, ny, perimeter, electrodeCount);
 
         private static LBMMesh LBMCreateRectangularWithBorder(int nx = 15, int ny = 15, int electrodeCount = 16)
         {
@@ -260,7 +434,7 @@ namespace Utility.Classes.Factories
                 for (int x = cx - half; x <= cx + half; x++)
                 {
                     // bounds‐check
-                    if (x < 0 || x >= nx || y < 0 || y >= ny) 
+                    if (x < 0 || x >= nx || y < 0 || y >= ny)
                         continue;
 
                     var el = mesh.GetElementAt(x, y);
@@ -332,5 +506,33 @@ namespace Utility.Classes.Factories
 
 
         #endregion
+
+        private static void ValidatePerimeter(IList<(double x, double y)> perimeter)
+        {
+            if (perimeter is null || perimeter.Count < 3)
+                throw new ArgumentException("Perimeter must contain at least three points.");
+            for (int i = 0; i < perimeter.Count; i++)
+            {
+                var a = perimeter[i];
+                var b = perimeter[(i + 1) % perimeter.Count];
+                if (a == b)
+                    throw new ArgumentException("Consecutive perimeter points must be distinct.");
+            }
+        }
+
+        private static bool IsPointInPolygon(double x, double y, IList<(double x, double y)> polygon)
+        {
+            bool inside = false;
+            for (int i = 0, j = polygon.Count - 1; i < polygon.Count; j = i++)
+            {
+                var pi = polygon[i];
+                var pj = polygon[j];
+                bool intersect = ((pi.y > y) != (pj.y > y)) &&
+                    (x < (pj.x - pi.x) * (y - pi.y) / ((pj.y - pi.y) + double.Epsilon) + pi.x);
+                if (intersect)
+                    inside = !inside;
+            }
+            return inside;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support polygonal domains for FEM meshes with fan triangulation and electrode placement
- generate LBM meshes from ordered perimeter points with optional rectangle and thorax helpers
- add perimeter validation and generic point-in-polygon utilities

## Testing
- ⚠️ `dotnet build` (tool not available)
- ⚠️ `apt-get update` (403 errors)
- ⚠️ `apt-get install -y dotnet-sdk-9.0` (package not found)


------
https://chatgpt.com/codex/tasks/task_e_68a2e7a5ca9483339210d8ab7d9b0f34