### PR TITLE
Add noise generation utilities and meshing UI feedback

### DIFF
--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -200,12 +200,14 @@ public partial class MeshingPage : ContentPage
             canvas.DrawCircle(p, 4f, _previewElectrode);
     }
 
-    private void OnAddNoiseTapped(object sender, TappedEventArgs e)
+    private async void OnAddNoiseTapped(object sender, TappedEventArgs e)
     {
         var mesh = _viewModel.GetCurrentMesh();
-
-        // TODO: Show popup: To Add noise you must first generate a mesh
-        if (mesh == null) return;
+        if (mesh == null)
+        {
+            await DisplayAlert("No mesh", "Generate a mesh before adding noise.", "OK");
+            return;
+        }
 
         _viewModel.AddNoiseToMesh();
     }

--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -630,7 +630,30 @@ namespace Utility.Classes.Factories
 
         public static void AddGaussianNoise(IMesh mesh)
         {
-            // TODO: add gaussian noise to element conductivites and update conductivity distribution
+            if (mesh == null) throw new ArgumentNullException(nameof(mesh));
+
+            var rng = new Random();
+            const double sigma = 0.05; // 5% relative noise
+
+            var elems = mesh.GetElements();
+            var noisy = new Dictionary<int, double>(elems.Count);
+
+            foreach (var el in elems)
+            {
+                // Box-Muller transform for normal distribution
+                double u1 = 1.0 - rng.NextDouble();
+                double u2 = 1.0 - rng.NextDouble();
+                double z = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+
+                double value = el.Conductivity * (1.0 + sigma * z);
+                if (value < 0) value = 0.0;
+                el.Conductivity = value;
+                noisy[el.Id] = value;
+            }
+
+            mesh.SetConductivityDistribution(new ConductivityDistribution(noisy));
+
+            Workspace.AddLogMessage("MeshFactory", "Added gaussian noise to mesh conductivities.");
         }
 
         private static void ValidatePerimeter(IList<(double x, double y)> perimeter)

--- a/Utility/Tests/FakeMesh.cs
+++ b/Utility/Tests/FakeMesh.cs
@@ -7,6 +7,9 @@ namespace Utility.Tests
     /// <summary>Minimal mesh double. Enough for units that don’t actually need FEM/LBM.</summary>
     internal sealed class FakeMesh : IMesh
     {
+        private sealed class FakeElement : MeshElement { }
+        private sealed class FakeElectrode : Electrode { }
+
         private readonly List<Electrode> _electrodes = new();
         private readonly List<FEMVertex> _vertices = new();
         private readonly List<MeshElement> _elements = new();
@@ -14,13 +17,24 @@ namespace Utility.Tests
         private ConductivityDistribution _sigma = new(new Dictionary<int, double>());
         private PotentialDistribution _phi = new(new Dictionary<int, double>());
 
-        public MeshMetadata Metadata { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public MeshMetadata Metadata { get; set; } = new();
 
         public FakeMesh(int nElems = 0, int nElectrodes = 0)
         {
-            // TODO: Implement correct fake maesh
-            //for (int i = 0; i < nElems; i++) _elements.Add(new MeshElement { Id = i, Conductivity = 0.0 });
-            //for (int i = 0; i < nElectrodes; i++) _electrodes.Add(new Electrode { Id = i, Potential = 0.0 });
+            for (int i = 0; i < nElems; i++)
+            {
+                var el = new FakeElement { Id = i, Conductivity = 1.0 };
+                _elements.Add(el);
+                _sigma.Conductivities[i] = el.Conductivity;
+            }
+
+            for (int i = 0; i < nElectrodes; i++)
+            {
+                var v = new FEMVertex(i, 0.0, 0.0) { IsElectrode = true, ElectrodeId = i };
+                _vertices.Add(v);
+                var el = new FakeElectrode { Id = i, Potential = 0.0 };
+                _electrodes.Add(el);
+            }
         }
 
         public void LogMesh() { }


### PR DESCRIPTION
## Summary
- Add Gaussian noise helper for mesh element conductivities
- Warn user when adding noise without a generated mesh
- Provide minimal FakeMesh implementation for tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a4533a7c83338e41893d3db88555