### PR TITLE
Color log messages and fix LBM mesh generation

### DIFF
--- a/ElectricalImpedanceTomography/Converters/MessageTypeToColorConverter.cs
+++ b/ElectricalImpedanceTomography/Converters/MessageTypeToColorConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Globalization;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Utility.Classes.Application;
+
+namespace ElectricalImpedanceTomography.Converters
+{
+    public class MessageTypeToColorConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value is WorkspaceMessageType type)
+            {
+                return type switch
+                {
+                    WorkspaceMessageType.Error => Colors.Red,
+                    WorkspaceMessageType.Warning => Color.FromArgb("#B8860B"),
+                    WorkspaceMessageType.Loading => Colors.Green,
+                    _ => Colors.White
+                };
+            }
+            return Colors.White;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+            => throw new NotImplementedException();
+    }
+}

--- a/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
@@ -1,5 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Maui.ApplicationModel;
+using System.Collections.ObjectModel;
 using Utility.Classes.Application;
 using Utility.Classes.ReconstructionParameters;
 
@@ -7,8 +9,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 {
     public partial class MainPageViewModel : BaseViewModel
     {
-        [ObservableProperty]
-        private string debugLog = string.Empty;
+        public ObservableCollection<WorkspaceMessage> DebugLog { get; } = new();
 
         [ObservableProperty]
         private EITReconstructionParameters reconstructionParameters = Workspace.GetReconstructionParameters();
@@ -31,7 +32,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         public MainPageViewModel()
         {
             foreach (var entry in Workspace.GetMessages())
-                DebugLog += $"{entry.Key:HH:mm:ss} >> {entry.Value}\n";
+                DebugLog.Add(entry);
 
             Workspace.MessageAdded += OnWorkspaceMessageAdded;
 
@@ -40,9 +41,9 @@ namespace ElectricalImpedanceTomography.ViewModels
             //  LoadMeshCommand = new AsyncRelayCommand(async () => await Task.CompletedTask);
         }
 
-        private void OnWorkspaceMessageAdded(DateTime time, string message)
+        private void OnWorkspaceMessageAdded(WorkspaceMessage message)
         {
-            DebugLog += $"{time:HH:mm:ss} >> {message}\n";
+            MainThread.BeginInvokeOnMainThread(() => DebugLog.Add(message));
         }
 
         public void OnLoadMeasurementClicked(object sender, EventArgs e)

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml
@@ -4,6 +4,7 @@
              x:Class="ElectricalImpedanceTomography.Views.MainPage"
              xmlns:viewmodels="clr-namespace:ElectricalImpedanceTomography.ViewModels"
              xmlns:controls="clr-namespace:ElectricalImpedanceTomography.Controls"
+             xmlns:converters="clr-namespace:ElectricalImpedanceTomography.Converters"
              x:DataType="viewmodels:MainPageViewModel"
              Shell.NavBarIsVisible="False"
              Title="MainPage">
@@ -17,6 +18,7 @@
         <Style TargetType="Button">
             <Setter Property="FontFamily" Value="SF Pro Text"/>
         </Style>
+        <converters:MessageTypeToColorConverter x:Key="MessageTypeToColorConverter"/>
     </ContentPage.Resources>
     <Grid RowDefinitions="Auto,*" ColumnDefinitions="200,*">
         <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="2" CurrentPageName="MainPage"/>
@@ -51,7 +53,20 @@
                 <Border Stroke="LightGray" StrokeThickness="1" Padding="10">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="Debug" FontAttributes="Bold"/>
-                        <Editor Text="{Binding DebugLog}" HeightRequest="120" IsReadOnly="True"/>
+                        <CollectionView ItemsSource="{Binding DebugLog}" HeightRequest="120">
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate>
+                                    <Label TextColor="{Binding Type, Converter={StaticResource MessageTypeToColorConverter}}">
+                                        <Label.FormattedText>
+                                            <FormattedString>
+                                                <Span Text="{Binding Time, StringFormat='{0:HH:mm:ss} >> '}" />
+                                                <Span Text="{Binding Message}" />
+                                            </FormattedString>
+                                        </Label.FormattedText>
+                                    </Label>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
                     </VerticalStackLayout>
                 </Border>
             </VerticalStackLayout>

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -63,7 +63,7 @@ public partial class MeshingPage : ContentPage
     private void OnMeshCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
         var canvas = e.Surface.Canvas;
-        canvas.Clear(SKColors.White);
+        canvas.Clear(SKColors.LightGray);
         var mesh = _viewModel.GetCurrentMesh();
         if (mesh is null)
         {

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -9,8 +9,8 @@ namespace Utility.Classes.Application
         private static IMesh? _mesh { get; set; } = null;
 
         private static List<ReconstructionResult> _reconstructionResults = [];
-        private static Dictionary<DateTime, string> _messages = [];
-        public static event Action<DateTime, string>? MessageAdded;
+        private static List<WorkspaceMessage> _messages = [];
+        public static event Action<WorkspaceMessage>? MessageAdded;
 
         private static bool _initialized = false; 
 
@@ -44,15 +44,17 @@ namespace Utility.Classes.Application
         public static void AddReconstructionResultToWorkspace(ReconstructionResult reconstructionResult) => _reconstructionResults.Add(reconstructionResult);
         public static void RemoveReconstructionResultFromWorkspace(int index) => _reconstructionResults.RemoveAt(index);
 
-        public static void AddMessage(string message)
+        public static void AddMessage(string message, WorkspaceMessageType type = WorkspaceMessageType.Log)
         {
             DateTime time = DateTime.Now;
-            _messages.Add(time, message);
-            MessageAdded?.Invoke(time, message);
+            var msg = new WorkspaceMessage(time, message, type);
+            _messages.Add(msg);
+            MessageAdded?.Invoke(msg);
         }
 
-        public static void AddLogMessage(string source, string message) => AddMessage(source + ": " + message);
+        public static void AddLogMessage(string source, string message, WorkspaceMessageType type = WorkspaceMessageType.Log)
+            => AddMessage(source + ": " + message, type);
 
-        public static IReadOnlyDictionary<DateTime, string> GetMessages() => _messages;
+        public static IReadOnlyList<WorkspaceMessage> GetMessages() => _messages;
     }
 }

--- a/Utility/Classes/Application/WorkspaceMessage.cs
+++ b/Utility/Classes/Application/WorkspaceMessage.cs
@@ -1,0 +1,12 @@
+namespace Utility.Classes.Application
+{
+    public enum WorkspaceMessageType
+    {
+        Log,
+        Warning,
+        Error,
+        Loading
+    }
+
+    public record WorkspaceMessage(DateTime Time, string Message, WorkspaceMessageType Type);
+}

--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -384,32 +384,43 @@ namespace Utility.Classes.Factories
             ValidatePerimeter(perimeter);
             var mesh = new LBMMesh(nx, ny, electrodeNum: 0);
 
+            var inside = new bool[nx, ny];
+            for (int y = 0; y < ny; y++)
+                for (int x = 0; x < nx; x++)
+                    inside[x, y] = IsPointInPolygon(x + 0.5, y + 0.5, perimeter);
+
             for (int y = 0; y < ny; y++)
             {
                 for (int x = 0; x < nx; x++)
                 {
                     var el = mesh.GetElementAt(x, y);
-                    bool inside = IsPointInPolygon(x + 0.5, y + 0.5, perimeter);
-                    el.IsWall = !inside;
+                    bool cellInside = inside[x, y];
+                    bool boundary = false;
+                    if (cellInside)
+                    {
+                        boundary = x == 0 || x == nx - 1 || y == 0 || y == ny - 1 ||
+                                   !inside[Math.Max(x - 1, 0), y] ||
+                                   !inside[Math.Min(x + 1, nx - 1), y] ||
+                                   !inside[x, Math.Max(y - 1, 0)] ||
+                                   !inside[x, Math.Min(y + 1, ny - 1)];
+                    }
+                    el.IsWall = !cellInside || boundary;
                     el.IsElectrode = false;
                 }
             }
 
+            var boundaryCells = mesh.ElementsTyped.Where(e => e.IsWall).ToList();
             var electrodes = new List<LBMElectrode>();
-            int count = Math.Min(electrodeCount, perimeter.Count);
+            int count = Math.Min(electrodeCount, boundaryCells.Count);
             if (count > 0)
             {
-                int step = Math.Max(perimeter.Count / count, 1);
+                int step = Math.Max(boundaryCells.Count / count, 1);
                 for (int e = 0; e < count; e++)
                 {
-                    var p = perimeter[e * step];
-                    int ix = (int)Math.Round(p.x);
-                    int iy = (int)Math.Round(p.y);
-                    if (ix < 0 || ix >= nx || iy < 0 || iy >= ny) continue;
-                    var cell = mesh.GetElementAt(ix, iy);
+                    var cell = boundaryCells[e * step];
                     cell.IsWall = false;
                     cell.IsElectrode = true;
-                    electrodes.Add(new LBMElectrode(id: e, gridId: cell.Id, current: 0.0, potential: 0.0, contactImpedance: 0.0));
+                    electrodes.Add(new LBMElectrode(e, cell.Id, 0.0, 0.0, 0.0));
                 }
             }
 

--- a/Utility/Logger/WorkspaceLogger.cs
+++ b/Utility/Logger/WorkspaceLogger.cs
@@ -6,7 +6,7 @@ namespace Utility.Logger
     {
         public void LogError(string error)
         {
-            Workspace.AddLogMessage("ErrorLog", error);
+            Workspace.AddLogMessage("ErrorLog", error, Classes.Application.WorkspaceMessageType.Error);
         }
 
         public void LogInfo(string info)
@@ -16,7 +16,7 @@ namespace Utility.Logger
 
         public void LogWarning(string warning)
         {
-            Workspace.AddLogMessage("WarningLog", warning);
+            Workspace.AddLogMessage("WarningLog", warning, Classes.Application.WorkspaceMessageType.Warning);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Color debug log entries by type on the main page and support typed log messages
- Generate LBM grids using polygon outlines with proper interior/wall classification and electrode placement
- Soften meshing canvas background for clearer FEM mesh display

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1639ed514833391eb7e7a849e5359