### PR TITLE
Fix LBM mesh visualization colors and electrode placement

### DIFF
--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -17,8 +17,8 @@ public partial class MeshingPage : ContentPage
     private readonly MeshingPageViewModel _viewModel;
 
     // paints for LBM drawing
-    private readonly SKPaint _lbmFill = new() { Style = SKPaintStyle.Fill, Color = SKColors.WhiteSmoke };
-    private readonly SKPaint _lbmWall = new() { Style = SKPaintStyle.Fill, Color = SKColors.Black };
+    private readonly SKPaint _lbmFill = new() { Style = SKPaintStyle.Fill, Color = SKColors.Black };
+    private readonly SKPaint _lbmWall = new() { Style = SKPaintStyle.Fill, Color = SKColors.White };
     private readonly SKPaint _lbmElectrode = new() { Style = SKPaintStyle.Fill, Color = SKColors.Orange };
     private readonly SKPaint _lbmStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.LightGray, StrokeWidth = 1 };
     private readonly SKPaint _lbmSelected = new() { Style = SKPaintStyle.Fill, Color = SKColors.LimeGreen };
@@ -87,9 +87,6 @@ public partial class MeshingPage : ContentPage
     {
         _cellW = (float)info.Width / mesh.Nx;
         _cellH = (float)info.Height / mesh.Ny;
-        var elems = mesh.ElementsTyped;
-        double min = elems.Min(el => el.Conductivity);
-        double max = elems.Max(el => el.Conductivity);
         for (int y = 0; y < mesh.Ny; y++)
         {
             for (int x = 0; x < mesh.Nx; x++)
@@ -103,7 +100,7 @@ public partial class MeshingPage : ContentPage
                 else if (el.IsWall)
                     fill = _lbmWall;
                 else
-                    fill = new SKPaint { Style = SKPaintStyle.Fill, Color = ColorForValue(el.Conductivity, min, max) };
+                    fill = _lbmFill;
                 var r = SKRect.Create(x * _cellW, y * _cellH, _cellW, _cellH);
                 canvas.DrawRect(r, fill);
                 canvas.DrawRect(r, _lbmStroke);

--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -410,22 +410,8 @@ namespace Utility.Classes.Factories
                 }
             }
 
-            var boundaryCells = mesh.ElementsTyped.Where(e => e.IsWall).ToList();
-            var electrodes = new List<LBMElectrode>();
-            int count = Math.Min(electrodeCount, boundaryCells.Count);
-            if (count > 0)
-            {
-                int step = Math.Max(boundaryCells.Count / count, 1);
-                for (int e = 0; e < count; e++)
-                {
-                    var cell = boundaryCells[e * step];
-                    cell.IsWall = false;
-                    cell.IsElectrode = true;
-                    electrodes.Add(new LBMElectrode(e, cell.Id, 0.0, 0.0, 0.0));
-                }
-            }
-
-            mesh.SetElectrodes(electrodes);
+            // place electrodes evenly around the domain boundary
+            mesh.PlaceEquidistantElectrodes(electrodeCount);
 
             var cd = mesh.GetElements().ToDictionary(e => e.Id, e => e.Conductivity);
             mesh.SetConductivityDistribution(new ConductivityDistribution(cd));


### PR DESCRIPTION
## Summary
- render LBMMesh with consistent colors: walls white, fluid cells black, electrodes orange
- distribute electrodes evenly along perimeter using PlaceEquidistantElectrodes to avoid scattered placement

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4aa640e8c8333b12ef1b1ec01ab49