### PR TITLE
feat: add mesh repository and measurement persistence

### DIFF
--- a/BusinessLayer/DAQPersistence.cs
+++ b/BusinessLayer/DAQPersistence.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Numerics;
 using DataAccessLayer;
+using Utility.Classes;
 using Utility.Classes.Measurement;
 
 namespace BusinessLayer
@@ -7,10 +9,12 @@ namespace BusinessLayer
     public class DAQPersistence : IDAQPersistence
     {
         private readonly IDAQRepository _daqRepository;
+        private readonly IMeshRepository _meshRepository;
 
-        public DAQPersistence(IDAQRepository daqRepository)
+        public DAQPersistence(IDAQRepository daqRepository, IMeshRepository meshRepository)
         {
             _daqRepository = daqRepository;
+            _meshRepository = meshRepository;
         }
 
         public EITMeasurement GetEITMeasurement()
@@ -36,6 +40,31 @@ namespace BusinessLayer
         public Complex[][] ComputeFFT(EITMeasurement measurement)
         {
             return _daqRepository.ComputeFFT(measurement);
+        }
+
+        public void SaveEITMeasurement(EITMeasurement measurement, string name)
+        {
+            _daqRepository.SaveEITMeasurement(measurement, name);
+        }
+
+        public EITMeasurement LoadEITMeasurement(string name, DateTime savedAt)
+        {
+            return _daqRepository.LoadEITMeasurement(name, savedAt);
+        }
+
+        public void DeleteEITMeasurement(string name, DateTime savedAt)
+        {
+            _daqRepository.DeleteEITMeasurement(name, savedAt);
+        }
+
+        public void SaveMesh(IMesh mesh, string name)
+        {
+            _meshRepository.SaveMesh(mesh, name);
+        }
+
+        public IMesh LoadMesh(string name, DateTime savedAt)
+        {
+            return _meshRepository.LoadMesh(name, savedAt);
         }
     }
 }

--- a/BusinessLayer/IDAQPersistence.cs
+++ b/BusinessLayer/IDAQPersistence.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Numerics;
+using Utility.Classes;
 using Utility.Classes.Measurement;
 
 namespace BusinessLayer
@@ -10,6 +12,11 @@ namespace BusinessLayer
         public Complex[][] ComputeDFT(EITMeasurement measurement);
         public double[][] ComputeDCT(EITMeasurement measurement);
         public Complex[][] ComputeFFT(EITMeasurement measurement);
+        public void SaveEITMeasurement(EITMeasurement measurement, string name);
+        public EITMeasurement LoadEITMeasurement(string name, DateTime savedAt);
+        public void DeleteEITMeasurement(string name, DateTime savedAt);
+        public void SaveMesh(IMesh mesh, string name);
+        public IMesh LoadMesh(string name, DateTime savedAt);
     }
 }
 

--- a/DataAccessLayer/DAQRepository.cs
+++ b/DataAccessLayer/DAQRepository.cs
@@ -1,6 +1,9 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
+using System.IO;
 using System.IO.Ports;
 using System.Numerics;
+using System.Linq;
 using System.Text.Json;
 using Utility.Classes.Configurations;
 using Utility.Classes.Measurement;
@@ -338,30 +341,68 @@ namespace DataAccessLayer
 
         // TODO: do something with these like saving and loading from json files
 
-        public void SaveEITMeasurement()
+        public void SaveEITMeasurement(EITMeasurement measurement, string name)
         {
-            throw new NotImplementedException();
+            if (measurement == null) throw new ArgumentNullException(nameof(measurement));
+            if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name required.", nameof(name));
+
+            string dir = Path.Combine(AppContext.BaseDirectory, "Measurements");
+            Directory.CreateDirectory(dir);
+
+            var model = new StoredMeasurement
+            {
+                Name = name,
+                SavedAt = DateTime.UtcNow,
+                Frames = measurement.Frames.ToArray(),
+                FrameSize = measurement.FrameSize,
+                CurrentAmplitude = measurement.CurrentAmplitude
+            };
+
+            string safeName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
+            string file = Path.Combine(dir, $"{safeName}_{model.SavedAt:yyyyMMdd_HHmmss}.json");
+            var opts = new JsonSerializerOptions { WriteIndented = true };
+            File.WriteAllText(file, JsonSerializer.Serialize(model, opts));
         }
 
