### PR TITLE
Implement reconstruction background runner

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -4,6 +4,8 @@ using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
+using System;
+using System.Threading.Tasks;
 using Workspace = Utility.Classes.Application.Workspace;
 
 namespace ElectricalImpedanceTomography.ViewModels
@@ -22,9 +24,11 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         [ObservableProperty]
         private bool adjecentDrivePattern = true;
-            
+
         [ObservableProperty]
         private bool oppositeDrivePattern = false;
+
+        public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
 
         public ReconstructionPageViewModel(IReconstructionService reconstructionService)
         {
@@ -32,6 +36,8 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             // Use global reconstruction parameters stored in the workspace
             ReconstructionParameters = Workspace.GetReconstructionParameters();
+
+            _reconstructionService.ReconstructionUpdated += OnServiceReconstructionUpdated;
         }
 
         private void UpdateMesh() => _mesh = Workspace.GetMesh();
@@ -68,34 +74,43 @@ namespace ElectricalImpedanceTomography.ViewModels
                 _reconstructionService.SolveLbmInverse(MaxIterationCount);
         }
 
-        private List<double[]> _simulatedMeasurements = [];
-        private int _simulatedMeasurementIndex = 0;
+        private double CalculateResidual(ConductivityDistribution reconstructed, ConductivityDistribution original)
+        {
+            double sum = 0.0;
+            foreach (var kv in reconstructed.Conductivities)
+            {
+                original.Conductivities.TryGetValue(kv.Key, out double origVal);
+                double diff = kv.Value - origVal;
+                sum += diff * diff;
+            }
+            return Math.Sqrt(sum);
+        }
 
-        public ReconstructionResult? InverseSolveStep()
+        public void StartBackgroundReconstruction()
         {
             InitializeReconstruction();
+            IterationCount = 0;
+            _reconstructionService.StartBackgroundReconstruction(MaxIterationCount, StepSize, RegularizationWeight, ExcitationCurrentAmplitude);
+        }
 
-            if (_mesh is FEMMesh femMesh)
-            {
-                if (_simulatedMeasurements.Count == 0)
-                    _simulatedMeasurements = _reconstructionService
-                        .SimulateFemMeasurements(femMesh, ExcitationCurrentAmplitude);
+        public void PauseReconstruction() => _reconstructionService.PauseBackgroundReconstruction();
 
-                var measurement = _simulatedMeasurements[_simulatedMeasurementIndex % _simulatedMeasurements.Count];
-                var electrodes = femMesh.GetElectrodes().Cast<FEMElectrode>().ToList();
-                var bc = new FEMBoundaryCondition(electrodes);
+        public void ResumeReconstruction() => _reconstructionService.ResumeBackgroundReconstruction();
 
-                var result = _reconstructionService.InverseSolveStepFem(femMesh,
-                                                                        measurement,
-                                                                        bc,
-                                                                        StepSize);
-                _simulatedMeasurementIndex++;
-                return result;
-            }
-            else if (_mesh is LBMMesh)
-                return _reconstructionService.SolveLbmInverse(1);
+        public void StopReconstruction() => _reconstructionService.StopBackgroundReconstruction();
 
-            return null;
+        public Task<ReconstructionResult?> StepReconstructionAsync()
+        {
+            InitializeReconstruction();
+            return _reconstructionService.StepReconstructionAsync();
+        }
+
+        private void OnServiceReconstructionUpdated(object? sender, ReconstructionResult result)
+        {
+            IterationCount++;
+            Residual = CalculateResidual(result.ReconstructedConductivityDistribution,
+                                         result.OriginalConductivityDistribution);
+            ReconstructionUpdated?.Invoke(this, result);
         }
     }
 }

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -99,7 +99,13 @@
                             <ImageButton Padding="3" Background="Transparent" HeightRequest="30" Source="icon_pause_blue.png" Clicked="OnPauseButtonClicked"/>    
                         </Border>
                         <Border Grid.Column="2" HeightRequest="50" WidthRequest="50" Margin="5">
-                            <ImageButton Padding="3" Background="Transparent" HeightRequest="30" Source="icon_next_blue.png" Clicked="OnStepButtonClicked"/>    
+                            <ImageButton x:Name="StepButton"
+                                         Padding="3"
+                                         Background="Transparent"
+                                         HeightRequest="30"
+                                         Source="icon_next_blue.png"
+                                         Clicked="OnStepButtonClicked"
+                                         IsEnabled="False"/>
                         </Border>
                         <Border Grid.Column="3" HeightRequest="50" WidthRequest="50" Margin="5">
                             <ImageButton Padding="3" Background="Transparent" HeightRequest="30" Source="icon_stop_red.png" Clicked="OnStopButtonClicked"/>    

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -8,6 +8,7 @@ using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
+using System.Threading.Tasks;
 using Workspace = Utility.Classes.Application.Workspace;
 
 namespace ElectricalImpedanceTomography.Views;
