### PR TITLE
Fix debug log visibility and add mesh canvas

### DIFF
--- a/ElectricalImpedanceTomography/Converters/MessageTypeToColorConverter.cs
+++ b/ElectricalImpedanceTomography/Converters/MessageTypeToColorConverter.cs
@@ -15,10 +15,10 @@ namespace ElectricalImpedanceTomography.Converters
                     WorkspaceMessageType.Warning => Color.FromArgb("#B8860B"),
                     WorkspaceMessageType.Loading => Colors.Green,
                     WorkspaceMessageType.Info => Colors.Blue,
-                    _ => Colors.White
+                    _ => Colors.Black
                 };
             }
-            return Colors.White;
+            return Colors.Black;
         }
 
         public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml
@@ -6,6 +6,7 @@
              xmlns:controls="clr-namespace:ElectricalImpedanceTomography.Controls"
              xmlns:converters="clr-namespace:ElectricalImpedanceTomography.Converters"
              xmlns:messages="clr-namespace:Utility.Classes.Application;assembly=Utility"
+             xmlns:skia="clr-namespace:SkiaSharp.Views.Maui.Controls;assembly=SkiaSharp.Views.Maui.Controls"
              x:DataType="viewmodels:MainPageViewModel"
              Shell.NavBarIsVisible="False"
              Title="MainPage">
@@ -21,19 +22,19 @@
         </Style>
         <converters:MessageTypeToColorConverter x:Key="MessageTypeToColorConverter"/>
     </ContentPage.Resources>
-    <Grid RowDefinitions="Auto,*" ColumnDefinitions="200,*">
+    <Grid RowDefinitions="Auto,*" ColumnDefinitions="300,*">
         <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="2" CurrentPageName="MainPage"/>
-        <Border Grid.Row="1" Grid.Column="0" Stroke="Gray" StrokeThickness="1" Padding="10" Margin="10">
-            <VerticalStackLayout Spacing="8">
-                <Label Text="Navigation" FontAttributes="Bold"/>
-                <Button Text="DAQ" Command="{Binding NavigateCommand}" CommandParameter="DAQPage"/>
-                <Button Text="Meshing" Command="{Binding NavigateCommand}" CommandParameter="MeshingPage"/>
-                <Button Text="LBM Reconstruction" Command="{Binding NavigateCommand}" CommandParameter="LBMReconstructionPage"/>
-                <Button Text="FEM Reconstruction" Command="{Binding NavigateCommand}" CommandParameter="FEMReconstructionPage"/>
-            </VerticalStackLayout>
-        </Border>
-        <ScrollView Grid.Row="1" Grid.Column="1">
+        <ScrollView Grid.Row="1" Grid.Column="0">
             <VerticalStackLayout Spacing="10" Padding="10">
+                <Border Stroke="Gray" StrokeThickness="1" Padding="10">
+                    <VerticalStackLayout Spacing="8">
+                        <Label Text="Navigation" FontAttributes="Bold"/>
+                        <Button Text="DAQ" Command="{Binding NavigateCommand}" CommandParameter="DAQPage"/>
+                        <Button Text="Meshing" Command="{Binding NavigateCommand}" CommandParameter="MeshingPage"/>
+                        <Button Text="LBM Reconstruction" Command="{Binding NavigateCommand}" CommandParameter="LBMReconstructionPage"/>
+                        <Button Text="FEM Reconstruction" Command="{Binding NavigateCommand}" CommandParameter="FEMReconstructionPage"/>
+                    </VerticalStackLayout>
+                </Border>
                 <Border Stroke="LightGray" StrokeThickness="1" Padding="10">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="Configuration" FontAttributes="Bold"/>
@@ -55,7 +56,7 @@
                     <VerticalStackLayout Spacing="6">
                         <Label Text="Debug" FontAttributes="Bold"/>
                         <CollectionView ItemsSource="{Binding DebugLog}" HeightRequest="120">
-                            <CollectionView.ItemTemplate >
+                            <CollectionView.ItemTemplate>
                                 <DataTemplate x:DataType="messages:WorkspaceMessage">
                                     <Label TextColor="{Binding Type, Converter={StaticResource MessageTypeToColorConverter}}" FontSize="Small">
                                         <Label.FormattedText>
