### PR TITLE
Ensure reconstruction parameters sync across pages

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using Utility.Classes.ReconstructionParameters;
+using Workspace = Utility.Classes.Application.Workspace;
 
 namespace ElectricalImpedanceTomography.ViewModels
 {
@@ -26,12 +27,12 @@ namespace ElectricalImpedanceTomography.ViewModels
                    .Cast<NumericOptimizer>();
 
         [ObservableProperty]
-        private EITReconstructionParameters reconstructionParameters = new(
-            DifferentialEquationSolver.FiniteElementMethod,
-            RegularizationTechnique.ZeroOrderTikhonov,
-            ErrorMetric.L2,
-            NumericSolver.SVD,
-            NumericOptimizer.GradientBased);
+        private EITReconstructionParameters reconstructionParameters = Workspace.GetReconstructionParameters();
+
+        partial void OnReconstructionParametersChanged(EITReconstructionParameters value)
+        {
+            Workspace.SetReconstructionParameters(value);
+        }
 
         [ObservableProperty]
         private int layers = 2;

--- a/ElectricalImpedanceTomography/ViewModels/LBMReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/LBMReconstructionPageViewModel.cs
@@ -16,8 +16,6 @@ namespace ElectricalImpedanceTomography.ViewModels
     {     
         private readonly IReconstructionService _reconstructionService;
 
-        [ObservableProperty]
-        private EITReconstructionParameters reconstructionParameters;
 
         [ObservableProperty]
         private ReconstructionResult reconstructionResult;
@@ -37,9 +35,8 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             _reconstructionService = reconstructionService;
 
-            ReconstructionParameters = new EITReconstructionParameters();
+            // Use and configure the global reconstruction parameters
             ReconstructionParameters.DifferentialEquationSolver = DifferentialEquationSolver.LatticeBoltzmannMethod;
-
             Workspace.SetReconstructionParameters(ReconstructionParameters);
 
             GenerateLbmMesh();
@@ -162,29 +159,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             ReconstructionResult = result;
             OnPropertyChanged(nameof(ReconstructionResult));
             return result;
-        }
-
-        public void OnReconstructionParametersChanged(object sender, EventArgs e)
-        {
-            if(sender is Picker picker)
-            {                
-                if(picker.BindingContext is EITReconstructionParameters reconstructionParameter)
-                {
-                    DifferentialEquationSolver differentialEquationSolver = reconstructionParameter.DifferentialEquationSolver;
-                    RegularizationTechnique regularizationTechnique = reconstructionParameter.RegularizationTechnique;
-                    ErrorMetric errorMetric = reconstructionParameter.ErrorMetric;
-                    NumericSolver numericSolver = reconstructionParameter.NumericSolver;
-                    NumericOptimizer numericOptimizer = reconstructionParameter.NumericOptimizer;
-
-                    ReconstructionParameters = new EITReconstructionParameters(differentialEquationSolver,
-                                                                               regularizationTechnique, 
-                                                                               errorMetric, 
-                                                                               numericSolver, 
-                                                                               numericOptimizer);
-
-                    Workspace.SetReconstructionParameters(ReconstructionParameters);
-                }
-            }
         }
 
         private async void SetupLBMReconstruction()

--- a/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
@@ -11,7 +11,12 @@ namespace ElectricalImpedanceTomography.ViewModels
         private string debugLog = string.Empty;
 
         [ObservableProperty]
-        private EITReconstructionParameters reconstructionParameters = new();
+        private EITReconstructionParameters reconstructionParameters = Workspace.GetReconstructionParameters();
+
+        partial void OnReconstructionParametersChanged(EITReconstructionParameters value)
+        {
+            Workspace.SetReconstructionParameters(value);
+        }
 
         public IEnumerable<DifferentialEquationSolver> Solvers => Enum.GetValues<DifferentialEquationSolver>();
         public IEnumerable<RegularizationTechnique> Regularizations => Enum.GetValues<RegularizationTechnique>();

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -17,8 +17,6 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         private IMesh? _mesh = Workspace.GetMesh();
 
-        [ObservableProperty]
-        private EITReconstructionParameters reconstructionParameters = Workspace.GetReconstructionParameters();
 
         [ObservableProperty]
         private int iterationCount = 0;
@@ -36,6 +34,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             _reconstructionService = reconstructionService;
 
+            // Use global reconstruction parameters stored in the workspace
             ReconstructionParameters = Workspace.GetReconstructionParameters();
         }
 


### PR DESCRIPTION
## Summary
- Use workspace's EITReconstructionParameters in base and main view models
- Update LBM and reconstruction view models to reference shared parameters
- Keep workspace parameters updated when changed on any page

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f155b92c8333992aa5ab8694b856