### PR TITLE
Add channel configuration dialog and SF Pro plot font

### DIFF
--- a/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
+++ b/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
@@ -89,12 +89,15 @@
 	  <MauiXaml Update="Controls\NavBarControl.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Views\BoundaryConditionPopup.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\DAQPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
+          <MauiXaml Update="Views\BoundaryConditionPopup.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\ChannelSettingsPopup.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\DAQPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
           <MauiXaml Update="Views\FEMReconstructionPage.xaml">
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>

--- a/ElectricalImpedanceTomography/ViewModels/DAQPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/DAQPageViewModel.cs
@@ -1,4 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Maui.Views;
+using ElectricalImpedanceTomography.Views;
 using OxyPlot;
 using OxyPlot.Axes;
 using OxyPlot.Series;
@@ -20,9 +23,14 @@ namespace ElectricalImpedanceTomography.ViewModels
         private readonly double _windowDays = TimeWindowSecs / 86400.0;
         private readonly DateTime _startTime;
 
+        private readonly double[] _channelGains = new double[16];
+        private readonly double[] _channelOffsets = new double[16];
+
         public DAQPageViewModel(IDAQService daqService)
         {
             _daqService = daqService;
+
+            Array.Fill(_channelGains, 1.0);
 
             _startTime = DateTime.Now;
             InitializePlots();
@@ -48,7 +56,10 @@ namespace ElectricalImpedanceTomography.ViewModels
                     TitleColor = OxyColors.DarkSlateGray,
                     IsLegendVisible = true,
                     TitleFontWeight = OxyPlot.FontWeights.Bold,
-                    PlotMargins = new OxyThickness(20, 20, 20, 20)
+                    PlotMargins = new OxyThickness(20, 20, 20, 20),
+                    DefaultFont = "SF Pro Text",
+                    TitleFont = "SF Pro Text",
+                    LegendFont = "SF Pro Text"
 
                 };
                 var series = new LineSeries
@@ -70,15 +81,45 @@ namespace ElectricalImpedanceTomography.ViewModels
                     MajorGridlineStyle = LineStyle.Solid,
                     MinorGridlineStyle = LineStyle.Dot,
                     IsZoomEnabled = false,
-                    IsPanEnabled = false
+                    IsPanEnabled = false,
+                    Font = "SF Pro Text",
+                    TitleFont = "SF Pro Text"
+                };
+                var valueAxis = new LinearAxis
+                {
+                    Position = AxisPosition.Left,
+                    TextColor = OxyColors.DarkSlateGray,
+                    MajorGridlineStyle = LineStyle.Solid,
+                    MinorGridlineStyle = LineStyle.Dot,
+                    IsZoomEnabled = false,
+                    IsPanEnabled = false,
+                    Font = "SF Pro Text",
+                    TitleFont = "SF Pro Text"
                 };
                 plotModel.Axes.Add(dateAxis);
+                plotModel.Axes.Add(valueAxis);
                 plotModel.Series.Add(series);
 
                 dateAxis.Minimum = DateTimeAxis.ToDouble(_startTime.AddSeconds(-TimeWindowSecs));
                 dateAxis.Maximum = DateTimeAxis.ToDouble(_startTime);
 
                 PlotModels.Add(plotModel);
+            }
+        }
+
+        [RelayCommand]
+        private async Task ConfigureChannelAsync(PlotModel model)
+        {
+            int index = PlotModels.IndexOf(model);
+            if (index < 0)
+                return;
+
+            var popup = new ChannelSettingsPopup(_channelGains[index], _channelOffsets[index]);
+            var result = await Application.Current.MainPage.ShowPopupAsync(popup);
+            if (result is ValueTuple<double, double> tuple)
+            {
+                _channelGains[index] = tuple.Item1;
+                _channelOffsets[index] = tuple.Item2;
             }
         }
         // Example measurement data:
@@ -122,7 +163,10 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             // Add new
             double x = DateTimeAxis.ToDouble(timestamp);