@@ -72,5 +73,6 @@
                 </Border>
             </VerticalStackLayout>
         </ScrollView>
+        <skia:SKCanvasView x:Name="MeshCanvasView" Grid.Row="1" Grid.Column="1" PaintSurface="OnCanvasViewPaintSurface" />
     </Grid>
 </ContentPage>

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
@@ -1,4 +1,9 @@
 ﻿using ElectricalImpedanceTomography.ViewModels;
+using SkiaSharp;
+using SkiaSharp.Views.Maui.Controls;
+using Utility.Classes.Application;
+using Utility.Classes.Meshing.FiniteElementMesh;
+using System.Linq;
 
 namespace ElectricalImpedanceTomography.Views
 {
@@ -15,6 +20,12 @@ namespace ElectricalImpedanceTomography.Views
             BindingContext = _viewModel;
         }
 
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            MeshCanvasView?.InvalidateSurface();
+        }
+
         private void OnLoadMeasurementClicked(object sender, EventArgs e)
         {
             _viewModel.OnLoadMeasurementClicked(sender, e);
@@ -23,6 +34,73 @@ namespace ElectricalImpedanceTomography.Views
         private void OnLoadMeshClicked(object sender, EventArgs e)
         {
             _viewModel.OnLoadMeshClicked(sender, e);
+            MeshCanvasView?.InvalidateSurface();
+        }
+
+        private void OnCanvasViewPaintSurface(object? sender, SKPaintSurfaceEventArgs e)
+        {
+            var canvas = e.Surface.Canvas;
+            var info = e.Info;
+            canvas.Clear(SKColors.White);
+
+            var mesh = Workspace.GetMesh();
+            if (mesh is FEMMesh femMesh)
+            {
+                DrawFEMMesh(canvas, info.Width, info.Height, femMesh);
+            }
+            else
+            {
+                DrawCheckerboard(canvas, info.Width, info.Height);
+            }
+        }
+
+        private static void DrawCheckerboard(SKCanvas canvas, int width, int height)
+        {
+            const int size = 20;
+            using var darkPaint = new SKPaint { Color = SKColors.Gray };
+            using var lightPaint = new SKPaint { Color = SKColors.Black };
+            for (int y = 0; y < height; y += size)
+            {
+                for (int x = 0; x < width; x += size)
+                {
+                    var paint = ((x / size + y / size) % 2 == 0) ? darkPaint : lightPaint;
+                    canvas.DrawRect(x, y, size, size, paint);
+                }
+            }
+        }
+
+        private static void DrawFEMMesh(SKCanvas canvas, int width, int height, FEMMesh mesh)
+        {
+            if (mesh.Vertices.Count == 0)
+            {
+                DrawCheckerboard(canvas, width, height);
+                return;
+            }
+
+            var minX = mesh.Vertices.Min(v => v.X);
+            var maxX = mesh.Vertices.Max(v => v.X);
+            var minY = mesh.Vertices.Min(v => v.Y);
+            var maxY = mesh.Vertices.Max(v => v.Y);
+
+            var scaleX = width / (float)(maxX - minX);
+            var scaleY = height / (float)(maxY - minY);
+            var scale = Math.Min(scaleX, scaleY);
+
+            using var paint = new SKPaint { Color = SKColors.Black, StrokeWidth = 1, Style = SKPaintStyle.Stroke };
+
+            foreach (var element in mesh.ElementsTyped)
+            {
+                var v1 = element.Vertices[0];
+                var v2 = element.Vertices[1];
+                var v3 = element.Vertices[2];
+
+                var path = new SKPath();
+                path.MoveTo((float)((v1.X - minX) * scale), height - (float)((v1.Y - minY) * scale));
+                path.LineTo((float)((v2.X - minX) * scale), height - (float)((v2.Y - minY) * scale));
+                path.LineTo((float)((v3.X - minX) * scale), height - (float)((v3.Y - minY) * scale));
+                path.Close();
+                canvas.DrawPath(path, paint);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure debug messages render in visible color
- restructure main page with left-hand controls and canvas displaying workspace mesh
- render checkerboard placeholder when no mesh is loaded

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b16a230aa4833394f2b026134412d6