### PR TITLE
Fix circular FEM mesh electrode spacing and optimize UI rendering

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
@@ -6,25 +6,20 @@ namespace ElectricalImpedanceTomography.ViewModels
 {
     public partial class BaseReconstructionPageViewModel : BaseViewModel
     {
-        public IEnumerable<DifferentialEquationSolver> DifferentialEquationSolverOptions
-            => Enum.GetValues(typeof(DifferentialEquationSolver))
-                   .Cast<DifferentialEquationSolver>();
+        private static readonly DifferentialEquationSolver[] DifferentialEquationSolverValues = Enum.GetValues<DifferentialEquationSolver>();
+        public IEnumerable<DifferentialEquationSolver> DifferentialEquationSolverOptions => DifferentialEquationSolverValues;
 
-        public IEnumerable<RegularizationTechnique> RegularizationTechniqueOptions
-            => Enum.GetValues(typeof(RegularizationTechnique))
-                   .Cast<RegularizationTechnique>();
+        private static readonly RegularizationTechnique[] RegularizationTechniqueValues = Enum.GetValues<RegularizationTechnique>();
+        public IEnumerable<RegularizationTechnique> RegularizationTechniqueOptions => RegularizationTechniqueValues;
 
-        public IEnumerable<ErrorMetric> ErrorMetricOptions
-            => Enum.GetValues(typeof(ErrorMetric))
-                   .Cast<ErrorMetric>();
+        private static readonly ErrorMetric[] ErrorMetricValues = Enum.GetValues<ErrorMetric>();
+        public IEnumerable<ErrorMetric> ErrorMetricOptions => ErrorMetricValues;
 
-        public IEnumerable<NumericSolver> NumericSolverOptions
-            => Enum.GetValues(typeof(NumericSolver))
-                   .Cast<NumericSolver>();
+        private static readonly NumericSolver[] NumericSolverValues = Enum.GetValues<NumericSolver>();
+        public IEnumerable<NumericSolver> NumericSolverOptions => NumericSolverValues;
 
-        public IEnumerable<NumericOptimizer> NumericOptimizerOptions
-            => Enum.GetValues(typeof(NumericOptimizer))
-                   .Cast<NumericOptimizer>();
+        private static readonly NumericOptimizer[] NumericOptimizerValues = Enum.GetValues<NumericOptimizer>();
+        public IEnumerable<NumericOptimizer> NumericOptimizerOptions => NumericOptimizerValues;
 
         [ObservableProperty]
         private EITReconstructionParameters reconstructionParameters = Workspace.GetReconstructionParameters();

--- a/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
@@ -37,11 +37,16 @@ namespace ElectricalImpedanceTomography.ViewModels
             Workspace.SetReconstructionParameters(value);
         }
 
-        public IEnumerable<DifferentialEquationSolver> Solvers => Enum.GetValues<DifferentialEquationSolver>();
-        public IEnumerable<RegularizationTechnique> Regularizations => Enum.GetValues<RegularizationTechnique>();
-        public IEnumerable<ErrorMetric> ErrorMetrics => Enum.GetValues<ErrorMetric>();
-        public IEnumerable<NumericOptimizer> NumericOptimizers => Enum.GetValues<NumericOptimizer>();
-        public IEnumerable<NumericSolver> NumericSolvers => Enum.GetValues<NumericSolver>();
+        private static readonly DifferentialEquationSolver[] SolverValues = Enum.GetValues<DifferentialEquationSolver>();
+        public IEnumerable<DifferentialEquationSolver> Solvers => SolverValues;
+        private static readonly RegularizationTechnique[] RegularizationValues = Enum.GetValues<RegularizationTechnique>();
+        public IEnumerable<RegularizationTechnique> Regularizations => RegularizationValues;
+        private static readonly ErrorMetric[] ErrorMetricValues = Enum.GetValues<ErrorMetric>();
+        public IEnumerable<ErrorMetric> ErrorMetrics => ErrorMetricValues;
+        private static readonly NumericOptimizer[] NumericOptimizerValues = Enum.GetValues<NumericOptimizer>();
+        public IEnumerable<NumericOptimizer> NumericOptimizers => NumericOptimizerValues;
+        private static readonly NumericSolver[] NumericSolverValues = Enum.GetValues<NumericSolver>();
+        public IEnumerable<NumericSolver> NumericSolvers => NumericSolverValues;
 
         public IAsyncRelayCommand<string> NavigateCommand { get; }
 

--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -12,7 +12,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 {
     public partial class MeshingPageViewModel : BaseViewModel
     {
-    private readonly IDAQService _daqService;
+        private readonly IDAQService _daqService;
 
         [ObservableProperty]
         private string name = string.Empty;
@@ -21,12 +21,14 @@ namespace ElectricalImpedanceTomography.ViewModels
         private DateTime saveTime;
 
         // mesh parameter bindings
-        public IEnumerable<MeshType> MeshTypes => Enum.GetValues<MeshType>();
+        private static readonly MeshType[] MeshTypeValues = Enum.GetValues<MeshType>();
+        public IEnumerable<MeshType> MeshTypes => MeshTypeValues;
 
         [ObservableProperty]
         private MeshType selectedMeshType = MeshType.FEM;
 
-        public IEnumerable<GeometryType> GeometryTypes => Enum.GetValues<GeometryType>();
+        private static readonly GeometryType[] GeometryTypeValues = Enum.GetValues<GeometryType>();
+        public IEnumerable<GeometryType> GeometryTypes => GeometryTypeValues;
 
         [ObservableProperty]
         private GeometryType selectedGeometry = GeometryType.Circular;

--- a/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/FEMReconstructionPage.xaml.cs
@@ -37,6 +37,8 @@ public partial class FEMReconstructionPage : ContentPage
     readonly SKColor ElectrodeFill = SKColors.Yellow;
     readonly SKColor ElectrodeStroke = SKColors.Black;
     const float ElectrodeRadius = 6f;
+    private readonly SKPaint _electrodeFillPaint = new() { Style = SKPaintStyle.Fill, Color = SKColors.Yellow, IsAntialias = true };
+    private readonly SKPaint _electrodeStrokePaint = new() { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1, IsAntialias = true };
 
     private bool _isSimulationRunning = false;
     private bool _isPaused = false;
@@ -68,6 +70,11 @@ public partial class FEMReconstructionPage : ContentPage
 
         InitializeComponent();
     }
+
+    // Reusable drawing resources to avoid per-frame allocations
+    private readonly SKPaint _meshFillPaint = new() { Style = SKPaintStyle.Fill, IsAntialias = true };
+    private readonly SKPaint _meshStrokePaint = new() { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1, IsAntialias = true };
+    private readonly SKPath _meshPath = new();
 
     #region CANVAS RELATED 
 
@@ -179,25 +186,11 @@ public partial class FEMReconstructionPage : ContentPage
 
     private void DrawElectrodes(SKCanvas canvas)
     {
-        using var fillPaint = new SKPaint
-        {
-            Style = SKPaintStyle.Fill,
-            Color = ElectrodeFill,
-            IsAntialias = true
-        };
-        using var strokePaint = new SKPaint
-        {
-            Style = SKPaintStyle.Stroke,
-            Color = ElectrodeStroke,
-            StrokeWidth = 1,
-            IsAntialias = true
-        };
-
         foreach (var v in _mesh.Vertices.Where(v => v.IsElectrode))
         {
             var p = ToCanvas(v);
-            canvas.DrawCircle(p, ElectrodeRadius, fillPaint);
-            canvas.DrawCircle(p, ElectrodeRadius, strokePaint);
+            canvas.DrawCircle(p, ElectrodeRadius, _electrodeFillPaint);
+            canvas.DrawCircle(p, ElectrodeRadius, _electrodeStrokePaint);
         }
     }
 
@@ -207,9 +200,7 @@ public partial class FEMReconstructionPage : ContentPage
         canvas.Clear(SKColor.Parse("#1E1E1E"));
         ComputeBoundsAndRanges(e.Info);
 
-        using var fill = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
-        using var stroke = new SKPaint { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1, IsAntialias = true };
-        var elements = _mesh.GetElements().Cast<FEMElement>().ToList();
+        var elements = _mesh.ElementsTyped;
 
         // draw mesh elements
         foreach (var elem in elements)
@@ -218,16 +209,16 @@ public partial class FEMReconstructionPage : ContentPage
             var avg = elem.Vertices.Average(v => v.Potential);
 
             // paint with the selected mode
-            fill.Color = GetPotentialColor(avg);
+            _meshFillPaint.Color = GetPotentialColor(avg);
 
-            using var path = new SKPath();
-            path.MoveTo(ToCanvas(elem.Vertices[0]));
-            path.LineTo(ToCanvas(elem.Vertices[1]));
-            path.LineTo(ToCanvas(elem.Vertices[2]));
-            path.Close();
+            _meshPath.Reset();
+            _meshPath.MoveTo(ToCanvas(elem.Vertices[0]));
+            _meshPath.LineTo(ToCanvas(elem.Vertices[1]));
+            _meshPath.LineTo(ToCanvas(elem.Vertices[2]));
+            _meshPath.Close();
 
-            canvas.DrawPath(path, fill);
-            canvas.DrawPath(path, stroke);
+            canvas.DrawPath(_meshPath, _meshFillPaint);
+            canvas.DrawPath(_meshPath, _meshStrokePaint);
         }
 
         DrawElectrodes(canvas);
@@ -313,9 +304,6 @@ public partial class FEMReconstructionPage : ContentPage
         canvas.Clear(SKColor.Parse("#1E1E1E"));
         ComputeBoundsAndRanges(e.Info);
 
-        using var fill = new SKPaint { IsAntialias = true, Style = SKPaintStyle.Fill };
-        using var stroke = new SKPaint { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1, IsAntialias = true };
-
         double minVal = ReferenceEquals(mesh, _mesh)
             ? _minCond
             : _minRecon;
@@ -323,28 +311,28 @@ public partial class FEMReconstructionPage : ContentPage
             ? _maxCond
             : _maxRecon;
 
-        var elements = mesh.GetElements().Cast<FEMElement>();
+        var elements = mesh.ElementsTyped;
 
         // fill
         foreach (var elem in elements)
         {
-            fill.Color = ColorForValue(elem.Conductivity, minVal, maxVal);
-            using var path = new SKPath();
-            path.MoveTo(ToCanvas(elem.Vertices[0]));
-            path.LineTo(ToCanvas(elem.Vertices[1]));
-            path.LineTo(ToCanvas(elem.Vertices[2]));
-            path.Close();
-            canvas.DrawPath(path, fill);
+            _meshFillPaint.Color = ColorForValue(elem.Conductivity, minVal, maxVal);
+            _meshPath.Reset();
+            _meshPath.MoveTo(ToCanvas(elem.Vertices[0]));
+            _meshPath.LineTo(ToCanvas(elem.Vertices[1]));
+            _meshPath.LineTo(ToCanvas(elem.Vertices[2]));
+            _meshPath.Close();
+            canvas.DrawPath(_meshPath, _meshFillPaint);
         }
         // outline
         foreach (var elem in elements)
         {
-            using var path = new SKPath();
-            path.MoveTo(ToCanvas(elem.Vertices[0]));
-            path.LineTo(ToCanvas(elem.Vertices[1]));
-            path.LineTo(ToCanvas(elem.Vertices[2]));
-            path.Close();
-            canvas.DrawPath(path, stroke);
+            _meshPath.Reset();
+            _meshPath.MoveTo(ToCanvas(elem.Vertices[0]));
+            _meshPath.LineTo(ToCanvas(elem.Vertices[1]));
+            _meshPath.LineTo(ToCanvas(elem.Vertices[2]));
+            _meshPath.Close();
+            canvas.DrawPath(_meshPath, _meshStrokePaint);
         }
 
         // hover‐info box for conductivity element

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -27,7 +27,7 @@ public partial class MeshingPage : ContentPage
     // stroke for FEM
     private readonly SKPaint _femStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1 };
     private readonly SKPaint _femFill = new() { Style = SKPaintStyle.Fill };
