### PR TITLE
Fix loading of FEM mesh

### DIFF
--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -74,11 +74,14 @@ namespace DataAccessLayer
             switch (mesh)
             {
                 case FEMMesh fem:
-                    var cd = fem.ConductivityDistribution;
-                    var pd = fem.PotentialDistribution;
+                    // After deserialization, the FEM mesh already contains
+                    // element conductivities and vertex potentials. Calling
+                    // Initialize() rebuilds internal structures (e.g. edges)
+                    // and reconstructs the distributions from those values.
+                    // Reapplying the previously deserialized distributions is
+                    // unnecessary and, when they are empty due to JSON not
+                    // containing them, leads to key‐mismatch exceptions.
                     fem.Initialize();
-                    fem.SetConductivityDistribution(cd);
-                    fem.SetPotentialDistribution(pd);
                     return fem;
                 case LBMMesh lbm:
                     lbm.RebuildGrid();


### PR DESCRIPTION
## Summary
- Avoid reapplying empty conductivity and potential distributions when loading a FEM mesh
- Rebuild internal structures and return the mesh without triggering key mismatch errors

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0f420bd08333ab29a7db00b9a6e9