### PR TITLE
Add main page layout and typed mesh persistence with metadata

### DIFF
--- a/BusinessLayer/DAQPersistence.cs
+++ b/BusinessLayer/DAQPersistence.cs
@@ -3,6 +3,8 @@ using System.Numerics;
 using DataAccessLayer;
 using Utility.Classes;
 using Utility.Classes.Measurement;
+using Utility.Classes.Meshing.FiniteElementMesh;
+using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 
 namespace BusinessLayer
 {
@@ -57,14 +59,24 @@ namespace BusinessLayer
             _daqRepository.DeleteEITMeasurement(name, savedAt);
         }
 
-        public void SaveMesh(IMesh mesh, string name)
+        public void SaveFEMMesh(FEMMesh mesh, string name)
         {
-            _meshRepository.SaveMesh(mesh, name);
+            _meshRepository.SaveFEMMesh(mesh, name);
         }
 
-        public IMesh LoadMesh(string filePath)
+        public void SaveLBMMesh(LBMMesh mesh, string name)
         {
-            return _meshRepository.LoadMesh(filePath);
+            _meshRepository.SaveLBMMesh(mesh, name);
+        }
+
+        public FEMMesh LoadFEMMesh(string filePath)
+        {
+            return _meshRepository.LoadFEMMesh(filePath);
+        }
+
+        public LBMMesh LoadLBMMesh(string filePath)
+        {
+            return _meshRepository.LoadLBMMesh(filePath);
         }
     }
 }

--- a/BusinessLayer/IDAQPersistence.cs
+++ b/BusinessLayer/IDAQPersistence.cs
@@ -1,22 +1,24 @@
 using System;
 using System.Numerics;
-using Utility.Classes;
 using Utility.Classes.Measurement;
+using Utility.Classes.Meshing.FiniteElementMesh;
+using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 
 namespace BusinessLayer
 {
     public interface IDAQPersistence
     {
-        public EITMeasurement GetEITMeasurement();
-        public Complex[][] ComputeFourierTransform(EITMeasurement measurement);
-        public Complex[][] ComputeDFT(EITMeasurement measurement);
-        public double[][] ComputeDCT(EITMeasurement measurement);
-        public Complex[][] ComputeFFT(EITMeasurement measurement);
-        public void SaveEITMeasurement(EITMeasurement measurement, string name);
-        public EITMeasurement LoadEITMeasurement(string name, DateTime savedAt);
-        public void DeleteEITMeasurement(string name, DateTime savedAt);
-        public void SaveMesh(IMesh mesh, string name);
-        public IMesh LoadMesh(string filePath);
+        EITMeasurement GetEITMeasurement();
+        Complex[][] ComputeFourierTransform(EITMeasurement measurement);
+        Complex[][] ComputeDFT(EITMeasurement measurement);
+        double[][] ComputeDCT(EITMeasurement measurement);
+        Complex[][] ComputeFFT(EITMeasurement measurement);
+        void SaveEITMeasurement(EITMeasurement measurement, string name);
+        EITMeasurement LoadEITMeasurement(string name, DateTime savedAt);
+        void DeleteEITMeasurement(string name, DateTime savedAt);
+        void SaveFEMMesh(FEMMesh mesh, string name);
+        void SaveLBMMesh(LBMMesh mesh, string name);
+        FEMMesh LoadFEMMesh(string filePath);
+        LBMMesh LoadLBMMesh(string filePath);
     }
 }
-

--- a/DataAccessLayer/IMeshRepository.cs
+++ b/DataAccessLayer/IMeshRepository.cs
@@ -1,10 +1,13 @@
-using Utility.Classes;
+using Utility.Classes.Meshing.FiniteElementMesh;
+using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 
 namespace DataAccessLayer
 {
     public interface IMeshRepository
     {
-        void SaveMesh(IMesh mesh, string name);
-        IMesh LoadMesh(string filePath);
+        void SaveFEMMesh(FEMMesh mesh, string name);
+        void SaveLBMMesh(LBMMesh mesh, string name);
+        FEMMesh LoadFEMMesh(string filePath);
+        LBMMesh LoadLBMMesh(string filePath);
     }
 }

