### PR TITLE
Add reconstruction running guard and numeric entry control

### DIFF
--- a/ElectricalImpedanceTomography/Controls/PlusMinusEntryControl.xaml
+++ b/ElectricalImpedanceTomography/Controls/PlusMinusEntryControl.xaml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="ElectricalImpedanceTomography.Controls.PlusMinusEntryControl"
+             x:Name="Root">
+    <Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto,Auto">
+        <Label Grid.Column="0"
+               Grid.RowSpan="2"
+               Text="{Binding Source={x:Reference Root}, Path=LabelText}"/>
+        <Entry x:Name="BindableEntry"
+               Grid.Column="1"
+               Grid.RowSpan="2"
+               HorizontalTextAlignment="End"
+               Keyboard="Numeric"
+               Text="{Binding Source={x:Reference Root}, Path=Value, Mode=TwoWay}"/>
+        <Image Grid.Column="2"
+               Grid.Row="0"
+               Source="{Binding Source={x:Reference Root}, Path=PlusImageSource}">
+            <Image.GestureRecognizers>
+                <TapGestureRecognizer Tapped="OnPlusTapped"/>
+            </Image.GestureRecognizers>
+        </Image>
+        <Image Grid.Column="2"
+               Grid.Row="1"
+               Source="{Binding Source={x:Reference Root}, Path=MinusImageSource}">
+            <Image.GestureRecognizers>
+                <TapGestureRecognizer Tapped="OnMinusTapped"/>
+            </Image.GestureRecognizers>
+        </Image>
+    </Grid>
+</ContentView>

