### PR TITLE
Improve main page UI and add hardware status

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Graphics;
+using ServiceLayer;
 using System.Collections.ObjectModel;
 using Utility.Classes.Application;
 using Utility.Classes.ReconstructionParameters;
@@ -9,7 +11,19 @@ namespace ElectricalImpedanceTomography.ViewModels
 {
     public partial class MainPageViewModel : BaseViewModel
     {
-        public ObservableCollection<WorkspaceMessage> DebugLog { get; } = [];
+        private readonly IDAQService _daqService;
+
+        [ObservableProperty]
+        private ObservableCollection<WorkspaceMessage> debugLog = new();
+
+        [ObservableProperty]
+        private double currentAmplitude;
+
+        [ObservableProperty]
+        private double excitationFrequency;
+
+        [ObservableProperty]
+        private bool hardwareConnected;
 
         [ObservableProperty]
         private EITReconstructionParameters reconstructionParameters = Workspace.GetReconstructionParameters();
@@ -27,19 +41,49 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public IAsyncRelayCommand<string> NavigateCommand { get; }
 
-        public MainPageViewModel()
+        public string HardwareConnectionText => HardwareConnected ? "Connected" : "Disconnected";
+        public Color HardwareStatusColor => HardwareConnected ? Colors.Green : Colors.Red;
+
+        partial void OnHardwareConnectedChanged(bool value)
         {
+            OnPropertyChanged(nameof(HardwareConnectionText));
+            OnPropertyChanged(nameof(HardwareStatusColor));
+        }
+
+        public MainPageViewModel(IDAQService daqService)
+        {
+            _daqService = daqService;
+
             foreach (var entry in Workspace.GetMessages())
                 DebugLog.Add(entry);
 
             Workspace.MessageAdded += OnWorkspaceMessageAdded;
 
             NavigateCommand = new AsyncRelayCommand<string>(async (route) => await Shell.Current.GoToAsync(route));
+
+            UpdateHardwareInfo();
         }
 
         private void OnWorkspaceMessageAdded(WorkspaceMessage message)
         {
             MainThread.BeginInvokeOnMainThread(() => DebugLog.Add(message));
+        }
+
+        private void UpdateHardwareInfo()
+        {
+            try
+            {
+                var meas = _daqService.GetEITMeasurement();
+                HardwareConnected = true;
+                CurrentAmplitude = meas.CurrentAmplitude ?? 0;
+                ExcitationFrequency = 0; // frequency not provided by hardware yet
+            }
+            catch
+            {
+                HardwareConnected = false;
+                CurrentAmplitude = 0;
+                ExcitationFrequency = 0;
+            }
         }
 
         public void OnLoadMeasurementClicked(object sender, EventArgs e)

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml
@@ -32,6 +32,9 @@
                 <Border>
                     <VerticalStackLayout>
                         <Label Text="Hardware Info"/>
+                        <Label Text="{Binding CurrentAmplitude, StringFormat='Current amplitude: {0:F2} mA'}"/>
+                        <Label Text="{Binding ExcitationFrequency, StringFormat='Excitation frequency: {0:F0} Hz'}"/>
+                        <Label Text="{Binding HardwareConnectionText}" TextColor="{Binding HardwareStatusColor}"/>
                     </VerticalStackLayout>
                 </Border>
                 
@@ -75,7 +78,10 @@
                 <Border Grid.Row="1" Stroke="LightGray" StrokeThickness="1" Padding="10" StrokeShape="RoundRectangle 3" HeightRequest="300" VerticalOptions="Start">
                     <VerticalStackLayout Spacing="2">
                         <Label Text="Debug" FontAttributes="Italic" FontSize="Medium"/>
-                        <CollectionView ItemsSource="{Binding DebugLog}">
+                        <CollectionView ItemsSource="{Binding DebugLog}" VerticalOptions="FillAndExpand">
+                            <CollectionView.ItemsLayout>
+                                <LinearItemsLayout Orientation="Vertical"/>
+                            </CollectionView.ItemsLayout>
                             <CollectionView.ItemTemplate>
                                 <DataTemplate x:DataType="messages:WorkspaceMessage">
                                     <Label TextColor="{Binding Type, Converter={StaticResource MessageTypeToColorConverter}}"

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
@@ -3,6 +3,7 @@ using SkiaSharp;
 using SkiaSharp.Views.Maui.Controls;
 using Utility.Classes.Application;
 using Utility.Classes.Meshing.FiniteElementMesh;
+using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using System.Linq;
 
 namespace ElectricalImpedanceTomography.Views
@@ -44,11 +45,14 @@ namespace ElectricalImpedanceTomography.Views
             canvas.Clear(SKColors.White);
 
             var mesh = Workspace.GetMesh();
-            if (mesh is FEMMesh femMesh)
+            if (mesh is LBMMesh lbm)
             {
-                DrawFEMMesh(canvas, info.Width, info.Height, femMesh);
-
-    }
+                DrawLBMMesh(canvas, info, lbm);
+            }
+            else if (mesh is FEMMesh fem)
+            {
+                DrawFEMMesh(canvas, info, fem);
+            }
             else
             {
                 DrawCheckerboard(canvas, info.Width, info.Height);
@@ -70,38 +74,97 @@ namespace ElectricalImpedanceTomography.Views
             }
         }
 