--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -1,91 +1,84 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Utility.Classes;
+using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
-using Utility.Classes;
 
 namespace DataAccessLayer
 {
     public class MeshRepository : IMeshRepository
     {
-        public void SaveMesh(IMesh mesh, string name)
+        private static JsonSerializerOptions Options => new()
+        {
+            IncludeFields = true,
+            ReferenceHandler = ReferenceHandler.Preserve,
+            MaxDepth = 1024
+        };
+
+        private static string MeshDir => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                                                       "EITApplication", "Meshes");
+
+        public void SaveFEMMesh(FEMMesh mesh, string name) => Save(mesh, name, "fem");
+        public void SaveLBMMesh(LBMMesh mesh, string name) => Save(mesh, name, "lbm");
+
+        public FEMMesh LoadFEMMesh(string filePath) => Load<FEMMesh>(filePath, fem =>
+        {
+            var cd = fem.ConductivityDistribution;
+            var pd = fem.PotentialDistribution;
+            fem.Initialize();
+            fem.SetConductivityDistribution(cd);
+            fem.SetPotentialDistribution(pd);
+        });
+
+        public LBMMesh LoadLBMMesh(string filePath) => Load<LBMMesh>(filePath, lbm =>
+        {
+            lbm.RebuildGrid();
+            lbm.SetConductivityDistribution(lbm.ConductivityDistribution);
+            lbm.SetPotentialDistribution(lbm.PotentialDistribution);
+        });
+
+        private void Save<TMesh>(TMesh mesh, string name, string suffix) where TMesh : Mesh
         {
             if (mesh == null) throw new ArgumentNullException(nameof(mesh));
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name required.", nameof(name));
 
-            var meshOptions = new JsonSerializerOptions
-            {
-                IncludeFields = true,
-                ReferenceHandler = ReferenceHandler.Preserve,
-                MaxDepth = 1024
-            };
-
-            var model = new StoredMesh
+            var model = new StoredMesh<TMesh>
             {
                 Name = name,
                 SavedAt = DateTime.UtcNow,
-                MeshType = mesh.GetType().AssemblyQualifiedName
-                            ?? mesh.GetType().FullName
-                            ?? throw new InvalidOperationException("Cannot determine mesh type."),
-                Mesh = JsonSerializer.SerializeToElement(mesh, mesh.GetType(), meshOptions)
+                Metadata = mesh.Metadata,
+                Mesh = mesh
             };
 
-            string dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                                       "EITApplication", "Meshes");
-            Directory.CreateDirectory(dir);
+            Directory.CreateDirectory(MeshDir);
             string safeName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
-            string file = Path.Combine(dir, $"{safeName}_{model.SavedAt:yyyyMMdd_HHmmss}.json");
+            string file = Path.Combine(MeshDir, $"{safeName}_{model.SavedAt:yyyyMMdd_HHmmss}_{suffix}.json");
             var opts = new JsonSerializerOptions { WriteIndented = true, MaxDepth = 1024 };
             File.WriteAllText(file, JsonSerializer.Serialize(model, opts));
         }
 
-        public IMesh LoadMesh(string filePath)
+        private TMesh Load<TMesh>(string filePath, Action<TMesh> fixer) where TMesh : Mesh
         {
             if (!File.Exists(filePath))
                 throw new FileNotFoundException($"Mesh file not found: {filePath}");
 
             var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true, MaxDepth = 1024 };
-            var model = JsonSerializer.Deserialize<StoredMesh>(File.ReadAllText(filePath), opts)
+            var model = JsonSerializer.Deserialize<StoredMesh<TMesh>>(File.ReadAllText(filePath), opts)
                         ?? throw new InvalidOperationException("Failed to deserialize mesh.");
 
-            var meshOpts = new JsonSerializerOptions
-            {
-                IncludeFields = true,
-                ReferenceHandler = ReferenceHandler.Preserve,
-                MaxDepth = 1024
-            };
-
-            var type = Type.GetType(model.MeshType)
-                       ?? throw new NotSupportedException($"Unsupported mesh type {model.MeshType}.");
-
-            IMesh mesh = (IMesh)(model.Mesh.Deserialize(type, meshOpts)
-                       ?? throw new InvalidOperationException("Failed to deserialize mesh."));
-
-            switch (mesh)
-            {
-                case FEMMesh fem:
-                    var cd = fem.ConductivityDistribution;
-                    var pd = fem.PotentialDistribution;
-                    fem.Initialize();
-                    fem.SetConductivityDistribution(cd);
-                    fem.SetPotentialDistribution(pd);
-                    return fem;
-                case LBMMesh lbm:
-                    lbm.RebuildGrid();
-                    lbm.SetConductivityDistribution(lbm.ConductivityDistribution);
-                    lbm.SetPotentialDistribution(lbm.PotentialDistribution);
-                    return lbm;
-                default:
-                    throw new NotSupportedException($"Unsupported mesh instance {mesh.GetType().Name}.");
-            }
+            TMesh mesh = model.Mesh ?? throw new InvalidOperationException("Mesh payload missing.");
+            mesh.Metadata = model.Metadata ?? new MeshMetadata();
+            fixer(mesh);
+            return mesh;
         }
 