-        public void LoadEITMeasurement(DateTime dateTime)
+        public EITMeasurement LoadEITMeasurement(string name, DateTime savedAt)
         {
-            throw new NotImplementedException();
+            string dir = Path.Combine(AppContext.BaseDirectory, "Measurements");
+            string safeName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
+            string file = Path.Combine(dir, $"{safeName}_{savedAt:yyyyMMdd_HHmmss}.json");
+            if (!File.Exists(file))
+                throw new FileNotFoundException($"Measurement file not found: {file}");
+
+            var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var model = JsonSerializer.Deserialize<StoredMeasurement>(File.ReadAllText(file), opts)
+                        ?? throw new InvalidOperationException("Failed to deserialize measurement.");
+
+            var frames = model.Frames.Select(f => f.ToArray()).ToList();
+            var measurement = new EITMeasurement(frames)
+            {
+                FrameSize = model.FrameSize,
+                CurrentAmplitude = model.CurrentAmplitude
+            };
+            return measurement;
         }
 
-        public void LoadEITMeasurement(int id)
+        public void DeleteEITMeasurement(string name, DateTime savedAt)
         {
-            throw new NotImplementedException();
+            string dir = Path.Combine(AppContext.BaseDirectory, "Measurements");
+            string safeName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
+            string file = Path.Combine(dir, $"{safeName}_{savedAt:yyyyMMdd_HHmmss}.json");
+            if (File.Exists(file))
+                File.Delete(file);
         }
 
-        public void DeleteEITMeasurement(int id)
+        private sealed class StoredMeasurement
         {
-            throw new NotImplementedException();
+            public string Name { get; set; } = string.Empty;
+            public DateTime SavedAt { get; set; }
+            public double[][] Frames { get; set; } = Array.Empty<double[]>();
+            public int FrameSize { get; set; }
+            public double? CurrentAmplitude { get; set; }
         }
 
-        public void DeleteEITMeasurement(DateTime dateTime)
-        {
-            throw new NotImplementedException();
-        }
 
         /*───────────────────────────────────────────────────────────────────*/
         public void Dispose()

--- a/DataAccessLayer/IDAQRepository.cs
+++ b/DataAccessLayer/IDAQRepository.cs
@@ -10,11 +10,10 @@ namespace DataAccessLayer
         public Complex[][] ComputeDFT(EITMeasurement measurement);
         public double[][] ComputeDCT(EITMeasurement measurement);
         public Complex[][] ComputeFFT(EITMeasurement measurement);
-        public void SaveEITMeasurement();
-        public void LoadEITMeasurement(DateTime dateTime);
-        public void LoadEITMeasurement(int id);
-        public void DeleteEITMeasurement(int id);
-        public void DeleteEITMeasurement(DateTime dateTime);
+
+        public void SaveEITMeasurement(EITMeasurement measurement, string name);
+        public EITMeasurement LoadEITMeasurement(string name, DateTime savedAt);
+        public void DeleteEITMeasurement(string name, DateTime savedAt);
     }
 }
 

--- a/DataAccessLayer/IMeshRepository.cs
+++ b/DataAccessLayer/IMeshRepository.cs
@@ -1,0 +1,11 @@
+using Utility.Classes.Meshing;
+using System;
+
+namespace DataAccessLayer
+{
+    public interface IMeshRepository
+    {
+        void SaveMesh(IMesh mesh, string name);
+        IMesh LoadMesh(string name, DateTime savedAt);
+    }
+}

