### PR TITLE
Fix LBMMesh deserialization and label conductivity editing

### DIFF
--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -40,6 +40,7 @@
                 <Entry Text="{Binding CustomPerimeter}" WidthRequest="200" IsVisible="{Binding IsCustomGeometry}"/>
 
                 <CheckBox IsChecked="{Binding InhomogenityEditing}"/>
+                <Label Text="EditConductivities" VerticalOptions="Center"/>
                 <Entry Text="{Binding InhomogenityValue}" WidthRequest="80" IsVisible="{Binding InhomogenityEditing}" Keyboard="Numeric"/>
 
                 <Label Text="Contact Imp." VerticalOptions="Center"/>

--- a/Utility/Classes/Meshing/LatticeBoltzmannMesh/LBMMesh.cs
+++ b/Utility/Classes/Meshing/LatticeBoltzmannMesh/LBMMesh.cs
@@ -1,4 +1,5 @@
-﻿using Utility.Classes.Factories;
+﻿using System.Text.Json.Serialization;
+using Utility.Classes.Factories;
 using Utility.Classes.Meshing.Graph.Graph;
 
 namespace Utility.Classes.Meshing.LatticeBoltzmannMesh
@@ -25,6 +26,7 @@ namespace Utility.Classes.Meshing.LatticeBoltzmannMesh
         /// </summary>
         /// <param name="nx">Number of cells in the x dimension.</param>
         /// <param name="ny">Number of cells in the y dimension.</param>
+        [JsonConstructor]
         public LBMMesh(int nx = _defaultNx, int ny = _defaultNy, int electrodeNum = 16)
         {
             Nx = nx;


### PR DESCRIPTION
## Summary
- enable JSON deserialization of `LBMMesh` by annotating main constructor
- display "EditConductivities" label next to the conductivity editing toggle

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0db7e0e08333a13af50ab115d6c6