### PR TITLE
Save meshes locally and add electrode controls

### DIFF
--- a/BusinessLayer/DAQPersistence.cs
+++ b/BusinessLayer/DAQPersistence.cs
@@ -62,9 +62,9 @@ namespace BusinessLayer
             _meshRepository.SaveMesh(mesh, name);
         }
 
-        public IMesh LoadMesh(string name, DateTime savedAt)
+        public IMesh LoadMesh(string filePath)
         {
-            return _meshRepository.LoadMesh(name, savedAt);
+            return _meshRepository.LoadMesh(filePath);
         }
     }
 }

--- a/BusinessLayer/IDAQPersistence.cs
+++ b/BusinessLayer/IDAQPersistence.cs
@@ -16,7 +16,7 @@ namespace BusinessLayer
         public EITMeasurement LoadEITMeasurement(string name, DateTime savedAt);
         public void DeleteEITMeasurement(string name, DateTime savedAt);
         public void SaveMesh(IMesh mesh, string name);
-        public IMesh LoadMesh(string name, DateTime savedAt);
+        public IMesh LoadMesh(string filePath);
     }
 }
 

--- a/DataAccessLayer/IMeshRepository.cs
+++ b/DataAccessLayer/IMeshRepository.cs
@@ -5,6 +5,6 @@ namespace DataAccessLayer
     public interface IMeshRepository
     {
         void SaveMesh(IMesh mesh, string name);
-        IMesh LoadMesh(string name, DateTime savedAt);
+        IMesh LoadMesh(string filePath);
     }
 }

--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -35,7 +35,8 @@ namespace DataAccessLayer
                 Graph = graph
             };
 
-            string dir = Path.Combine(AppContext.BaseDirectory, "Meshes");
+            string dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                                       "EITApplication", "Meshes");
             Directory.CreateDirectory(dir);
             string safeName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
             string file = Path.Combine(dir, $"{safeName}_{model.SavedAt:yyyyMMdd_HHmmss}.json");
@@ -43,16 +44,13 @@ namespace DataAccessLayer
             File.WriteAllText(file, JsonSerializer.Serialize(model, opts));
         }
 
-        public IMesh LoadMesh(string name, DateTime savedAt)
+        public IMesh LoadMesh(string filePath)
         {
-            string dir = Path.Combine(AppContext.BaseDirectory, "Meshes");
-            string safeName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
-            string file = Path.Combine(dir, $"{safeName}_{savedAt:yyyyMMdd_HHmmss}.json");
-            if (!File.Exists(file))
-                throw new FileNotFoundException($"Mesh file not found: {file}");
+            if (!File.Exists(filePath))
+                throw new FileNotFoundException($"Mesh file not found: {filePath}");
 
             var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            var model = JsonSerializer.Deserialize<StoredMesh>(File.ReadAllText(file), opts)
+            var model = JsonSerializer.Deserialize<StoredMesh>(File.ReadAllText(filePath), opts)
                         ?? throw new InvalidOperationException("Failed to deserialize mesh.");
 
             return model.MeshType switch

--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -56,6 +56,12 @@ namespace ElectricalImpedanceTomography.ViewModels
         [ObservableProperty]
         private double inhomogenityValue = 1.0;
 
+        [ObservableProperty]
+        private double electrodeContactImpedance = 0.1;
+
+        [ObservableProperty]
+        private double electrodeSize = 0.3;
+
         private IMesh? _currentMesh;
 
         public MeshingPageViewModel(IDAQService dAQService)
@@ -71,14 +77,22 @@ namespace ElectricalImpedanceTomography.ViewModels
                 _daqService.SaveMesh(_currentMesh, Name);
         }
 
-        public void LoadMesh(string name, DateTime savedAt)
+        public void LoadMesh(string filePath)
         {
-            _daqService.LoadMesh(name, savedAt);
+            _currentMesh = _daqService.LoadMesh(filePath);
         }
 
         public void GenerateMesh()
         {
             _currentMesh = selectedMeshType == MeshType.FEM ? GenerateFEMMesh() : GenerateLBMMesh();
+            if (_currentMesh != null)
+            {
+                foreach (var el in _currentMesh.GetElectrodes())
+                    el.ZContact = ElectrodeContactImpedance;
+                if (_currentMesh is FEMMesh fem)
+                    foreach (var el in fem.ElectrodesTyped)
+                        el.Length = ElectrodeSize;
+            }
         }
 
         private FEMMesh GenerateFEMMesh()