@@ -31,9 +32,8 @@ public partial class ReconstructionPage : ContentPage
     private enum PotentialDisplayMode { Default, Grayscale, Inverted, Heatmap, Rainbow }
     private PotentialDisplayMode _potMode = PotentialDisplayMode.Default;
 
-    private Task? _simulationTask;
-    private CancellationTokenSource? _simulationCts;
     private bool _isPaused = false;
+    private bool _hasStarted = false;
 
     public ReconstructionPage()
     {
@@ -49,6 +49,10 @@ public partial class ReconstructionPage : ContentPage
         };
 
         PotentialModeChanged += OnPotentialModeChanged;
+
+        _viewModel.ReconstructionUpdated += OnReconstructionUpdated;
+
+        StepButton.IsEnabled = false;
     }
 
     private IMesh? GetMesh()
@@ -67,63 +71,51 @@ public partial class ReconstructionPage : ContentPage
     private async void OnPlayButtonClicked(object sender, EventArgs e)
     {
         await AnimateButtonAsync(sender);
-        if (_simulationTask == null || _simulationTask.IsCompleted)
+        if (!_hasStarted)
         {
-            _simulationCts = new CancellationTokenSource();
-            _isPaused = false;
-            _simulationTask = RunSimulationLoop(_simulationCts.Token);
+            _viewModel.StartBackgroundReconstruction();
+            _hasStarted = true;
         }
         else
         {
-            _isPaused = false;
+            _viewModel.ResumeReconstruction();
         }
+        _isPaused = false;
+        StepButton.IsEnabled = false;
     }
 
     private async void OnPauseButtonClicked(object sender, EventArgs e)
     {
         await AnimateButtonAsync(sender);
-        if (_simulationTask != null)
-            _isPaused = !_isPaused;
+        _viewModel.PauseReconstruction();
+        _isPaused = true;
+        StepButton.IsEnabled = true;
     }
 
     private async void OnStepButtonClicked(object sender, EventArgs e)
     {
         await AnimateButtonAsync(sender);
-        var result = await Task.Run(() => _viewModel.InverseSolveStep());
-        if (result != null)
-        {
-            _currentResult = result;
-            Dispatcher.Dispatch(InvalidateAll);
-        }
+        if (!_isPaused)
+            return;
+
+        await _viewModel.StepReconstructionAsync();
     }
 
     private async void OnStopButtonClicked(object sender, EventArgs e)
     {
         await AnimateButtonAsync(sender);
-        _simulationCts?.Cancel();
-        _simulationTask = null;
+        _viewModel.StopReconstruction();
         _isPaused = false;
-    }
-
-    private async Task RunSimulationLoop(CancellationToken token)
-    {
-        while (!token.IsCancellationRequested)
-        {
-            if (_isPaused)
-            {
-                await Task.Delay(100, token);
-                continue;
-            }
-
-            var result = await Task.Run(() => _viewModel.InverseSolveStep());
-            if (result != null)
-            {
-                _currentResult = result;
-                Dispatcher.Dispatch(InvalidateAll);
-            }
-        }
+        _hasStarted = false;
+        StepButton.IsEnabled = false;
     }
     #endregion
+
+    private void OnReconstructionUpdated(object? sender, ReconstructionResult result)
+    {
+        _currentResult = result;
+        Dispatcher.Dispatch(InvalidateAll);
+    }
 
     #region Drawing helpers
     private void ComputeFemTransform(FEMMesh mesh, SKImageInfo info)