--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using Utility.Classes.Meshing;
+using Utility.Classes.Meshing.FiniteElementMesh;
+using Utility.Classes.Meshing.GraphMesh;
+using Utility.Classes.Meshing.LatticeBoltzmannMesh;
+
+namespace DataAccessLayer
+{
+    public class MeshRepository : IMeshRepository
+    {
+        public void SaveMesh(IMesh mesh, string name)
+        {
+            if (mesh == null) throw new ArgumentNullException(nameof(mesh));
+            if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name required.", nameof(name));
+
+            Graph graph = mesh switch
+            {
+                FEMMesh fem => fem.ToGraph(),
+                LBMMesh lbm => lbm.ToGraph(),
+                _ => throw new NotSupportedException($"Mesh type {mesh.GetType().Name} not supported.")
+            };
+
+            var model = new StoredMesh
+            {
+                Name = name,
+                SavedAt = DateTime.UtcNow,
+                MeshType = mesh switch
+                {
+                    FEMMesh => MeshType.FEM,
+                    LBMMesh => MeshType.LBM,
+                    _ => throw new NotSupportedException($"Mesh type {mesh.GetType().Name} not supported.")
+                },
+                Graph = graph
+            };
+
+            string dir = Path.Combine(AppContext.BaseDirectory, "Meshes");
+            Directory.CreateDirectory(dir);
+            string safeName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
+            string file = Path.Combine(dir, $"{safeName}_{model.SavedAt:yyyyMMdd_HHmmss}.json");
+            var opts = new JsonSerializerOptions { WriteIndented = true };
+            File.WriteAllText(file, JsonSerializer.Serialize(model, opts));
+        }
+
+        public IMesh LoadMesh(string name, DateTime savedAt)
+        {
+            string dir = Path.Combine(AppContext.BaseDirectory, "Meshes");
+            string safeName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
+            string file = Path.Combine(dir, $"{safeName}_{savedAt:yyyyMMdd_HHmmss}.json");
+            if (!File.Exists(file))
+                throw new FileNotFoundException($"Mesh file not found: {file}");
+
+            var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var model = JsonSerializer.Deserialize<StoredMesh>(File.ReadAllText(file), opts)
+                        ?? throw new InvalidOperationException("Failed to deserialize mesh.");
+
+            return model.MeshType switch
+            {
+                MeshType.FEM => new FEMMesh().FromGraph(model.Graph),
+                MeshType.LBM => new LBMMesh().FromGraph(model.Graph),
+                _ => throw new NotSupportedException($"Unsupported mesh type {model.MeshType}.")
+            };
+        }
+
+        private sealed class StoredMesh
+        {
+            public string Name { get; set; } = string.Empty;
+            public DateTime SavedAt { get; set; }
+            public MeshType MeshType { get; set; }
+            public Graph Graph { get; set; } = null!;
+        }
+
+        private enum MeshType
+        {
+            FEM,
+            LBM
+        }
+    }
+}

--- a/ServiceLayer/DAQService.cs
+++ b/ServiceLayer/DAQService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Numerics;
 using BusinessLayer;
 using System.Diagnostics;
+using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Logger;
 
@@ -83,6 +84,81 @@ namespace ServiceLayer
             try
             {
                 return _daqPersistence.ComputeFFT(measurement);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        public void SaveEITMeasurement(EITMeasurement measurement, string name)
+        {
+            try
+            {
+                _daqPersistence.SaveEITMeasurement(measurement, name);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        public EITMeasurement LoadEITMeasurement(string name, DateTime savedAt)
+        {
+            try
+            {
+                return _daqPersistence.LoadEITMeasurement(name, savedAt);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        public void DeleteEITMeasurement(string name, DateTime savedAt)
+        {
+            try
+            {
+                _daqPersistence.DeleteEITMeasurement(name, savedAt);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        public void SaveMesh(IMesh mesh, string name)
+        {
+            try
+            {
+                _daqPersistence.SaveMesh(mesh, name);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        public IMesh LoadMesh(string name, DateTime savedAt)
+        {
+            try
+            {
+                return _daqPersistence.LoadMesh(name, savedAt);
             }
             catch (Exception ex)
             {

--- a/ServiceLayer/IDAQService.cs
+++ b/ServiceLayer/IDAQService.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Numerics;
+using Utility.Classes;
 using Utility.Classes.Measurement;
 
 namespace ServiceLayer
@@ -10,6 +12,11 @@ namespace ServiceLayer
         public Complex[][] ComputeDFT(EITMeasurement measurement);
         public double[][] ComputeDCT(EITMeasurement measurement);
         public Complex[][] ComputeFFT(EITMeasurement measurement);
+        public void SaveEITMeasurement(EITMeasurement measurement, string name);
+        public EITMeasurement LoadEITMeasurement(string name, DateTime savedAt);
+        public void DeleteEITMeasurement(string name, DateTime savedAt);
+        public void SaveMesh(IMesh mesh, string name);
+        public IMesh LoadMesh(string name, DateTime savedAt);
     }
 }
 


### PR DESCRIPTION
## Summary
- move mesh save/load logic into new `MeshRepository`
- expose mesh and measurement persistence through business and service layers
- implement DAQ repository measurement save/load/delete with metadata

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c914f4d08333ae43e7aa476f8df4