-        private sealed class StoredMesh
+        private sealed class StoredMesh<T>
         {
             public string Name { get; set; } = string.Empty;
             public DateTime SavedAt { get; set; }
-            public string MeshType { get; set; } = string.Empty;
-            public JsonElement Mesh { get; set; }
+            public MeshMetadata? Metadata { get; set; }
+            public T? Mesh { get; set; }
         }
     }
 }

--- a/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
@@ -1,10 +1,31 @@
-﻿namespace ElectricalImpedanceTomography.ViewModels
+using System;
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Utility.Classes.ReconstructionParameters;
+
+namespace ElectricalImpedanceTomography.ViewModels
 {
     public partial class MainPageViewModel : BaseViewModel
-    {        
+    {
+        [ObservableProperty]
+        private string debugLog = string.Empty;
+
+        [ObservableProperty]
+        private EITReconstructionParameters reconstructionParameters = new();
+
+        public IEnumerable<DifferentialEquationSolver> Solvers => Enum.GetValues<DifferentialEquationSolver>();
+        public IEnumerable<RegularizationTechnique> Regularizations => Enum.GetValues<RegularizationTechnique>();
+
+        public IAsyncRelayCommand<string> NavigateCommand { get; }
+        public IAsyncRelayCommand LoadMeasurementCommand { get; }
+        public IAsyncRelayCommand LoadMeshCommand { get; }
+
         public MainPageViewModel()
         {
-
+            NavigateCommand = new AsyncRelayCommand<string>(async (route) => await Shell.Current.GoToAsync(route));
+            LoadMeasurementCommand = new AsyncRelayCommand(async () => await Task.CompletedTask);
+            LoadMeshCommand = new AsyncRelayCommand(async () => await Task.CompletedTask);
         }
     }
 }

--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -73,18 +73,38 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public void SaveMesh()
         {
-            if (_currentMesh != null)
-                _daqService.SaveMesh(_currentMesh, Name);
+            if (_currentMesh is FEMMesh fem)
+                _daqService.SaveFEMMesh(fem, Name);
+            else if (_currentMesh is LBMMesh lbm)
+                _daqService.SaveLBMMesh(lbm, Name);
         }
 
         public void LoadMesh(string filePath)
         {
-            _currentMesh = _daqService.LoadMesh(filePath);
+            _currentMesh = SelectedMeshType == MeshType.FEM
+                ? _daqService.LoadFEMMesh(filePath)
+                : _daqService.LoadLBMMesh(filePath);
         }
 
         public void GenerateMesh()
         {
             _currentMesh = selectedMeshType == MeshType.FEM ? GenerateFEMMesh() : GenerateLBMMesh();
+            if (_currentMesh != null)
+            {
+                _currentMesh.Metadata = new MeshMetadata
+                {
+                    CreatedOn = DateTime.UtcNow,
+                    Generator = $"{SelectedMeshType}-{SelectedGeometry}",
+                    Parameters = new Dictionary<string, string>
+                    {
+                        {"Layers", Layers.ToString()},
+                        {"BoundaryFEMVertexCount", BoundaryFEMVertexCount.ToString()},
+                        {"ElectrodeCount", ElectrodeCount.ToString()},
+                        {"Nx", Nx.ToString()},
+                        {"Ny", Ny.ToString()}
+                    }
+                };
+            }
             if (_currentMesh != null)
             {
                 foreach (var el in _currentMesh.GetElectrodes())

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml
@@ -1,22 +1,46 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="ElectricalImpedanceTomography.Views.MainPage"
              xmlns:viewmodels="clr-namespace:ElectricalImpedanceTomography.ViewModels"
              xmlns:controls="clr-namespace:ElectricalImpedanceTomography.Controls"
              x:DataType="viewmodels:MainPageViewModel"
-             Shell.NavBarIsVisible="False" 
+             Shell.NavBarIsVisible="False"
              Title="MainPage">
-
-    <ScrollView>
-        <Grid RowDefinitions="Auto, Auto">
-            <controls:NavBarControl Grid.Row="0" CurrentPageName="MainPage"/>
-            <VerticalStackLayout Grid.Row="1"
-                                Padding="30,0"
-                                Spacing="25">
-                <Label Text="Hello world!"/>
+    <Grid RowDefinitions="Auto,*" ColumnDefinitions="200,*">
+        <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="2" CurrentPageName="MainPage"/>
+        <Border Grid.Row="1" Grid.Column="0" Stroke="Gray" StrokeThickness="1" Padding="10" Margin="10">
+            <VerticalStackLayout Spacing="8">
+                <Label Text="Navigation" FontAttributes="Bold"/>
+                <Button Text="DAQ" Command="{Binding NavigateCommand}" CommandParameter="DAQPage"/>
+                <Button Text="Meshing" Command="{Binding NavigateCommand}" CommandParameter="MeshingPage"/>
+                <Button Text="LBM Reconstruction" Command="{Binding NavigateCommand}" CommandParameter="LBMReconstructionPage"/>
+                <Button Text="FEM Reconstruction" Command="{Binding NavigateCommand}" CommandParameter="FEMReconstructionPage"/>
             </VerticalStackLayout>
-        </Grid>
-    </ScrollView>
-
+        </Border>
+        <ScrollView Grid.Row="1" Grid.Column="1">
+            <VerticalStackLayout Spacing="10" Padding="10">
+                <Border Stroke="LightGray" StrokeThickness="1" Padding="10">
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Configuration" FontAttributes="Bold"/>
+                        <Picker Title="Solver" ItemsSource="{Binding Solvers}" SelectedItem="{Binding ReconstructionParameters.DifferentialEquationSolver}"/>
+                        <Picker Title="Regularization" ItemsSource="{Binding Regularizations}" SelectedItem="{Binding ReconstructionParameters.RegularizationTechnique}"/>
+                    </VerticalStackLayout>
+                </Border>
+                <Border Stroke="LightGray" StrokeThickness="1" Padding="10">
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Toolbox" FontAttributes="Bold"/>
+                        <Button Text="Load Measurement" Command="{Binding LoadMeasurementCommand}"/>
+                        <Button Text="Load Mesh" Command="{Binding LoadMeshCommand}"/>
+                    </VerticalStackLayout>
+                </Border>
+                <Border Stroke="LightGray" StrokeThickness="1" Padding="10">
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Debug" FontAttributes="Bold"/>
+                        <Editor Text="{Binding DebugLog}" HeightRequest="120" IsReadOnly="True"/>
+                    </VerticalStackLayout>
+                </Border>
+            </VerticalStackLayout>
+        </ScrollView>
+    </Grid>
 </ContentPage>

--- a/ServiceLayer/DAQService.cs
+++ b/ServiceLayer/DAQService.cs
@@ -2,7 +2,8 @@ using System;
 using System.Numerics;
 using BusinessLayer;
 using System.Diagnostics;
-using Utility.Classes;
+using Utility.Classes.Meshing.FiniteElementMesh;
+using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Utility.Classes.Measurement;
 using Utility.Logger;
 
@@ -139,11 +140,11 @@ namespace ServiceLayer
             }
         }
 
-        public void SaveMesh(IMesh mesh, string name)
+        public void SaveFEMMesh(FEMMesh mesh, string name)
         {
             try
             {
-                _daqPersistence.SaveMesh(mesh, name);
+                _daqPersistence.SaveFEMMesh(mesh, name);
             }
             catch (Exception ex)
             {
@@ -154,11 +155,41 @@ namespace ServiceLayer
             }
         }
 
-        public IMesh LoadMesh(string filePath)
+        public void SaveLBMMesh(LBMMesh mesh, string name)
         {
             try
             {
-                return _daqPersistence.LoadMesh(filePath);
+                _daqPersistence.SaveLBMMesh(mesh, name);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        public FEMMesh LoadFEMMesh(string filePath)
+        {
+            try
+            {
+                return _daqPersistence.LoadFEMMesh(filePath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        public LBMMesh LoadLBMMesh(string filePath)
+        {
+            try
+            {
+                return _daqPersistence.LoadLBMMesh(filePath);
             }
             catch (Exception ex)
             {

--- a/ServiceLayer/IDAQService.cs
+++ b/ServiceLayer/IDAQService.cs
@@ -1,22 +1,24 @@
 using System;
 using System.Numerics;
-using Utility.Classes;
 using Utility.Classes.Measurement;
+using Utility.Classes.Meshing.FiniteElementMesh;
+using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 
 namespace ServiceLayer
 {
     public interface IDAQService
     {
-        public EITMeasurement GetEITMeasurement();
-        public Complex[][] ComputeFourierTransform(EITMeasurement measurement);
-        public Complex[][] ComputeDFT(EITMeasurement measurement);
-        public double[][] ComputeDCT(EITMeasurement measurement);
-        public Complex[][] ComputeFFT(EITMeasurement measurement);
-        public void SaveEITMeasurement(EITMeasurement measurement, string name);
-        public EITMeasurement LoadEITMeasurement(string name, DateTime savedAt);
-        public void DeleteEITMeasurement(string name, DateTime savedAt);
-        public void SaveMesh(IMesh mesh, string name);
-        public IMesh LoadMesh(string filePath);
+        EITMeasurement GetEITMeasurement();
+        Complex[][] ComputeFourierTransform(EITMeasurement measurement);
+        Complex[][] ComputeDFT(EITMeasurement measurement);
+        double[][] ComputeDCT(EITMeasurement measurement);
+        Complex[][] ComputeFFT(EITMeasurement measurement);
+        void SaveEITMeasurement(EITMeasurement measurement, string name);
+        EITMeasurement LoadEITMeasurement(string name, DateTime savedAt);
+        void DeleteEITMeasurement(string name, DateTime savedAt);
+        void SaveFEMMesh(FEMMesh mesh, string name);
+        void SaveLBMMesh(LBMMesh mesh, string name);
+        FEMMesh LoadFEMMesh(string filePath);
+        LBMMesh LoadLBMMesh(string filePath);
     }
 }
-

--- a/Utility/Classes/Meshing/FiniteElementMesh/FEMMesh.cs
+++ b/Utility/Classes/Meshing/FiniteElementMesh/FEMMesh.cs
@@ -1,4 +1,5 @@
 ﻿using Utility.Classes.Factories;
+using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 
 namespace Utility.Classes.Meshing.FiniteElementMesh
@@ -123,7 +124,15 @@ namespace Utility.Classes.Meshing.FiniteElementMesh
                 newElements.Add(el2);
             }
 
-            var copy = new FEMMesh(newVertices, newElements);
+            var copy = new FEMMesh(newVertices, newElements)
+            {
+                Metadata = new MeshMetadata
+                {
+                    CreatedOn = this.Metadata.CreatedOn,
+                    Generator = this.Metadata.Generator,
+                    Parameters = new Dictionary<string, string>(this.Metadata.Parameters)
+                }
+            };
 
             if (_electrodes.Count > 0)
             {

--- a/Utility/Classes/Meshing/LatticeBoltzmannMesh/LBMMesh.cs
+++ b/Utility/Classes/Meshing/LatticeBoltzmannMesh/LBMMesh.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 using Utility.Classes.Factories;
+using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.Graph.Graph;
 
 namespace Utility.Classes.Meshing.LatticeBoltzmannMesh
@@ -231,7 +232,15 @@ namespace Utility.Classes.Meshing.LatticeBoltzmannMesh
 
         public override Mesh DeepCopy()
         {
-            var copy = new LBMMesh(Nx, Ny);
+            var copy = new LBMMesh(Nx, Ny)
+            {
+                Metadata = new MeshMetadata
+                {
+                    CreatedOn = this.Metadata.CreatedOn,
+                    Generator = this.Metadata.Generator,
+                    Parameters = new Dictionary<string, string>(this.Metadata.Parameters)
+                }
+            };
 
             // copy element state
             for (int i = 0; i < _elements.Count; i++)

--- a/Utility/Classes/Meshing/Mesh.cs
+++ b/Utility/Classes/Meshing/Mesh.cs
@@ -25,6 +25,8 @@ namespace Utility.Classes
 
 
         Mesh DeepCopy();
+
+        MeshMetadata Metadata { get; set; }
     }
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Utility.Classes
     {
         public abstract ConductivityDistribution ConductivityDistribution { get; protected set; }
         public abstract PotentialDistribution PotentialDistribution { get; protected set; }
+
+        public MeshMetadata Metadata { get; set; } = new();
 
         public ConductivityDistribution GetConductivityDistribution() => ConductivityDistribution;
         public PotentialDistribution GetPotentialDistribution() => PotentialDistribution;

--- a/Utility/Classes/Meshing/MeshMetadata.cs
+++ b/Utility/Classes/Meshing/MeshMetadata.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace Utility.Classes.Meshing
+{
+    public class MeshMetadata
+    {
+        public DateTime CreatedOn { get; set; } = DateTime.UtcNow;
+        public string Generator { get; set; } = string.Empty;
+        public Dictionary<string, string> Parameters { get; set; } = new();
+    }
+}


### PR DESCRIPTION
## Summary
- redesign main page with navigation menu, configuration settings, toolbox and debug window
- introduce MeshMetadata to track creation details and attach it to meshes
- add FEM/LBM-specific mesh save/load routines that persist metadata

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68ae39c65ca083339feee279a8cf9704