### PR TITLE
Add reconstruction playback slider

### DIFF
--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -91,7 +91,10 @@
 
                 <!-- Control Panel to control reconstruction -->
                 <Border Background="Transparent" Stroke="Gray">
-                    <Grid Grid.Row="0" ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" ColumnSpacing="15" HorizontalOptions="Center">
+                    <Grid ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
+                          RowDefinitions="Auto, Auto"
+                          ColumnSpacing="15"
+                          HorizontalOptions="Center">
                         <Border Grid.Column="0" HeightRequest="50" WidthRequest="50" Margin="5">
                             <ImageButton Padding="3" Background="Transparent" HeightRequest="30" WidthRequest="30" Source="icon_play_green.png" Clicked="OnPlayButtonClicked"/>
                         </Border>
@@ -120,9 +123,9 @@
                         <Border Grid.Column="7" Margin="2" Background="Transparent">
                             <Button Text="Solve Inverse" Margin="10" BackgroundColor="DarkRed" TextColor="White" FontAttributes="Bold" Clicked="OnSolveInverseClicked"/>
                         </Border>
-                        <Picker x:Name="PotentialModePicker" 
+                        <Picker x:Name="PotentialModePicker"
                                 Margin="5"
-                                Grid.Column="8" 
+                                Grid.Column="8"
                                 HorizontalOptions="Center"
                                 VerticalOptions="Center"
                                 SelectedItem="Default"
@@ -135,6 +138,12 @@
                                 <x:String>Rainbow</x:String>
                             </Picker.Items>
                         </Picker>
+                        <Slider x:Name="PlaybackSlider"
+                                Grid.Row="1"
+                                Grid.ColumnSpan="10"
+                                Minimum="0"
+                                Maximum="0"
+                                ValueChanged="OnPlaybackSliderValueChanged" />
                     </Grid>
                 </Border>
 

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -34,6 +34,7 @@ public partial class ReconstructionPage : ContentPage
 
     private bool _isPaused = false;
     private bool _hasStarted = false;
+    private bool _sliderChanging = false;
 
     public ReconstructionPage()
     {
@@ -114,6 +115,14 @@ public partial class ReconstructionPage : ContentPage
     private void OnReconstructionUpdated(object? sender, ReconstructionResult result)
     {
         _currentResult = result;
+        _sliderChanging = true;
+        var results = Workspace.GetReconstructionResults();
+        if (results.Count > 0)
+        {
+            PlaybackSlider.Maximum = results.Count - 1;
+            PlaybackSlider.Value = PlaybackSlider.Maximum;
+        }
+        _sliderChanging = false;
         Dispatcher.Dispatch(InvalidateAll);
     }
 
@@ -624,6 +633,36 @@ public partial class ReconstructionPage : ContentPage
         PotentialColorbarCanvas.InvalidateSurface();
         ReconstructedColorbarCanvas.InvalidateSurface();
         AdjointColorbarCanvas.InvalidateSurface();
+    }
+
+    private static double CalculateResidual(ConductivityDistribution reconstructed, ConductivityDistribution original)
+    {
+        double sum = 0.0;
+        foreach (var kv in reconstructed.Conductivities)
+        {
+            original.Conductivities.TryGetValue(kv.Key, out double origVal);
+            double diff = kv.Value - origVal;
+            sum += diff * diff;
+        }
+        return Math.Sqrt(sum);
+    }
+
+    private void OnPlaybackSliderValueChanged(object sender, ValueChangedEventArgs e)
+    {
+        if (_sliderChanging)
+            return;
+
+        var results = Workspace.GetReconstructionResults();
+        int index = (int)Math.Round(e.NewValue);
+        if (index >= 0 && index < results.Count)
+        {
+            var result = results[index];
+            _currentResult = result;
+            _viewModel.IterationCount = index + 1;
+            _viewModel.Residual = CalculateResidual(result.ReconstructedConductivityDistribution,
+                                                   result.OriginalConductivityDistribution);
+            Dispatcher.Dispatch(InvalidateAll);
+        }
     }
 
     private async void OnSolveForwardClicked(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- add media-style playback slider to the reconstruction page
- update code-behind to sync slider with reconstruction updates and manual navigation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b5800fbc83339ac1d753e3039553