### PR TITLE
Add hardware connection plumbing and refine LBM circular mesh

### DIFF
--- a/BusinessLayer/DAQPersistence.cs
+++ b/BusinessLayer/DAQPersistence.cs
@@ -78,6 +78,16 @@ namespace BusinessLayer
         {
             return _meshRepository.LoadLBMMesh(filePath);
         }
+
+        public bool ConnectHardware()
+        {
+            return _daqRepository.Connect();
+        }
+
+        public bool DisconnectHardware()
+        {
+            return _daqRepository.Disconnect();
+        }
     }
 }
 

--- a/BusinessLayer/IDAQPersistence.cs
+++ b/BusinessLayer/IDAQPersistence.cs
@@ -20,5 +20,7 @@ namespace BusinessLayer
         void SaveLBMMesh(LBMMesh mesh, string name);
         FEMMesh LoadFEMMesh(string filePath);
         LBMMesh LoadLBMMesh(string filePath);
+        bool ConnectHardware();
+        bool DisconnectHardware();
     }
 }

--- a/DataAccessLayer/DAQRepository.cs
+++ b/DataAccessLayer/DAQRepository.cs
@@ -389,6 +389,16 @@ namespace DataAccessLayer
                 File.Delete(file);
         }
 
+        public bool Connect()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Disconnect()
+        {
+            throw new NotImplementedException();
+        }
+
         /*───────────────────────────────────────────────────────────────────*/
         public void Dispose()
         {

--- a/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ServiceLayer;
 using System.Collections.ObjectModel;
+using System;
 using Utility.Classes.Application;
 using Utility.Classes.ReconstructionParameters;
 
@@ -102,15 +103,18 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public void OnConnectButtonClicked(object sender, EventArgs e)
         {
-            if(HardwareConnected)
+            if (HardwareConnected)
             {
-                // TODO: disconnect
-                HardwareConnected = false;
+                if (_daqService.DisconnectHardware())
+                    HardwareConnected = false;
             }
             else
             {
-                // TODO: connect
-                HardwareConnected = true;
+                if (_daqService.ConnectHardware())
+                {
+                    HardwareConnected = true;
+                    UpdateHardwareInfo();
+                }
             }
         }
     }

--- a/ServiceLayer/DAQService.cs
+++ b/ServiceLayer/DAQService.cs
@@ -199,6 +199,36 @@ namespace ServiceLayer
                 throw;
             }
         }
+
+        public bool ConnectHardware()
+        {
+            try
+            {
+                return _daqPersistence.ConnectHardware();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                return false;
+            }
+        }
+
+        public bool DisconnectHardware()
+        {
+            try
+            {
+                return _daqPersistence.DisconnectHardware();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                return false;
+            }
+        }
     }
 }
 

--- a/ServiceLayer/IDAQService.cs
+++ b/ServiceLayer/IDAQService.cs
@@ -20,5 +20,7 @@ namespace ServiceLayer
         void SaveLBMMesh(LBMMesh mesh, string name);
         FEMMesh LoadFEMMesh(string filePath);
         LBMMesh LoadLBMMesh(string filePath);
+        bool ConnectHardware();
+        bool DisconnectHardware();
     }
 }

