### PR TITLE
refactor: centralize reconstruction parameters control

### DIFF
--- a/ElectricalImpedanceTomography/Controls/ReconstructionParametersControl.xaml
+++ b/ElectricalImpedanceTomography/Controls/ReconstructionParametersControl.xaml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="ElectricalImpedanceTomography.Controls.ReconstructionParametersControl"
+             xmlns:converters="clr-namespace:ElectricalImpedanceTomography.Converters">
+    <ContentView.Resources>
+        <Style TargetType="Picker">
+            <Setter Property="FontAttributes" Value="Bold"/>
+        </Style>
+        <converters:EnumDescriptionConverter x:Key="EnumDesc" />
+    </ContentView.Resources>
+    <Grid RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*" RowSpacing="5" ColumnSpacing="10">
+        <!-- LBM parameters -->
+        <Grid x:Name="LBMParametersGrid"
+              Grid.Row="0"
+              ColumnDefinitions="Auto,Auto,Auto,Auto,Auto"
+              ColumnSpacing="10">
+            <Picker Grid.Column="0"
+                    Title="Differential Eq. Solver"
+                    ItemsSource="{Binding DifferentialEquationSolverOptions}"
+                    SelectedItem="{Binding ReconstructionParameters.DifferentialEquationSolver}"
+                    ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDesc}}"/>
+            <Picker Grid.Column="1"
+                    Title="Regularisation"
+                    ItemsSource="{Binding RegularizationTechniqueOptions}"
+                    SelectedItem="{Binding ReconstructionParameters.RegularizationTechnique}"
+                    ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDesc}}"/>
+            <Picker Grid.Column="2"
+                    Title="Error metric"
+                    ItemsSource="{Binding ErrorMetricOptions}"
+                    SelectedItem="{Binding ReconstructionParameters.ErrorMetric}"
+                    ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDesc}}"/>
+            <Picker Grid.Column="3"
+                    Title="Numeric solver"
+                    ItemsSource="{Binding NumericSolverOptions}"
+                    SelectedItem="{Binding ReconstructionParameters.NumericSolver}"
+                    ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDesc}}"/>
+            <Picker Grid.Column="4"
+                    Title="Optimizer"
+                    ItemsSource="{Binding NumericOptimizerOptions}"
+                    SelectedItem="{Binding ReconstructionParameters.NumericOptimizer}"
+                    ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDesc}}"/>
+        </Grid>
+        <!-- FEM parameters -->
+        <Grid x:Name="FEMParametersGrid"
+              Grid.Row="1"
+              RowDefinitions="Auto,Auto,Auto,Auto"
+              ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto"
+              RowSpacing="5"
+              ColumnSpacing="10">
+            <!-- Row 0 labels -->
+            <Label Grid.Row="0" Grid.Column="0" Text="Layers:" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <Label Grid.Row="0" Grid.Column="1" Text="Boundary nodes:" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <Label Grid.Row="0" Grid.Column="2" Text="Electrode Count:" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <Label Grid.Row="0" Grid.Column="3" Text="Excitation Id:" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <Label Grid.Row="0" Grid.Column="4" Text="Ground Id:" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <Label Grid.Row="0" Grid.Column="5" Text="Current[mA]:" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <!-- Row 1 entries -->
+            <Entry Grid.Row="1" Grid.Column="0" WidthRequest="80" Keyboard="Numeric" Text="{Binding Layers}"/>
+            <Entry Grid.Row="1" Grid.Column="1" WidthRequest="80" Keyboard="Numeric" Text="{Binding BoundaryNodeCount}"/>
+            <Entry Grid.Row="1" Grid.Column="2" WidthRequest="80" Keyboard="Numeric" Text="{Binding ElectrodeCount}"/>
+            <Entry Grid.Row="1" Grid.Column="3" WidthRequest="80" Keyboard="Numeric" Text="{Binding ExcitationElectrodeId}"/>
+            <Entry Grid.Row="1" Grid.Column="4" WidthRequest="80" Keyboard="Numeric" Text="{Binding GroundElectrodeId}"/>
+            <Entry Grid.Row="1" Grid.Column="5" WidthRequest="80" Keyboard="Numeric" Text="{Binding ExcitationCurrentAmplitude}"/>
+            <!-- Row 2 labels -->
+            <Label Grid.Row="2" Grid.Column="0" Text="Electrode Size[%]:" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <Label Grid.Row="2" Grid.Column="1" Text="Contact Impedance [mΩ]:" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <Label Grid.Row="2" Grid.Column="2" Text="Inhomogenity [mS]:" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <Label Grid.Row="2" Grid.Column="3" Text="Max iteration count:" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <Label Grid.Row="2" Grid.Column="4" Text="Gradient Step Size (β):" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <Label Grid.Row="2" Grid.Column="5" Text="Regularization Weight (θ):" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <!-- Row 3 entries -->
+            <Entry Grid.Row="3" Grid.Column="0" WidthRequest="80" Keyboard="Numeric" Text="{Binding ElectrodeSurfaceLength}"/>
+            <Entry Grid.Row="3" Grid.Column="1" WidthRequest="80" Keyboard="Numeric" Text="{Binding ContactImpedance}"/>
+            <Entry Grid.Row="3" Grid.Column="2" WidthRequest="80" Keyboard="Numeric" Text="{Binding InhomogenityValue}"/>
+            <Entry Grid.Row="3" Grid.Column="3" WidthRequest="80" Keyboard="Numeric" Text="{Binding MaxIterationCount}"/>
+            <Entry Grid.Row="3" Grid.Column="4" WidthRequest="80" Keyboard="Numeric" Text="{Binding StepSize}"/>
+            <Entry Grid.Row="3" Grid.Column="5" WidthRequest="80" Keyboard="Numeric" Text="{Binding RegularizationWeight}"/>
+        </Grid>
+        <!-- Potential mode picker -->
+        <Picker x:Name="PotentialModePicker"
+                Grid.Row="2"
+                Title="Potential Display Mode">
+            <Picker.Items>
+                <x:String>Default</x:String>
+                <x:String>Grayscale</x:String>
+                <x:String>Inverted</x:String>
+                <x:String>Heatmap</x:String>
+                <x:String>Rainbow</x:String>
+            </Picker.Items>
+        </Picker>
+    </Grid>
+</ContentView>

