### PR TITLE
Animate tap on plus/minus control

### DIFF
--- a/ElectricalImpedanceTomography/Controls/PlusMinusEntryControl.xaml.cs
+++ b/ElectricalImpedanceTomography/Controls/PlusMinusEntryControl.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui.Controls;
 using System;
+using System.Threading.Tasks;
 
 namespace ElectricalImpedanceTomography.Controls;
 
@@ -55,19 +56,31 @@ public partial class PlusMinusEntryControl : ContentView
         InitializeComponent();
     }
 
-    public void OnPlusTapped(object sender, EventArgs e)
+    public async void OnPlusTapped(object sender, EventArgs e)
     {
+        if (sender is Image img)
+        {
+            await img.ScaleTo(0.8, 80);
+            await img.ScaleTo(1, 80);
+        }
+
         if (Value + 1 <= Max)
         {
-            Value = Value + 1;
+            Value += 1;
         }
     }
 
-    public void OnMinusTapped(object sender, EventArgs e)
+    public async void OnMinusTapped(object sender, EventArgs e)
     {
+        if (sender is Image img)
+        {
+            await img.ScaleTo(0.8, 80);
+            await img.ScaleTo(1, 80);
+        }
+
         if (Value - 1 > 0)
         {
-            Value = Value - 1;
+            Value -= 1;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Animate plus/minus images on tap to briefly shrink and expand for button-like feedback

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c778d8e08333b553f9edf1336932