--- a/ElectricalImpedanceTomography/Controls/PlusMinusEntryControl.xaml.cs
+++ b/ElectricalImpedanceTomography/Controls/PlusMinusEntryControl.xaml.cs
@@ -1,0 +1,73 @@
+using Microsoft.Maui.Controls;
+using System;
+
+namespace ElectricalImpedanceTomography.Controls;
+
+public partial class PlusMinusEntryControl : ContentView
+{
+    public static readonly BindableProperty LabelTextProperty =
+        BindableProperty.Create(nameof(LabelText), typeof(string), typeof(PlusMinusEntryControl), string.Empty);
+
+    public static readonly BindableProperty ValueProperty =
+        BindableProperty.Create(nameof(Value), typeof(int), typeof(PlusMinusEntryControl), 0, BindingMode.TwoWay);
+
+    public static readonly BindableProperty MaxProperty =
+        BindableProperty.Create(nameof(Max), typeof(int), typeof(PlusMinusEntryControl), int.MaxValue);
+
+    public static readonly BindableProperty PlusImageSourceProperty =
+        BindableProperty.Create(nameof(PlusImageSource), typeof(ImageSource), typeof(PlusMinusEntryControl));
+
+    public static readonly BindableProperty MinusImageSourceProperty =
+        BindableProperty.Create(nameof(MinusImageSource), typeof(ImageSource), typeof(PlusMinusEntryControl));
+
+    public string LabelText
+    {
+        get => (string)GetValue(LabelTextProperty);
+        set => SetValue(LabelTextProperty, value);
+    }
+
+    public int Value
+    {
+        get => (int)GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    public int Max
+    {
+        get => (int)GetValue(MaxProperty);
+        set => SetValue(MaxProperty, value);
+    }
+
+    public ImageSource PlusImageSource
+    {
+        get => (ImageSource)GetValue(PlusImageSourceProperty);
+        set => SetValue(PlusImageSourceProperty, value);
+    }
+
+    public ImageSource MinusImageSource
+    {
+        get => (ImageSource)GetValue(MinusImageSourceProperty);
+        set => SetValue(MinusImageSourceProperty, value);
+    }
+
+    public PlusMinusEntryControl()
+    {
+        InitializeComponent();
+    }
+
+    public void OnPlusTapped(object sender, EventArgs e)
+    {
+        if (Value + 1 <= Max)
+        {
+            Value = Value + 1;
+        }
+    }
+
+    public void OnMinusTapped(object sender, EventArgs e)
+    {
+        if (Value - 1 > 0)
+        {
+            Value = Value - 1;
+        }
+    }
+}

--- a/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
+++ b/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
@@ -80,6 +80,9 @@
           <Compile Update="Controls\ReconstructionParametersControl.xaml.cs">
             <DependentUpon>ReconstructionParametersControl.xaml</DependentUpon>
           </Compile>
+          <Compile Update="Controls\PlusMinusEntryControl.xaml.cs">
+            <DependentUpon>PlusMinusEntryControl.xaml</DependentUpon>
+          </Compile>
           <Compile Update="Views\LBMReconstructionPage.xaml.cs">
             <DependentUpon>LBMReconstructionPage.xaml</DependentUpon>
           </Compile>
@@ -105,6 +108,9 @@
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
           <MauiXaml Update="Controls\ReconstructionParametersControl.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Controls\PlusMinusEntryControl.xaml">
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
           <MauiXaml Update="Views\MeshingPage.xaml">

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -56,10 +56,17 @@
                     <BoxView WidthRequest="200" HeightRequest="2" BackgroundColor="Gray"/>
 
                     <!-- Common parameters -->
-                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10" Margin="10">
-                        <Label Grid.Column="0" Text="Electrodes" VerticalOptions="Center"/>
-                        <Entry Grid.Column="1" Text="{Binding ElectrodeCount}" WidthRequest="30" HorizontalOptions="End" Keyboard="Numeric"/>
-                    </Grid>
+                    <controls:PlusMinusEntryControl Margin="10"
+                                                   LabelText="Electrodes"
+                                                   Value="{Binding ElectrodeCount}"
+                                                   Max="200">
+                        <controls:PlusMinusEntryControl.PlusImageSource>
+                            <FontImageSource Glyph="+" Size="20" />
+                        </controls:PlusMinusEntryControl.PlusImageSource>
+                        <controls:PlusMinusEntryControl.MinusImageSource>
+                            <FontImageSource Glyph="-" Size="20" />
+                        </controls:PlusMinusEntryControl.MinusImageSource>
+                    </controls:PlusMinusEntryControl>
 
                     <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10" Margin="10" IsVisible="{Binding IsCustomGeometry}">
                         <Label Grid.Column="0" Text="Custom" VerticalOptions="Center"/>
@@ -116,10 +123,17 @@
                     <BoxView WidthRequest="200" HeightRequest="2" BackgroundColor="Gray"/>
                                        
                     <!-- Common parameters -->
-                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10" Margin="10">
-                        <Label Grid.Column="0" Text="Electrodes" VerticalOptions="Center"/>
-                        <Entry Grid.Column="1" Text="{Binding ElectrodeCount}" WidthRequest="30" HorizontalOptions="End" Keyboard="Numeric"/>
-                    </Grid>
+                    <controls:PlusMinusEntryControl Margin="10"
+                                                   LabelText="Electrodes"
+                                                   Value="{Binding ElectrodeCount}"
+                                                   Max="200">
+                        <controls:PlusMinusEntryControl.PlusImageSource>
+                            <FontImageSource Glyph="+" Size="20" />
+                        </controls:PlusMinusEntryControl.PlusImageSource>
+                        <controls:PlusMinusEntryControl.MinusImageSource>
+                            <FontImageSource Glyph="-" Size="20" />
+                        </controls:PlusMinusEntryControl.MinusImageSource>
+                    </controls:PlusMinusEntryControl>
 
                     <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10" Margin="10" IsVisible="{Binding IsCustomGeometry}">
                         <Label Grid.Column="0" Text="Custom" VerticalOptions="Center"/>

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -76,13 +76,21 @@ public partial class ReconstructionPage : ContentPage
         {
             _viewModel.StartBackgroundReconstruction();
             _hasStarted = true;
+            _isPaused = false;
+            StepButton.IsEnabled = false;
+            return;
+        }
+
+        if (_isPaused)
+        {
+            _viewModel.ResumeReconstruction();
+            _isPaused = false;
+            StepButton.IsEnabled = false;
         }
         else
         {
-            _viewModel.ResumeReconstruction();
+            await DisplayAlert("Reconstruction Running", "You should either pause or stop reconstruction to start a new one.", "OK");
         }
-        _isPaused = false;
-        StepButton.IsEnabled = false;
     }
 
     private async void OnPauseButtonClicked(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- Prevent starting a new reconstruction while one is running and alert the user to pause or stop first
- Introduce `PlusMinusEntryControl` with plus/minus taps to adjust a bound numeric value
- Use the new control on the Meshing page for electrode count adjustment

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bcbc24488333abf83b38715aa1e5