-            series.Points.Add(new DataPoint(x, value));
+            int idx = PlotModels.IndexOf(model);
+            double gain = _channelGains[idx];
+            double offset = _channelOffsets[idx];
+            series.Points.Add(new DataPoint(x, value * gain + offset));
 
             // Trim old
             if (series.Points.Count > MaxPoints)

--- a/ElectricalImpedanceTomography/Views/ChannelSettingsPopup.xaml
+++ b/ElectricalImpedanceTomography/Views/ChannelSettingsPopup.xaml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+               xmlns:toolkit="clr-namespace:CommunityToolkit.Maui.Views;assembly=CommunityToolkit.Maui"
+               x:Class="ElectricalImpedanceTomography.Views.ChannelSettingsPopup">
+    <Border Padding="16" BackgroundColor="White">
+        <VerticalStackLayout Spacing="8">
+            <Label Text="Channel Settings" FontAttributes="Bold" FontFamily="SF Pro Text" />
+            <Entry x:Name="GainEntry" Placeholder="Gain" Keyboard="Numeric" FontFamily="SF Pro Text" />
+            <Entry x:Name="OffsetEntry" Placeholder="Offset" Keyboard="Numeric" FontFamily="SF Pro Text" />
+            <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                <Button Text="Cancel" Clicked="OnCancelClicked" />
+                <Button Grid.Column="1" Text="Save" Clicked="OnSaveClicked" />
+            </Grid>
+        </VerticalStackLayout>
+    </Border>
+</toolkit:Popup>

--- a/ElectricalImpedanceTomography/Views/ChannelSettingsPopup.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ChannelSettingsPopup.xaml.cs
@@ -1,0 +1,23 @@
+using System;
+using CommunityToolkit.Maui.Views;
+
+namespace ElectricalImpedanceTomography.Views;
+
+public partial class ChannelSettingsPopup : Popup
+{
+    public ChannelSettingsPopup(double gain, double offset)
+    {
+        InitializeComponent();
+        GainEntry.Text = gain.ToString();
+        OffsetEntry.Text = offset.ToString();
+    }
+
+    void OnCancelClicked(object sender, EventArgs e) => Close();
+
+    void OnSaveClicked(object sender, EventArgs e)
+    {
+        double.TryParse(GainEntry.Text, out var gain);
+        double.TryParse(OffsetEntry.Text, out var offset);
+        Close((gain, offset));
+    }
+}

--- a/ElectricalImpedanceTomography/Views/DAQPage.xaml
+++ b/ElectricalImpedanceTomography/Views/DAQPage.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="ElectricalImpedanceTomography.Views.DAQPage"
+             x:Name="Page"
              xmlns:viewmodels="clr-namespace:ElectricalImpedanceTomography.ViewModels"
              xmlns:oxy="clr-namespace:OxyPlot.Maui.Skia;assembly=OxyPlot.Maui.Skia"
              xmlns:oxyplot="clr-namespace:OxyPlot;assembly=OxyPlot"
@@ -50,8 +51,16 @@
                     <VerticalStackLayout Spacing="2" Padding="5" BackgroundColor="Transparent">
                         <Border Style="{StaticResource CardFrameStyle}">
                             <oxy:PlotView Model="{Binding .}"
-                                          HeightRequest="150"             
-                                          MinimumWidthRequest="100"/>
+                                          HeightRequest="150"
+                                          MinimumWidthRequest="100">
+                                <oxy:PlotView.GestureRecognizers>
+                                    <TapGestureRecognizer
+                                        NumberOfTapsRequired="1"
+                                        Buttons="Secondary"
+                                        Command="{Binding Source={x:Reference Page}, Path=BindingContext.ConfigureChannelCommand}"
+                                        CommandParameter="{Binding .}" />
+                                </oxy:PlotView.GestureRecognizers>
+                            </oxy:PlotView>
                             <Border.Shadow>
                                 <Shadow Brush="Gray" Opacity="1.0" Radius="1.0" Offset="1.0, 1.0"/>
                             </Border.Shadow>


### PR DESCRIPTION
## Summary
- Use SF Pro Text font for all DAQ plots
- Right-click plot to set channel gain and offset via popup

## Testing
- `apt-get update` *(fails: repository not signed)*
- `dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0eea25c188333bcf23e33e66846b0