--- a/ElectricalImpedanceTomography/Controls/ReconstructionParametersControl.xaml.cs
+++ b/ElectricalImpedanceTomography/Controls/ReconstructionParametersControl.xaml.cs
@@ -1,0 +1,15 @@
+namespace ElectricalImpedanceTomography.Controls;
+
+public partial class ReconstructionParametersControl : ContentView
+{
+    public event EventHandler<int>? PotentialModeChanged;
+
+    public ReconstructionParametersControl()
+    {
+        InitializeComponent();
+        PotentialModePicker.SelectedIndexChanged += (s, e) =>
+        {
+            PotentialModeChanged?.Invoke(this, PotentialModePicker.SelectedIndex);
+        };
+    }
+}

--- a/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
+++ b/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
@@ -68,21 +68,24 @@
 		<PackageReference Include="SkiaSharp" Version="3.119.0" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\ServiceLayer\ServiceLayer.csproj" />
-	  <ProjectReference Include="..\Utility\Utility.csproj" />
-	</ItemGroup>
+        <ItemGroup>
+          <ProjectReference Include="..\ServiceLayer\ServiceLayer.csproj" />
+          <ProjectReference Include="..\Utility\Utility.csproj" />
+        </ItemGroup>
 
-	<ItemGroup>
-	  <Compile Update="Controls\NavBarControl.xaml.cs">
-	    <DependentUpon>NavBarControl.xaml</DependentUpon>
-	  </Compile>
-	  <Compile Update="Views\LBMReconstructionPage.xaml.cs">
-	    <DependentUpon>LBMReconstructionPage.xaml</DependentUpon>
-	  </Compile>
-	</ItemGroup>
+        <ItemGroup>
+          <Compile Update="Controls\NavBarControl.xaml.cs">
+            <DependentUpon>NavBarControl.xaml</DependentUpon>
+          </Compile>
+          <Compile Update="Controls\ReconstructionParametersControl.xaml.cs">
+            <DependentUpon>ReconstructionParametersControl.xaml</DependentUpon>
+          </Compile>
+          <Compile Update="Views\LBMReconstructionPage.xaml.cs">
+            <DependentUpon>LBMReconstructionPage.xaml</DependentUpon>
+          </Compile>
+        </ItemGroup>
 