--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -3,6 +3,7 @@ using MIConvexHull;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Utility.Classes.Application;
+using System.Collections.Generic;
 
 namespace Utility.Classes.Factories
 {
@@ -530,40 +531,63 @@ namespace Utility.Classes.Factories
                 throw new ArgumentOutOfRangeException(nameof(radius),
                     "Cannot create circular LBM mesh: radius too big.");
 
-            // 1) build rectangular then carve circle
-            var mesh = new LBMMesh(nx, ny, electrodeCount);
+            var mesh = new LBMMesh(nx, ny, electrodeCount: 0);
 
             double cx = (nx - 1) / 2.0;
             double cy = (ny - 1) / 2.0;
             double r2 = radius * radius;
 
+            // Generate circle perimeter using midpoint (Minecraft) algorithm
+            var circle = new HashSet<(int x, int y)>();
+            void PlotCirclePoints(int px, int py)
+            {
+                if (px >= 0 && px < nx && py >= 0 && py < ny)
+                    circle.Add((px, py));
+            }
+
+            int x = 0;
+            int y = radius;
+            int d = 3 - 2 * radius;
+            while (y >= x)
+            {
+                PlotCirclePoints((int)(cx + x), (int)(cy + y));
+                PlotCirclePoints((int)(cx - x), (int)(cy + y));
+                PlotCirclePoints((int)(cx + x), (int)(cy - y));
+                PlotCirclePoints((int)(cx - x), (int)(cy - y));
+                PlotCirclePoints((int)(cx + y), (int)(cy + x));
+                PlotCirclePoints((int)(cx - y), (int)(cy + x));
+                PlotCirclePoints((int)(cx + y), (int)(cy - x));
+                PlotCirclePoints((int)(cx - y), (int)(cy - x));
+
+                if (d < 0)
+                    d += 4 * x + 6;
+                else
+                {
+                    d += 4 * (x - y) + 10;
+                    y--;
+                }
+                x++;
+            }
+
             var elements = mesh.GetElements().Cast<LBMElement>();
 
-
-            // mark anything outside circle as wall
             foreach (var el in elements)
             {
                 el.IsElectrode = false;
-                el.IsWall = true;
+                var (ex, ey) = mesh.ToLattice(el.Id);
+                double dx = ex - cx;
+                double dy = ey - cy;
+                double distSq = dx * dx + dy * dy;
+                bool outside = distSq >= r2;
+                bool onBoundary = circle.Contains((ex, ey));
 
-                var (x, y) = mesh.ToLattice(el.Id);
-                double dx = x - cx;
-                double dy = y - cy;
-                if (dx * dx + dy * dy > r2)
-                {
-                    el.IsWall = true;
-                    el.IsElectrode = false;
-                }
-                else
-                {
-                    el.IsWall = false;
-                }
+                el.IsWall = outside || onBoundary || ex == 0 || ey == 0 || ex == nx - 1 || ey == ny - 1;
             }
 
-            // 2) rebuild electrode list along the new inner perimeter            
+            // Place electrodes on outermost non-wall layer
             mesh.PlaceEquidistantElectrodes(electrodeCount);
 
-            // 3) refresh conductivity distribution
+            // Refresh conductivity distribution
             var cd = mesh.GetElements().ToDictionary(e => e.Id, e => e.Conductivity);
             mesh.SetConductivityDistribution(new ConductivityDistribution(cd));
 

--- a/Utility/Classes/Meshing/LatticeBoltzmannMesh/LBMMesh.cs
+++ b/Utility/Classes/Meshing/LatticeBoltzmannMesh/LBMMesh.cs
@@ -142,7 +142,20 @@ namespace Utility.Classes.Meshing.LatticeBoltzmannMesh
             // 2) Compute center and max radius in lattice coords
             double cx = (Nx - 1) / 2.0;
             double cy = (Ny - 1) / 2.0;
-            double maxR = Math.Min(cx, cy);
+
+            double maxR = 0.0;
+            for (int y = 0; y < Ny; y++)
+                for (int x = 0; x < Nx; x++)
+                    if (!_grid[x, y].IsWall)
+                    {
+                        double dx = x - cx;
+                        double dy = y - cy;
+                        double dist = Math.Sqrt(dx * dx + dy * dy);
+                        if (dist > maxR)
+                            maxR = dist;
+                    }
+
+            maxR += 1.0; // start from just outside the domain
 
             // 3) For each electrode, pick an angle and ray‐cast inward
             for (int i = 0; i < numElectrodes; i++)


### PR DESCRIPTION
## Summary
- Stub hardware Connect/Disconnect methods in DAQ repository and expose them through persistence, service, and MainPageViewModel
- Allow main page to toggle hardware connection and update status text/color
- Improve circular LBMMesh generation using Minecraft-style perimeter walls and adjust electrode placement

## Testing
- ⚠️ `dotnet build ElectricalImpedanceTomography.sln` *(dotnet not installed, apt repositories inaccessible)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bf79f0e883338c741f7b6a4c9bc5