--- a/ServiceLayer/IReconstructionService.cs
+++ b/ServiceLayer/IReconstructionService.cs
@@ -1,4 +1,6 @@
-﻿using Utility.Classes;
+﻿using System;
+using System.Threading.Tasks;
+using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
@@ -10,6 +12,14 @@ namespace ServiceLayer
     {
         public Task<ReconstructionResult> GetReconstructionResult();
         public void InitializeReconstruction(IMesh mesh, EITReconstructionParameters parameters);
+
+        // --- Background reconstruction control ---
+        public event EventHandler<ReconstructionResult> ReconstructionUpdated;
+        public void StartBackgroundReconstruction(int maxIterationCount, double stepSize, double regularizationWeight, double excitationAmplitude);
+        public void PauseBackgroundReconstruction();
+        public void ResumeBackgroundReconstruction();
+        public void StopBackgroundReconstruction();
+        public Task<ReconstructionResult?> StepReconstructionAsync();
 
         // --- LBM Reconstruction ---
 

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -1,5 +1,10 @@
 ﻿using BusinessLayer;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Meshing.FiniteElementMesh;
@@ -15,6 +20,21 @@ namespace ServiceLayer
     {
         private readonly IReconstructionPersistence _reconstructionPersistence;
         private readonly ILogger _logger;
+
+        // Background reconstruction state
+        private IMesh? _mesh;
+        private CancellationTokenSource? _cts;
+        private Task? _backgroundTask;
+        private bool _isPaused;
+        private int _maxIterationCount;
+        private int _currentIteration;
+        private double _stepSize;
+        private double _regularizationWeight;
+        private double _excitationAmplitude;
+        private List<double[]> _simulatedMeasurements = new();
+        private int _simMeasurementIndex;
+
+        public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
 
         public ReconstructionService(IReconstructionPersistence reconstructionPersistence, ILogger logger)
         {
@@ -94,7 +114,9 @@ namespace ServiceLayer
             try
             {
                 Workspace.AddLogMessage("Reconstruction Service", "Reconstruction initialization started with the specified EITReconstructionParameters object.");
-
+                _mesh = mesh;
+                _simulatedMeasurements.Clear();
+                _simMeasurementIndex = 0;
                 _reconstructionPersistence.InitializeReconstruction(mesh, parameters);
             }
             catch(Exception ex)
@@ -171,6 +193,90 @@ namespace ServiceLayer
                 throw;
             }
         }
+
+        #region Background reconstruction
+
+        private ReconstructionResult? PerformInverseStep()
+        {
+            if (_mesh is FEMMesh femMesh)
+            {
+                if (_simulatedMeasurements.Count == 0)
+                {
+                    _simulatedMeasurements = _reconstructionPersistence.SimulateFemMeasurements(femMesh, _excitationAmplitude);
+                }
+
+                var measurement = _simulatedMeasurements[_simMeasurementIndex % _simulatedMeasurements.Count];
+                var electrodes = femMesh.GetElectrodes().Cast<FEMElectrode>().ToList();
+                var bc = new FEMBoundaryCondition(electrodes);
+
+                var result = InverseSolveStepFem(femMesh, measurement, bc, _stepSize);
+                _simMeasurementIndex++;
+                return result;
+            }
+            else if (_mesh is LBMMesh)
+            {
+                return SolveLbmInverse(1);
+            }
+
+            return null;
+        }
+
+        private async Task RunLoop(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested && _currentIteration < _maxIterationCount)
+            {
+                if (_isPaused)
+                {
+                    await Task.Delay(100, token);
+                    continue;
+                }
+
+                var result = PerformInverseStep();
+                if (result != null)
+                {
+                    _currentIteration++;
+                    ReconstructionUpdated?.Invoke(this, result);
+                }
+
+                await Task.Yield();
+            }
+        }
+
+        public void StartBackgroundReconstruction(int maxIterationCount, double stepSize, double regularizationWeight, double excitationAmplitude)
+        {
+            _maxIterationCount = maxIterationCount;
+            _stepSize = stepSize;
+            _regularizationWeight = regularizationWeight;
+            _excitationAmplitude = excitationAmplitude;
+            _currentIteration = 0;
+            _isPaused = false;
+            _cts = new CancellationTokenSource();
+            _backgroundTask = Task.Run(() => RunLoop(_cts.Token));
+        }
+
+        public void PauseBackgroundReconstruction() => _isPaused = true;
+
+        public void ResumeBackgroundReconstruction() => _isPaused = false;
+
+        public void StopBackgroundReconstruction()
+        {
+            _cts?.Cancel();
+            _backgroundTask = null;
+            _isPaused = false;
+        }
+
+        public async Task<ReconstructionResult?> StepReconstructionAsync()
+        {
+            var result = await Task.Run(PerformInverseStep);
+            if (result != null)
+            {
+                _currentIteration++;
+                ReconstructionUpdated?.Invoke(this, result);
+            }
+            return result;
+        }
+
+        #endregion
 
         /// <summary>
         ///     Delegates a graph-based forward solve to the persistence layer.


### PR DESCRIPTION
## Summary
- Add service-layer background reconstruction loop with start, pause, resume, stop, and step controls
- Forward reconstruction playback commands from viewmodel and update residual/iteration on service events
- Update reconstruction page to drive new background runner and refresh canvases on result updates

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4af58c2c08333854a8bcd25d16649