-	<ItemGroup>
+        <ItemGroup>
 	  <MauiXaml Update="Controls\NavBarControl.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
@@ -92,12 +95,15 @@
 	  <MauiXaml Update="Views\DAQPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Views\FEMReconstructionPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\LBMReconstructionPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	</ItemGroup>
+          <MauiXaml Update="Views\FEMReconstructionPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\LBMReconstructionPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Controls\ReconstructionParametersControl.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+        </ItemGroup>
 
 </Project>

--- a/ElectricalImpedanceTomography/ViewModels/FEMReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/FEMReconstructionPageViewModel.cs
@@ -13,7 +13,35 @@ namespace ElectricalImpedanceTomography.ViewModels
     {
         private const int defaultMaxIterationCount = 50;
         private readonly ReconstructionService _reconstructionService;
-        
+
+        public IEnumerable<DifferentialEquationSolver> DifferentialEquationSolverOptions
+            => Enum.GetValues(typeof(DifferentialEquationSolver))
+                   .Cast<DifferentialEquationSolver>();
+
+        public IEnumerable<RegularizationTechnique> RegularizationTechniqueOptions
+            => Enum.GetValues(typeof(RegularizationTechnique))
+                   .Cast<RegularizationTechnique>();
+
+        public IEnumerable<ErrorMetric> ErrorMetricOptions
+            => Enum.GetValues(typeof(ErrorMetric))
+                   .Cast<ErrorMetric>();
+
+        public IEnumerable<NumericSolver> NumericSolverOptions
+            => Enum.GetValues(typeof(NumericSolver))
+                   .Cast<NumericSolver>();
+
+        public IEnumerable<NumericOptimizer> NumericOptimizerOptions
+            => Enum.GetValues(typeof(NumericOptimizer))
+                   .Cast<NumericOptimizer>();
+
+        [ObservableProperty]
+        private EITReconstructionParameters reconstructionParameters = new(
+            DifferentialEquationSolver.FiniteElementMethod,
+            RegularizationTechnique.ZeroOrderTikhonov,
+            ErrorMetric.L2,
+            NumericSolver.SVD,
+            NumericOptimizer.GradientBased);
+
         [ObservableProperty]
         private int layers = 2;
 
@@ -61,12 +89,6 @@ namespace ElectricalImpedanceTomography.ViewModels
         private List<double[]> _simulatedMeasurements = [];
         private int _simulatedMeasurementsIndex = 0;
 
-        private EITReconstructionParameters reconstructionParameters = new (DifferentialEquationSolver.FiniteElementMethod, 
-                                                                            RegularizationTechnique.ZeroOrderTikhonov, 
-                                                                            ErrorMetric.L2, 
-                                                                            NumericSolver.SVD, 
-                                                                            NumericOptimizer.GradientBased);
-
         public FEMReconstructionPageViewModel(ReconstructionService reconstructionService)
         {
             _reconstructionService = reconstructionService;
@@ -75,7 +97,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             _reconstructedMesh = GenerateMesh();
 
             // Initialize solver
-            _reconstructionService.InitializeReconstruction(_mesh, reconstructionParameters);            
+            _reconstructionService.InitializeReconstruction(_mesh, ReconstructionParameters);
         }
 
 
@@ -134,7 +156,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                 mesh.SetElectrodes(electrodes);
             }
 
-            _reconstructionService.InitializeReconstruction(_mesh, reconstructionParameters);
+            _reconstructionService.InitializeReconstruction(_mesh, ReconstructionParameters);
 
             var retMesh = _reconstructionService.SolveFemForward(mesh);
 
