### PR TITLE
Enhance LBM meshing with dynamic sliders and element editing

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -65,6 +65,8 @@ namespace ElectricalImpedanceTomography.ViewModels
         private IList<(double x, double y)>? _drawnPerimeter;
         private IList<(double x, double y)>? _drawnElectrodes;
 
+        public event Action? MeshChanged;
+
         public MeshingPageViewModel(IDAQService dAQService)
         {
             _daqService = dAQService;
@@ -244,11 +246,25 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             if (IsFEM) reconstructionParameters.DifferentialEquationSolver = Utility.Classes.ReconstructionParameters.DifferentialEquationSolver.FiniteElementMethod;
             else if (IsLBM) reconstructionParameters.DifferentialEquationSolver = Utility.Classes.ReconstructionParameters.DifferentialEquationSolver.LatticeBoltzmannMethod;
+
+            AutoGenerateMesh();
         }
 
         partial void OnSelectedGeometryChanged(GeometryType value)
         {
             OnPropertyChanged(nameof(IsCustomGeometry));
+            AutoGenerateMesh();
+        }
+
+        partial void OnNxChanged(int value) => AutoGenerateMesh();
+
+        partial void OnNyChanged(int value) => AutoGenerateMesh();
+
+        private void AutoGenerateMesh()
+        {
+            if (SelectedMeshType != MeshType.LBM) return;
+            GenerateMesh();
+            MeshChanged?.Invoke();
         }
     }
 }

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -94,14 +94,16 @@
                     <BoxView WidthRequest="200" HeightRequest="2" BackgroundColor="Gray"/>
                     
                     <!-- LBM parameters -->
-                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10" Margin="10">
-                        <Label Grid.Column="0" Text="Nx" IsVisible="{Binding IsLBM}" VerticalOptions="Center"/>
-                        <Entry Grid.Column="1" Text="{Binding Nx}" WidthRequest="60" IsVisible="{Binding IsLBM}" Keyboard="Numeric" HorizontalOptions="End"/>
+                    <Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto,Auto" ColumnSpacing="10" Margin="10">
+                        <Label Grid.Column="0" Grid.Row="0" Text="Nx" IsVisible="{Binding IsLBM}" VerticalOptions="Center"/>
+                        <Entry Grid.Column="1" Grid.Row="0" Text="{Binding Nx}" WidthRequest="60" IsVisible="{Binding IsLBM}" Keyboard="Numeric" HorizontalOptions="End"/>
+                        <Slider Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Minimum="3" Maximum="200" Value="{Binding Nx}" IsVisible="{Binding IsLBM}"/>
                     </Grid>
 
-                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10" Margin="10">
-                        <Label Grid.Column="0" Text="Ny" IsVisible="{Binding IsLBM}" VerticalOptions="Center"/>
-                        <Entry Grid.Column="1" Text="{Binding Ny}" WidthRequest="60" IsVisible="{Binding IsLBM}" Keyboard="Numeric" HorizontalOptions="End"/>
+                    <Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto,Auto" ColumnSpacing="10" Margin="10">
+                        <Label Grid.Column="0" Grid.Row="0" Text="Ny" IsVisible="{Binding IsLBM}" VerticalOptions="Center"/>
+                        <Entry Grid.Column="1" Grid.Row="0" Text="{Binding Ny}" WidthRequest="60" IsVisible="{Binding IsLBM}" Keyboard="Numeric" HorizontalOptions="End"/>
+                        <Slider Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Minimum="3" Maximum="200" Value="{Binding Ny}" IsVisible="{Binding IsLBM}"/>
                     </Grid>
 
                     <BoxView WidthRequest="200" HeightRequest="2" BackgroundColor="Gray"/>

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -1,6 +1,7 @@
 using ElectricalImpedanceTomography.ViewModels;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Storage;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
@@ -39,6 +40,7 @@ public partial class MeshingPage : ContentPage
         InitializeComponent();
         _viewModel = Utility.Composition.Container.ResolveObject<MeshingPageViewModel>();
         BindingContext = _viewModel;
+        _viewModel.MeshChanged += () => { MeshCanvas.InvalidateSurface(); };
     }
 
     private SKColor ColorForValue(double val, double min, double max)
@@ -203,21 +205,33 @@ public partial class MeshingPage : ContentPage
             if (x < 0 || x >= lbm.Nx || y < 0 || y >= lbm.Ny)
                 return;
             var el = lbm.GetElementAt(x, y);
+
             if (_viewModel.InhomogenityEditing)
             {
-                el.Conductivity = _viewModel.InhomogenityValue;
-                _viewModel.RefreshConductivity();
+                if (e.MouseButton == SKMouseButton.Right && e.ActionType == SKTouchAction.Pressed)
+                {
+                    el.Conductivity = _viewModel.InhomogenityValue;
+                    _viewModel.RefreshConductivity();
+                }
+                else if (e.MouseButton == SKMouseButton.Left && e.ActionType == SKTouchAction.Pressed)
+                {
+                    el.IsWall = !el.IsWall;
+                    if (el.IsWall) el.IsElectrode = false;
+                }
             }
-            else if (e.MouseButton == SKMouseButton.Left)
+            else
             {
-                el.IsWall = !el.IsWall;
-                if (el.IsWall) el.IsElectrode = false;
-            }
-            else if (e.MouseButton == SKMouseButton.Right)
-            {
-                el.IsElectrode = !el.IsElectrode;
-                if (el.IsElectrode) el.IsWall = false;
-                _viewModel.RefreshLbmElectrodes();
+                if (e.MouseButton == SKMouseButton.Left && e.ActionType == SKTouchAction.Pressed)
+                {
+                    el.IsWall = !el.IsWall;
+                    if (el.IsWall) el.IsElectrode = false;
+                }
+                else if (e.MouseButton == SKMouseButton.Right && e.ActionType == SKTouchAction.Pressed)
+                {
+                    el.IsElectrode = !el.IsElectrode;
+                    if (el.IsElectrode) el.IsWall = false;
+                    _viewModel.RefreshLbmElectrodes();
+                }
             }
             MeshCanvas.InvalidateSurface();
         }

--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -445,10 +445,10 @@ namespace Utility.Classes.Factories
         {
             var pts = new List<(double x, double y)>
             {
-                (1,1),
-                (nx - 2, 1),
-                (nx - 2, ny - 2),
-                (1, ny - 2)
+                (0, 0),
+                (nx - 1, 0),
+                (nx - 1, ny - 1),
+                (0, ny - 1)
             };
             var mesh = CreateLBMMeshFromPerimeter(nx, ny, pts, electrodeCount);
             mesh.Metadata.Generator = nameof(CreateRectangularLBMMesh);


### PR DESCRIPTION
## Summary
- Fix rectangular LBM mesh generation so walls sit on outermost boundary
- Add Nx/Ny sliders that regenerate LBM meshes instantly
- Allow per-cell conductivity editing with right-click; drop shift-based multi-cell selection logic

## Testing
- ❌ `dotnet build ElectricalImpedanceTomography.sln` (command not found: dotnet)


------
https://chatgpt.com/codex/tasks/task_e_68b48b0a74288333b50bab1917ffbd81