-        private static void DrawFEMMesh(SKCanvas canvas, int width, int height, FEMMesh mesh)
+        private static SKColor ColorForValue(double val, double min, double max)
         {
-            if (mesh.Vertices.Count == 0)
+            double mid = (min + max) * 0.5;
+            if (val >= mid)
             {
-                DrawCheckerboard(canvas, width, height);
-                return;
+                float t = (float)((val - mid) / (max - mid));
+                t = Math.Clamp(t, 0f, 1f);
+                byte r = (byte)(255 * t);
+                return new SKColor(r, 0, 0);
+            }
+            else
+            {
+                float t = (float)((mid - val) / (mid - min));
+                t = Math.Clamp(t, 0f, 1f);
+                byte b = (byte)(255 * t);
+                return new SKColor(0, 0, b);
+            }
+        }
+
+        private static void DrawLBMMesh(SKCanvas canvas, SKImageInfo info, LBMMesh mesh)
+        {
+            float cellW = (float)info.Width / mesh.Nx;
+            float cellH = (float)info.Height / mesh.Ny;
+            var elems = mesh.ElementsTyped;
+            double min = elems.Min(el => el.Conductivity);
+            double max = elems.Max(el => el.Conductivity);
+            var stroke = new SKPaint { Style = SKPaintStyle.Stroke, Color = SKColors.LightGray, StrokeWidth = 1 };
+            var wall = new SKPaint { Style = SKPaintStyle.Fill, Color = SKColors.Black };
+            var electrode = new SKPaint { Style = SKPaintStyle.Fill, Color = SKColors.Orange };
+
+            for (int y = 0; y < mesh.Ny; y++)
+            {
+                for (int x = 0; x < mesh.Nx; x++)
+                {
+                    var el = mesh.GetElementAt(x, y);
+                    SKPaint fill;
+                    if (el.IsElectrode)
+                        fill = electrode;
+                    else if (el.IsWall)
+                        fill = wall;
+                    else
+                        fill = new SKPaint { Style = SKPaintStyle.Fill, Color = ColorForValue(el.Conductivity, min, max) };
+                    var r = SKRect.Create(x * cellW, y * cellH, cellW, cellH);
+                    canvas.DrawRect(r, fill);
+                    canvas.DrawRect(r, stroke);
+                }
+            }
+        }
+
+        private static void DrawFEMMesh(SKCanvas canvas, SKImageInfo info, FEMMesh mesh)
+        {
+            const float pad = 10f;
+            float availW = info.Width - 2 * pad;
+            float availH = info.Height - 2 * pad;
+            var verts = mesh.Vertices;
+            float minX = (float)verts.Min(v => v.X);
+            float minY = (float)verts.Min(v => v.Y);
+            float maxX = (float)verts.Max(v => v.X);
+            float maxY = (float)verts.Max(v => v.Y);
+            float meshW = maxX - minX;
+            float meshH = maxY - minY;
+            float scale = Math.Min(availW / meshW, availH / meshH);
+            float usedW = meshW * scale;
+            float usedH = meshH * scale;
+            float marginX = pad + (availW - usedW) / 2f;
+            float marginY = pad + (availH - usedH) / 2f;
+
+            SKPoint ToCanvas(FEMVertex v)
+                => new SKPoint((float)(v.X - minX) * scale + marginX,
+                               info.Height - ((float)(v.Y - minY) * scale + marginY));
+
+            var stroke = new SKPaint { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1 };
+            var elements = mesh.ElementsTyped;
+            double min = elements.Min(el => el.Conductivity);
+            double max = elements.Max(el => el.Conductivity);
+
+            foreach (var el in elements)
+            {
+                var p1 = ToCanvas(el.Vertices[0]);
+                var p2 = ToCanvas(el.Vertices[1]);
+                var p3 = ToCanvas(el.Vertices[2]);
+                using var path = new SKPath();
+                path.MoveTo(p1); path.LineTo(p2); path.LineTo(p3); path.Close();
+                using var fill = new SKPaint { Style = SKPaintStyle.Fill, Color = ColorForValue(el.Conductivity, min, max) };
+                canvas.DrawPath(path, fill);
+                canvas.DrawPath(path, stroke);
             }
 
-            var minX = mesh.Vertices.Min(v => v.X);
-            var maxX = mesh.Vertices.Max(v => v.X);
-            var minY = mesh.Vertices.Min(v => v.Y);
-            var maxY = mesh.Vertices.Max(v => v.Y);
-
-            var scaleX = width / (float)(maxX - minX);
-            var scaleY = height / (float)(maxY - minY);
-            var scale = Math.Min(scaleX, scaleY);
-
-            using var paint = new SKPaint { Color = SKColors.Black, StrokeWidth = 1, Style = SKPaintStyle.Stroke };
-
-            foreach (var element in mesh.ElementsTyped)
-            {
-                var v1 = element.Vertices[0];
-                var v2 = element.Vertices[1];
-                var v3 = element.Vertices[2];
-
-                var path = new SKPath();
-                path.MoveTo((float)((v1.X - minX) * scale), height - (float)((v1.Y - minY) * scale));
-                path.LineTo((float)((v2.X - minX) * scale), height - (float)((v2.Y - minY) * scale));
-                path.LineTo((float)((v3.X - minX) * scale), height - (float)((v3.Y - minY) * scale));
-                path.Close();
-                canvas.DrawPath(path, paint);
-            }
+            using var electrodeFill = new SKPaint { Style = SKPaintStyle.Fill, Color = SKColors.Yellow };
+            foreach (var v in mesh.Vertices.Where(v => v.IsElectrode))
+                canvas.DrawCircle(ToCanvas(v), 4f, electrodeFill);
         }
     }
 }

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -3,6 +3,7 @@ using ElectricalImpedanceTomography.ViewModels;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
 using SkiaSharp.Views.Maui.Controls;
