### PR TITLE
Animate plus/minus control and limit startup self-tests

### DIFF
--- a/ElectricalImpedanceTomography/App.xaml.cs
+++ b/ElectricalImpedanceTomography/App.xaml.cs
@@ -18,12 +18,14 @@ namespace ElectricalImpedanceTomography
             Settings.ApplyContainerRegistration();
             ServiceLayer.Settings.ApplyContainerRegistration();
 
+            #if DEBUG
             // Run built-in self-tests
             StartupSelfTests.RunAll();
 
             // Execute analytic validation suite comparing numerical solvers to
             // reference equations (Fourier modes, dipole, layered media, etc.)
             ValidationSelfTests.RunAll();
+            #endif
 
             // Workspace initialization
             Workspace.Initialize(new DefaultUser(1, "Test1", "Test1@factroymail.com"), null, null);

--- a/ElectricalImpedanceTomography/Controls/PlusMinusEntryControl.xaml.cs
+++ b/ElectricalImpedanceTomography/Controls/PlusMinusEntryControl.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.Controls;
 using System;
+using System.Threading.Tasks;
 
 namespace ElectricalImpedanceTomography.Controls;
 
@@ -55,19 +56,32 @@ public partial class PlusMinusEntryControl : ContentView
         InitializeComponent();
     }
 
-    public void OnPlusTapped(object sender, EventArgs e)
+    public async void OnPlusTapped(object sender, EventArgs e)
     {
+        if (sender is Image image)
+            await AnimateTap(image);
+
         if (Value + 1 <= Max)
         {
             Value = Value + 1;
         }
     }
 
-    public void OnMinusTapped(object sender, EventArgs e)
+    public async void OnMinusTapped(object sender, EventArgs e)
     {
+        if (sender is Image image)
+            await AnimateTap(image);
+
         if (Value - 1 > 0)
         {
             Value = Value - 1;
         }
+    }
+
+    private static async Task AnimateTap(Image image)
+    {
+        const uint duration = 50;
+        await image.ScaleTo(0.8, duration);
+        await image.ScaleTo(1, duration);
     }
 }


### PR DESCRIPTION
## Summary
- shrink plus/minus icons briefly when tapped to give button feedback
- restrict costly self-tests to debug builds to reduce startup slowdown

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c778d8e08333b553f9edf1336932