### PR TITLE
Fix meshing page interactions and LBM generation

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -61,6 +61,9 @@ namespace ElectricalImpedanceTomography.ViewModels
         [ObservableProperty]
         private double electrodeSize = 0.3;
 
+        [ObservableProperty]
+        private string hoveredElementInfo = string.Empty;
+
         private IMesh? _currentMesh;
         private IList<(double x, double y)>? _drawnPerimeter;
         private IList<(double x, double y)>? _drawnElectrodes;
@@ -231,6 +234,13 @@ namespace ElectricalImpedanceTomography.ViewModels
                 if (el.IsElectrode)
                     electrodes.Add(new LBMElectrode(id++, el.Id, 0.0, 0.0, ElectrodeContactImpedance));
             mesh.SetElectrodes(electrodes);
+        }
+
+        public void Clear()
+        {
+            _currentMesh = null;
+            Workspace.SetMesh(null);
+            MeshChanged?.Invoke();
         }
 
         public bool IsFEM => SelectedMeshType == MeshType.FEM;

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -139,8 +139,8 @@
             </Border>
 
             <!-- Middle Canvas display -->
-            <Grid Grid.Column="1" RowDefinitions="Auto, *" >
-                <HorizontalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Spacing="10" Padding="10">
+            <Grid Grid.Column="1" RowDefinitions="Auto,Auto,*" >
+                <HorizontalStackLayout Grid.Row="0" VerticalOptions="Center" HorizontalOptions="Center" Spacing="10" Padding="10">
                     <Border Padding="5" StrokeShape="RoundRectangle 5">
                         <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10">
                             <Image Grid.Column="0" Source="icon_save.png" HeightRequest="30"/>
@@ -193,8 +193,10 @@
                     </Border>
 
                 </HorizontalStackLayout>
-                
-                <Border Grid.Row="1"
+
+                <Label Grid.Row="1" Text="{Binding HoveredElementInfo}" HorizontalOptions="Center"/>
+
+                <Border Grid.Row="2"
                         Stroke="DarkGray"
                         StrokeThickness="2"
                         Margin="10"

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -68,7 +68,7 @@ public partial class MeshingPage : ContentPage
     private void OnMeshCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
         var canvas = e.Surface.Canvas;
-        canvas.Clear(SKColors.LightGray);
+        canvas.Clear(SKColor.Parse("#1E1E1E"));
         var mesh = _viewModel.GetCurrentMesh();
         if (mesh is null)
         {
@@ -156,7 +156,14 @@ public partial class MeshingPage : ContentPage
 
     private void OnClearClicked(object sender, EventArgs e)
     {
-        // TODO: Clear canvas
+        _outlinePoints.Clear();
+        _electrodePoints.Clear();
+        _selectedCells.Clear();
+        _outlineClosed = false;
+        _isDrawing = false;
+        _viewModel.HoveredElementInfo = string.Empty;
+        _viewModel.Clear();
+        MeshCanvas.InvalidateSurface();
     }
 
     private void OnEditClicked(object sender, TappedEventArgs e)
@@ -208,7 +215,10 @@ public partial class MeshingPage : ContentPage
             int x = (int)(e.Location.X / _cellW);
             int y = (int)(e.Location.Y / _cellH);
             if (x < 0 || x >= lbm.Nx || y < 0 || y >= lbm.Ny)
+            {
+                _viewModel.HoveredElementInfo = string.Empty;
                 return;
+            }
             var el = lbm.GetElementAt(x, y);
 
             if (_viewModel.InhomogenityEditing)
@@ -240,11 +250,14 @@ public partial class MeshingPage : ContentPage
                     _viewModel.RefreshLbmElectrodes();
                 }
             }
+            if (e.ActionType == SKTouchAction.Moved || e.ActionType == SKTouchAction.Entered)
+                _viewModel.HoveredElementInfo = $"ID: {el.Id} \u03C3: {el.Conductivity:F2}";
             MeshCanvas.InvalidateSurface();
         }
         else if (mesh is FEMMesh fem)
         {
             var pt = e.Location;
+            bool found = false;
             foreach (var el in fem.ElementsTyped)
             {
                 var a = ToCanvas(el.Vertices[0]);
@@ -252,15 +265,26 @@ public partial class MeshingPage : ContentPage
                 var c = ToCanvas(el.Vertices[2]);
                 if (PointInTriangle(pt, a, b, c))
                 {
-                    if (_viewModel.InhomogenityEditing)
+                    found = true;
+                    if (_viewModel.InhomogenityEditing && e.MouseButton == SKMouseButton.Left && e.ActionType == SKTouchAction.Pressed)
                     {
                         el.Conductivity = _viewModel.InhomogenityValue;
                         _viewModel.RefreshConductivity();
                         MeshCanvas.InvalidateSurface();
                     }
+                    else if (e.ActionType == SKTouchAction.Moved || e.ActionType == SKTouchAction.Entered)
+                    {
+                        _viewModel.HoveredElementInfo = $"ID: {el.Id} \u03C3: {el.Conductivity:F2}";
+                    }
                     break;
                 }
             }
+            if (!found)
+                _viewModel.HoveredElementInfo = string.Empty;
+        }
+        else
+        {
+            _viewModel.HoveredElementInfo = string.Empty;
         }
         e.Handled = true;
     }

--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -443,14 +443,37 @@ namespace Utility.Classes.Factories
 
         public static LBMMesh CreateRectangularLBMMesh(int nx, int ny, int electrodeCount = 16)
         {
-            var pts = new List<(double x, double y)>
+            var mesh = new LBMMesh(nx, ny);
+
+            // collect inner boundary cells (adjacent to outer walls)
+            var boundary = new List<LBMElement>();
+            for (int x = 1; x < nx - 1; x++)
+                boundary.Add(mesh.GetElementAt(x, 1));
+            for (int y = 2; y < ny - 1; y++)
+                boundary.Add(mesh.GetElementAt(nx - 2, y));
+            for (int x = nx - 3; x >= 1; x--)
+                boundary.Add(mesh.GetElementAt(x, ny - 2));
+            for (int y = ny - 3; y >= 2; y--)
+                boundary.Add(mesh.GetElementAt(1, y));
+
+            var electrodes = new List<LBMElectrode>();
+            int count = Math.Min(electrodeCount, boundary.Count);
+            if (count > 0)
             {
-                (0, 0),
-                (nx - 1, 0),
-                (nx - 1, ny - 1),
-                (0, ny - 1)
-            };
-            var mesh = CreateLBMMeshFromPerimeter(nx, ny, pts, electrodeCount);
+                int step = Math.Max(boundary.Count / count, 1);
+                for (int i = 0; i < count; i++)
+                {
+                    var cell = boundary[i * step];
+                    cell.IsElectrode = true;
+                    electrodes.Add(new LBMElectrode(i, cell.Id, 0.0, 0.0, 0.0));
+                }
+            }
+
+            mesh.SetElectrodes(electrodes);
+
+            var cd = mesh.GetElements().ToDictionary(e => e.Id, e => e.Conductivity);
+            mesh.SetConductivityDistribution(new ConductivityDistribution(cd));
+
             mesh.Metadata.Generator = nameof(CreateRectangularLBMMesh);
             mesh.Metadata.Parameters["nx"] = nx.ToString();
             mesh.Metadata.Parameters["ny"] = ny.ToString();


### PR DESCRIPTION
## Summary
- Reset mesh and canvas with working clear button
- Prevent unintended FEM conductivity edits; show hovered element data
- Apply reconstruction-like styling and implement rectangular LBM mesh generation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b49854604483338ce537d8f42d8522