-    private readonly SKPaint _previewElectrode = new() { Style = SKPaintStyle.Fill, Color = SKColors.Yellow };
+    private readonly SKPaint _electrodeFill = new() { Style = SKPaintStyle.Fill, Color = SKColors.Yellow };
 
     // caching values for coordinate transforms
     private float _cellW, _cellH;
@@ -155,9 +155,8 @@ public partial class MeshingPage : ContentPage
             canvas.DrawPath(path, _femStroke);
         }
 
-        using var electrodeFill = new SKPaint { Style = SKPaintStyle.Fill, Color = SKColors.Yellow };
         foreach (var v in mesh.Vertices.Where(v => v.IsElectrode))
-            canvas.DrawCircle(ToCanvas(v), 4f, electrodeFill);
+            canvas.DrawCircle(ToCanvas(v), 4f, _electrodeFill);
     }
 
     private async void OnClearClicked(object sender, EventArgs e)
@@ -205,7 +204,7 @@ public partial class MeshingPage : ContentPage
         canvas.DrawPath(path, _femStroke);
 
         foreach (var p in _electrodePoints)
-            canvas.DrawCircle(p, 4f, _previewElectrode);
+            canvas.DrawCircle(p, 4f, _electrodeFill);
     }
 
     private async void OnAddNoiseTapped(object sender, TappedEventArgs e)