@@ -149,7 +163,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             int id = 0;
             foreach (var el in mesh.ElementsTyped)
                 if (el.IsElectrode)
-                    electrodes.Add(new LBMElectrode(id++, el.Id, 0.0, 0.0, 0.0));
+                    electrodes.Add(new LBMElectrode(id++, el.Id, 0.0, 0.0, ElectrodeContactImpedance));
             mesh.SetElectrodes(electrodes);
         }
 

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -12,7 +12,7 @@
         <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="1" CurrentPageName="MeshingPage"/>
 
         <!-- Parameter selection -->
-        <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto">
+        <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
             <Label Grid.Column="0" Text="Mesh" VerticalOptions="Center"/>
             <Picker Grid.Column="1" ItemsSource="{Binding MeshTypes}" SelectedItem="{Binding SelectedMeshType}" WidthRequest="100"/>
 
@@ -40,6 +40,11 @@
 
             <CheckBox Grid.Row="3" Grid.Column="2" IsChecked="{Binding InhomogenityEditing}"/>
             <Entry Grid.Row="3" Grid.Column="3" Text="{Binding InhomogenityValue}" WidthRequest="80" IsVisible="{Binding InhomogenityEditing}" Keyboard="Numeric"/>
+
+            <Label Grid.Row="4" Grid.Column="0" Text="Contact Imp."/>
+            <Entry Grid.Row="4" Grid.Column="1" Text="{Binding ElectrodeContactImpedance}" WidthRequest="60" Keyboard="Numeric"/>
+            <Label Grid.Row="4" Grid.Column="2" Text="Electrode Size" IsVisible="{Binding IsFEM}"/>
+            <Entry Grid.Row="4" Grid.Column="3" Text="{Binding ElectrodeSize}" WidthRequest="60" IsVisible="{Binding IsFEM}" Keyboard="Numeric"/>
         </Grid>
 
         <Border Grid.Row="2"

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -1,6 +1,7 @@
 using ElectricalImpedanceTomography.ViewModels;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
+using Microsoft.Maui.Storage;
 using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
@@ -212,9 +213,14 @@ public partial class MeshingPage : ContentPage
         }
     }
 
-    private void OnLoadClicked(object sender, EventArgs e)
+    private async void OnLoadClicked(object sender, EventArgs e)
     {
-        _viewModel.LoadMesh(string.Empty, DateTime.Now);
+        var file = await FilePicker.Default.PickAsync();
+        if (file != null)
+        {
+            _viewModel.LoadMesh(file.FullPath);
+            MeshCanvas.InvalidateSurface();
+        }
     }
 
     private void OnGenerateClicked(object sender, EventArgs e)

--- a/ServiceLayer/DAQService.cs
+++ b/ServiceLayer/DAQService.cs
@@ -154,11 +154,11 @@ namespace ServiceLayer
             }
         }
 
-        public IMesh LoadMesh(string name, DateTime savedAt)
+        public IMesh LoadMesh(string filePath)
         {
             try
             {
-                return _daqPersistence.LoadMesh(name, savedAt);
+                return _daqPersistence.LoadMesh(filePath);
             }
             catch (Exception ex)
             {

--- a/ServiceLayer/IDAQService.cs
+++ b/ServiceLayer/IDAQService.cs
@@ -16,7 +16,7 @@ namespace ServiceLayer
         public EITMeasurement LoadEITMeasurement(string name, DateTime savedAt);
         public void DeleteEITMeasurement(string name, DateTime savedAt);
         public void SaveMesh(IMesh mesh, string name);
-        public IMesh LoadMesh(string name, DateTime savedAt);
+        public IMesh LoadMesh(string filePath);
     }
 }
 


### PR DESCRIPTION
## Summary
- Store mesh files under a dedicated local application data folder
- Allow loading meshes from a user-selected file via FilePicker
- Expose contact impedance for all electrodes and size for FEM electrodes in UI and mesh generation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa05adc62c833389348e952a8c8c52