@@ -145,7 +167,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public FEMMesh SolveInverse(FEMMesh mesh)
         {
-            _reconstructionService.InitializeReconstruction(_mesh, reconstructionParameters);
+            _reconstructionService.InitializeReconstruction(_mesh, ReconstructionParameters);
 
             if (BoundaryCondition != null)
             {

--- a/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml
@@ -45,144 +45,51 @@
     <Grid RowDefinitions="Auto,Auto,Auto,*" ColumnDefinitions="*" RowSpacing="10">
         
         <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="2" CurrentPageName="FEMReconstructionPage"/>
-        <!-- radius & boundary nodes -->
-
-        <Grid Grid.Row="1"
-              HorizontalOptions="Center"
-              RowSpacing="5"
-              ColumnSpacing="10"              
-              RowDefinitions="Auto, Auto, Auto, Auto"
-              ColumnDefinitions="*, *, *, *, *,*, *, *, *, *">
-            
-            <Label Grid.Row="0" Grid.Column="0" Text="Layers:" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="1" Grid.Column="0"
-                   WidthRequest="80"
-                   Keyboard="Numeric"
-                   Text="{Binding Layers}"/>
-
-            <Label Grid.Row="0" Grid.Column="1" Text="Boundary nodes:" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="1" Grid.Column="1"
-                   WidthRequest="80" 
-                   Keyboard="Numeric"
-                   Text="{Binding BoundaryNodeCount}"/>
-
-            <Label Grid.Row="0" Grid.Column="2" Text="Electrode Count:" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="1" Grid.Column="2"
-                   WidthRequest="80" 
-                   Keyboard="Numeric"
-                   Text="{Binding ElectrodeCount}"/>
-
-            <Label Grid.Row="0" Grid.Column="3" Text="Excitation Id:" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="1" Grid.Column="3"
-                   WidthRequest="80" 
-                   Keyboard="Numeric"
-                   Text="{Binding ExcitationElectrodeId}"/>
-
-            <Label Grid.Row="0" Grid.Column="4" Text="Ground Id:" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="1" Grid.Column="4"
-                   WidthRequest="80" 
-                   Keyboard="Numeric"
-                   Text="{Binding GroundElectrodeId}"/>
-
-            <Label Grid.Row="0" Grid.Column="5" Text="Current[mA]:" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="1" Grid.Column="5"
-                   WidthRequest="80" 
-                   Keyboard="Numeric"
-                   Text="{Binding ExcitationCurrentAmplitude}"/>
-
-            <Label Grid.Row="2" Grid.Column="0" Text="Electrode Size[%]:" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="4" Grid.Column="0"
-                   WidthRequest="80" 
-                   Keyboard="Numeric"
-                   Text="{Binding ElectrodeSurfaceLength}"/>
-
-            <Label Grid.Row="2" Grid.Column="1" Text="Contact Impedance [mΩ]:" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="4" Grid.Column="1"
-                   WidthRequest="80" 
-                   Keyboard="Numeric"
-                   Text="{Binding ContactImpedance}"/>
-
-            <Label Grid.Row="2" Grid.Column="2" Text="Inhomogenity [mS]:" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="4" Grid.Column="2"
-                   WidthRequest="80" 
-                   Keyboard="Numeric"
-                   Text="{Binding InhomogenityValue}"/>
-
-            <Label Grid.Row="2" Grid.Column="3" Text="Max iteration count:" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="4" Grid.Column="3"
-                   WidthRequest="80" 
-                   Keyboard="Numeric"
-                   Text="{Binding MaxIterationCount}"/>
-
-            <Label Grid.Row="2" Grid.Column="4" Text="Gradient Step Size (β):" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="4" Grid.Column="4"
-                   WidthRequest="80" 
-                   Keyboard="Numeric"
-                   Text="{Binding StepSize}"/>
-
-            <Label Grid.Row="2" Grid.Column="5" Text="Regularization Weight (θ):" VerticalOptions="Center" HorizontalOptions="Center"/>
-            <Entry Grid.Row="4" Grid.Column="5"
-                   WidthRequest="80" 
-                   Keyboard="Numeric"
-                   Text="{Binding RegularizationWeight}"/>
-        </Grid>
+        <controls:ReconstructionParametersControl Grid.Row="1" PotentialModeChanged="OnPotentialModeChanged" />
 
 
         <!-- buttons -->
         <Grid Grid.Row="2"
               RowDefinitions="Auto"
-              ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
+              ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto"
               HorizontalOptions="Center"
               Padding="10"
               ColumnSpacing="10">
 
             <Button Style="{StaticResource ButtonStyle}"
                     Grid.Column="0"
-                    Text="Generate Mesh" 
+                    Text="Generate Mesh"
                     Clicked="OnGenerateMeshClicked"/>
-            
-            <Picker Grid.Column="1"
-                    x:Name="PotentialModePicker"
-                    Title="Potential Display Mode"
-                    SelectedIndexChanged="OnPotentialModeChanged">
-                <Picker.Items>
-                    <x:String>Default</x:String>
-                    <x:String>Grayscale</x:String>
-                    <x:String>Inverted</x:String>
-                    <x:String>Heatmap</x:String>
-                    <x:String>Rainbow</x:String>
-                </Picker.Items>
-            </Picker>
-            
+
             <Button Style="{StaticResource ButtonStyle}"
-                    Grid.Column="2" 
-                    Text="Solve Forward" 
+                    Grid.Column="1"
+                    Text="Solve Forward"
                     Clicked="OnSolveForwardClicked"/>
 
             <Button Style="{StaticResource ButtonStyle}"
-                    Grid.Column="3" 
-                    Text="Solve Inverse"  
+                    Grid.Column="2"
+                    Text="Solve Inverse"
                     Clicked="OnSolveInverseClicked"/>
 
             <Button x:Name="StartStopButton"
                     Style="{StaticResource ButtonStyle}"
-                    Grid.Column="4"
+                    Grid.Column="3"
                     Text="Start"
                     Clicked="StartStopButtonClicked"/>
 
             <Button x:Name="StopButton"
                     Style="{StaticResource ButtonStyle}"
-                    Grid.Column="5"
+                    Grid.Column="4"
                     Text="Stop"
                     Clicked="StopButtonClicked"/>
 
             <Button Style="{StaticResource ButtonStyle}"
-                    Grid.Column="6"
+                    Grid.Column="5"
                     Text="Step"
                     Clicked="StepButtonClicked"/>
 
             <Button Style="{StaticResource ButtonStyle}"
-                    Grid.Column="7"
+                    Grid.Column="6"
                     Text="Edit Boundary Conditions"
                     Clicked="OnEditBoundaryConditions"/>
 

--- a/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml.cs
@@ -397,9 +397,9 @@ public partial class FEMReconstructionPage : ContentPage
     private void OnReconstructionTouch(object sender, SKTouchEventArgs e)
         => HandleConductivityTouch(e, _reconstructedMesh, ReconstructionCanvas);
 
-    private void OnPotentialModeChanged(object sender, EventArgs e)
+    private void OnPotentialModeChanged(object sender, int selectedIndex)
     {
-        _potMode = (PotentialDisplayMode)PotentialModePicker.SelectedIndex;
+        _potMode = (PotentialDisplayMode)selectedIndex;
         PotentialCanvas.InvalidateSurface();
         PotentialColorbar.InvalidateSurface();
     }

--- a/ElectricalImpedanceTomography/Views/LBMReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/LBMReconstructionPage.xaml
@@ -47,95 +47,52 @@
                 </Setter>
             </Style>
         </ContentPage.Resources>
-        <Grid RowDefinitions="Auto, Auto, Auto">
-        <Grid RowDefinitions="Auto, Auto, *" ColumnDefinitions="*, Auto">
-            <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="2" CurrentPageName="LBMReconstructionPage"/>
-            <Grid Grid.Row="1"
-                  Grid.Column="0"
-                  ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
-                  Padding="1"
-                  ColumnSpacing="20"
-                  HorizontalOptions="Center">
-                <Picker x:Name="DESolverPicker"
-                        Grid.Column="0"
-                        Title="Differential Eq. Solver"
-                        ItemsSource="{Binding DifferentialEquationSolverOptions}"
-                        SelectedItem="{Binding ReconstructionParameters.DifferentialEquationSolver}"
-                        ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDesc}}"/>
-                <Picker x:Name="RegulariaztionPicker"
-                        Grid.Column="1"
-                        Title="Regularisation"
-                        ItemsSource="{Binding RegularizationTechniqueOptions}"
-                        SelectedItem="{Binding ReconstructionParameters.RegularizationTechnique}"
-                        ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDesc}}" />
-                <Picker x:Name="ErrorMetricPicker"
-                        Grid.Column="2"
-                        Title="Error metric"
-                        ItemsSource="{Binding ErrorMetricOptions}"
-                        SelectedItem="{Binding ReconstructionParameters.ErrorMetric}"
-                        ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDesc}}" />
-                <Picker x:Name="NumericSolverPicker"
-                        Grid.Column="3"
-                        Title="Numeric solver"
-                        ItemsSource="{Binding NumericSolverOptions}"
-                        SelectedItem="{Binding ReconstructionParameters.NumericSolver}"
-                        ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDesc}}" />
-                <Picker x:Name="NumericOptimizerPicker"
-                        Grid.Column="4"
-                        Title="Optimizer"
-                        ItemsSource="{Binding NumericOptimizerOptions}"
-                        SelectedItem="{Binding ReconstructionParameters.NumericOptimizer}"
-                        ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDesc}}" />
-                <Picker x:Name="PotentialModePicker"
-                        Grid.Column="5"
-                        Title="Potential Display Mode"
-                        SelectedIndexChanged="OnPotentialModeChanged">
-                    <Picker.Items>
-                        <x:String>Default</x:String>
-                        <x:String>Grayscale</x:String>
-                        <x:String>Inverted</x:String>
-                        <x:String>Heatmap</x:String>
-                        <x:String>Rainbow</x:String>
-                    </Picker.Items>
-                </Picker>
-                <Button Grid.Column="6"
+        <Grid RowDefinitions="Auto, Auto, Auto, *" ColumnDefinitions="*">
+            <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="1" CurrentPageName="LBMReconstructionPage"/>
+            <controls:ReconstructionParametersControl Grid.Row="1" PotentialModeChanged="OnPotentialModeChanged" />
+            <Grid Grid.Row="2"
+                  ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto"
+                  HorizontalOptions="Center"
+                  Padding="10"
+                  ColumnSpacing="10">
+                <Button Grid.Column="0"
                         Style="{StaticResource ButtonStyle}"
                         Padding="10"
                         Margin="10"
                         Text="Solve Forward"
                         Clicked="OnSolveForwardClicked"/>