--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -144,14 +144,18 @@ namespace Utility.Classes.Factories
                 .OrderBy(v => v.BoundaryId)
                 .ToList();
             int boundaryCount = boundaryVerts.Count;
-            int increment = Math.Max(boundaryCount / electrodeCount, 1);
+
+            // use fractional steps so electrodes remain evenly spaced even
+            // when boundaryCount isn't divisible by electrodeCount
+            double step = boundaryCount / (double)electrodeCount;
+            double pos = 0.0;
 
             var electrodes = new List<FEMElectrode>(electrodeCount);
             for (int elId = 0; elId < electrodeCount; elId++)
             {
-                // pick every 'increment' boundary FEMVertex
-                int idx = elId * increment;
-                if (idx >= boundaryCount) idx = boundaryCount - 1;
+                int idx = (int)Math.Round(pos, MidpointRounding.AwayFromZero);
+                if (idx >= boundaryCount)
+                    idx = boundaryCount - 1;
 
                 FEMVertex v = boundaryVerts[idx];
                 v.IsElectrode = true;
@@ -166,6 +170,8 @@ namespace Utility.Classes.Factories
 
                 el.FEMVertexIds.Add(v.GlobalId);
                 electrodes.Add(el);
+
+                pos += step;
             }
 
             mesh.SetElectrodes(electrodes);


### PR DESCRIPTION
## Summary
- evenly space electrodes on circular FEM meshes using fractional boundary step
- cache enum values in view models to reduce allocations and improve UI performance
- reuse shared `SKPaint` and `SKPath` objects when rendering canvases to avoid per-frame allocations

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d250ee908333900ed6b8d0370964