+using Microsoft.Maui.Controls;
 using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Meshing.FiniteElementMesh;
@@ -53,9 +54,19 @@ public partial class ReconstructionPage : ContentPage
     private IMesh? GetMesh()
         => (_currentResult?.Mesh as IMesh) ?? (IMesh?)Workspace.GetMesh();
 
+    private static async Task AnimateButtonAsync(object sender)
+    {
+        if (sender is VisualElement ve)
+        {
+            await ve.ScaleTo(0.95, 50, Easing.CubicIn);
+            await ve.ScaleTo(1, 50, Easing.CubicOut);
+        }
+    }
+
     #region Simulation control
     private async void OnPlayButtonClicked(object sender, EventArgs e)
     {
+        await AnimateButtonAsync(sender);
         if (_simulationTask == null || _simulationTask.IsCompleted)
         {
             _simulationCts = new CancellationTokenSource();
@@ -68,14 +79,16 @@ public partial class ReconstructionPage : ContentPage
         }
     }
 
-    private void OnPauseButtonClicked(object sender, EventArgs e)
+    private async void OnPauseButtonClicked(object sender, EventArgs e)
     {
+        await AnimateButtonAsync(sender);
         if (_simulationTask != null)
             _isPaused = !_isPaused;
     }
 
     private async void OnStepButtonClicked(object sender, EventArgs e)
     {
+        await AnimateButtonAsync(sender);
         var result = await Task.Run(() => _viewModel.InverseSolveStep());
         if (result != null)
         {
@@ -84,8 +97,9 @@ public partial class ReconstructionPage : ContentPage
         }
     }
 
-    private void OnStopButtonClicked(object sender, EventArgs e)
+    private async void OnStopButtonClicked(object sender, EventArgs e)
     {
+        await AnimateButtonAsync(sender);
         _simulationCts?.Cancel();
         _simulationTask = null;
         _isPaused = false;
@@ -620,18 +634,21 @@ public partial class ReconstructionPage : ContentPage
         AdjointColorbarCanvas.InvalidateSurface();
     }
 
-    private void OnSolveForwardClicked(object sender, EventArgs e)
+    private async void OnSolveForwardClicked(object sender, EventArgs e)
     {
+        await AnimateButtonAsync(sender);
         _viewModel?.OnSolveForwardClicked(this, e);
     }
 
-    private void OnSolveInverseClicked(object sender, EventArgs e)
+    private async void OnSolveInverseClicked(object sender, EventArgs e)
     {
+        await AnimateButtonAsync(sender);
         _viewModel?.OnSolveInverseClicked(this, e);
     }
 
     private async void OnEditBoundaryConditionsClicked(object sender, EventArgs e)
     {
+        await AnimateButtonAsync(sender);
         var mesh = GetMesh();
         if (mesh is FEMMesh fem)
         {


### PR DESCRIPTION
## Summary
- show hardware connection, amplitude and frequency on main page
- color main page mesh like reconstruction displays
- animate reconstruction buttons on click
- ensure debug log collection fills available space

## Testing
- `dotnet build ElectricalImpedanceTomography.sln -c Release` *(fails: command not found)*
- `apt-get update` *(fails: repository access 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b170593aa08333a832a65b169ecc33