-                <Button Grid.Column="7"
+                <Button Grid.Column="1"
                         Style="{StaticResource ButtonStyle}"
                         Padding="10"
                         Margin="10"
                         Text="Solve Inverse"
                         Clicked="OnSolveInverseClicked"/>
                 <Button x:Name="StartStopButton"
-                        Grid.Column="8"
+                        Grid.Column="2"
                         Style="{StaticResource ButtonStyle}"
                         Padding="10"
                         Margin="10"
                         Text="Start"
                         Clicked="StartStopButtonClicked"/>
                 <Button x:Name="StopButton"
-                        Grid.Column="9"
+                        Grid.Column="3"
                         Style="{StaticResource ButtonStyle}"
                         Padding="10"
                         Margin="10"
                         Text="Stop"
                         Clicked="StopButtonClicked"/>
-                <Button Grid.Column="10"
+                <Button Grid.Column="4"
                         Style="{StaticResource ButtonStyle}"
                         Padding="10"
                         Margin="10"
                         Text="Step"
                         Clicked="StepButtonClicked"/>
-                <Button Style="{StaticResource ButtonStyle}"
-                        Grid.Column="11"
+                <Button Grid.Column="5"
+                        Style="{StaticResource ButtonStyle}"
                         Text="Edit Boundary Conditions"
                         Clicked="OnEditBoundaryConditions"/>
             </Grid>
-            <Grid Grid.Row="2"
+            <Grid Grid.Row="3"
                   HorizontalOptions="Center"
                   RowDefinitions="Auto, Auto"
                   ColumnDefinitions="Auto, Auto"

--- a/ElectricalImpedanceTomography/Views/LBMReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/LBMReconstructionPage.xaml.cs
@@ -595,9 +595,9 @@ public partial class LBMReconstructionPage : ContentPage
         }
     }
 
-    private void OnPotentialModeChanged(object sender, EventArgs e)
+    private void OnPotentialModeChanged(object sender, int selectedIndex)
     {
-        _potMode = (PotentialDisplayMode)PotentialModePicker.SelectedIndex;
+        _potMode = (PotentialDisplayMode)selectedIndex;
         PotentialResultCanvas.InvalidateSurface();
         CurrentAmplitudeCanvas.InvalidateSurface();
         ConductivityCanvas.InvalidateSurface();


### PR DESCRIPTION
## Summary
- always show all LBM and FEM reconstruction parameters in a single control
- expose reconstruction parameter option lists and observable settings in FEM view model

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ec1089588333819b6c5481be10c2