### PR TITLE
feat: add undo/redo for meshing edits

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -1,5 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using ServiceLayer;
+using System.Collections.Generic;
 using Utility.Classes;
 using Utility.Classes.Factories;
 using Utility.Classes.Meshing;
@@ -67,6 +69,8 @@ namespace ElectricalImpedanceTomography.ViewModels
         private string hoveredElementInfo = string.Empty;
 
         private IMesh? _currentMesh;
+        private readonly Stack<IMesh> _undoStack = new();
+        private readonly Stack<IMesh> _redoStack = new();
         private IList<(double x, double y)>? _drawnPerimeter;
         private IList<(double x, double y)>? _drawnElectrodes;
 
@@ -104,8 +108,43 @@ namespace ElectricalImpedanceTomography.ViewModels
             Workspace.SetMesh(_currentMesh);
         }
 
+        public void PushState()
+        {
+            if (_currentMesh != null)
+            {
+                _undoStack.Push(_currentMesh.DeepCopy());
+                _redoStack.Clear();
+            }
+        }
+
+        [RelayCommand]
+        public void Undo()
+        {
+            if (_undoStack.Count == 0)
+                return;
+            if (_currentMesh != null)
+                _redoStack.Push(_currentMesh.DeepCopy());
+            _currentMesh = _undoStack.Pop();
+            Workspace.SetMesh(_currentMesh);
+            MeshChanged?.Invoke();
+        }
+
+        [RelayCommand]
+        public void Redo()
+        {
+            if (_redoStack.Count == 0)
+                return;
+            if (_currentMesh != null)
+                _undoStack.Push(_currentMesh.DeepCopy());
+            _currentMesh = _redoStack.Pop();
+            Workspace.SetMesh(_currentMesh);
+            MeshChanged?.Invoke();
+        }
+
         public void GenerateMesh()
         {
+            if (_currentMesh != null)
+                PushState();
             _currentMesh = SelectedMeshType == MeshType.FEM ? GenerateFEMMesh() : GenerateLBMMesh();
 
             Workspace.SetMesh(_currentMesh);
@@ -130,6 +169,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             if (_currentMesh == null)
                 return;
 
+            PushState();
             MeshFactory.AddGaussianNoise(_currentMesh);
         }
 

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -266,6 +266,32 @@
 
                                 </Border>
 
+                                <Border Stroke="Transparent">
+                                    <Grid ColumnDefinitions="Auto, *" Margin="5">
+                                        <Image Grid.Column="0" Source="icon_next_black.png" HeightRequest="30" Rotation="180"/>
+                                        <Label Grid.Column="1" Text="Undo" FontSize="Medium" HorizontalOptions="Center" VerticalOptions="Center" FontAttributes="Bold"/>
+                                    </Grid>
+                                    <Border.GestureRecognizers>
+                                        <TapGestureRecognizer Tapped="OnUndoClicked"/>
+                                    </Border.GestureRecognizers>
+                                    <Border.Shadow>
+                                        <Shadow Brush="Black" Opacity="5.0" Radius="4.0"/>
+                                    </Border.Shadow>
+                                </Border>
+
+                                <Border Stroke="Transparent">
+                                    <Grid ColumnDefinitions="Auto, *" Margin="5">
+                                        <Image Grid.Column="0" Source="icon_next_black.png" HeightRequest="30"/>
+                                        <Label Grid.Column="1" Text="Redo" FontSize="Medium" HorizontalOptions="Center" VerticalOptions="Center" FontAttributes="Bold"/>
+                                    </Grid>
+                                    <Border.GestureRecognizers>
+                                        <TapGestureRecognizer Tapped="OnRedoClicked"/>
+                                    </Border.GestureRecognizers>
+                                    <Border.Shadow>
+                                        <Shadow Brush="Black" Opacity="5.0" Radius="4.0"/>
+                                    </Border.Shadow>
+                                </Border>
+
                             </HorizontalStackLayout>
                         </Border>
                         

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -159,18 +159,19 @@ public partial class MeshingPage : ContentPage
             canvas.DrawCircle(ToCanvas(v), 4f, _electrodeFill);
     }
 
-    private async void OnClearClicked(object sender, EventArgs e)
-    {
-        if (sender is VisualElement v) await ShrinkViewAsync(v);
-        _outlinePoints.Clear();
-        _electrodePoints.Clear();
-        _selectedCells.Clear();
-        _outlineClosed = false;
-        _isDrawing = false;
-        _viewModel.HoveredElementInfo = string.Empty;
-        _viewModel.Clear();
-        MeshCanvas.InvalidateSurface();
-    }
+        private async void OnClearClicked(object sender, EventArgs e)
+        {
+            if (sender is VisualElement v) await ShrinkViewAsync(v);
+            _outlinePoints.Clear();
+            _electrodePoints.Clear();
+            _selectedCells.Clear();
+            _outlineClosed = false;
+            _isDrawing = false;
+            _viewModel.HoveredElementInfo = string.Empty;
+            _viewModel.PushState();
+            _viewModel.Clear();
+            MeshCanvas.InvalidateSurface();
+        }
 
     private async void OnEditClicked(object sender, TappedEventArgs e)
     {
@@ -188,6 +189,20 @@ public partial class MeshingPage : ContentPage
             _viewModel.InhomogenityEditing = true;
         }
 
+    }
+
+    private async void OnUndoClicked(object sender, TappedEventArgs e)
+    {
+        if (sender is VisualElement v) await ShrinkViewAsync(v);
+        _viewModel.Undo();
+        MeshCanvas.InvalidateSurface();
+    }
+
+    private async void OnRedoClicked(object sender, TappedEventArgs e)
+    {
+        if (sender is VisualElement v) await ShrinkViewAsync(v);
+        _viewModel.Redo();
+        MeshCanvas.InvalidateSurface();
     }
 
     private void DrawFEMPreview(SKCanvas canvas)
@@ -241,35 +256,39 @@ public partial class MeshingPage : ContentPage
             }
             var el = lbm.GetElementAt(x, y);
 
-            if (_viewModel.InhomogenityEditing)
-            {
+                if (_viewModel.InhomogenityEditing)
+                {
 
-                if (e.MouseButton == SKMouseButton.Right && e.ActionType == SKTouchAction.Pressed)
-                {
-                    el.Conductivity = _viewModel.InhomogenityValue;
-                    _viewModel.RefreshConductivity();
+                    if (e.MouseButton == SKMouseButton.Right && e.ActionType == SKTouchAction.Pressed)
+                    {
+                        _viewModel.PushState();
+                        el.Conductivity = _viewModel.InhomogenityValue;
+                        _viewModel.RefreshConductivity();
+                    }
+                    else if (e.MouseButton == SKMouseButton.Left && e.ActionType == SKTouchAction.Pressed)
+                    {
+                        _viewModel.PushState();
+                        el.IsWall = !el.IsWall;
+                        if (el.IsWall) el.IsElectrode = false;
+                    }
                 }
-                else if (e.MouseButton == SKMouseButton.Left && e.ActionType == SKTouchAction.Pressed)
+                else
                 {
-                    el.IsWall = !el.IsWall;
-                    if (el.IsWall) el.IsElectrode = false;
-                }
-            }
-            else
-            {
 
-                if (e.MouseButton == SKMouseButton.Left && e.ActionType == SKTouchAction.Pressed)
-                {
-                    el.IsWall = !el.IsWall;
-                    if (el.IsWall) el.IsElectrode = false;
+                    if (e.MouseButton == SKMouseButton.Left && e.ActionType == SKTouchAction.Pressed)
+                    {
+                        _viewModel.PushState();
+                        el.IsWall = !el.IsWall;
+                        if (el.IsWall) el.IsElectrode = false;
+                    }
+                    else if (e.MouseButton == SKMouseButton.Right && e.ActionType == SKTouchAction.Pressed)
+                    {
+                        _viewModel.PushState();
+                        el.IsElectrode = !el.IsElectrode;
+                        if (el.IsElectrode) el.IsWall = false;
+                        _viewModel.RefreshLbmElectrodes();
+                    }
                 }
-                else if (e.MouseButton == SKMouseButton.Right && e.ActionType == SKTouchAction.Pressed)
-                {
-                    el.IsElectrode = !el.IsElectrode;
-                    if (el.IsElectrode) el.IsWall = false;
-                    _viewModel.RefreshLbmElectrodes();
-                }
-            }
             if (e.ActionType == SKTouchAction.Moved || e.ActionType == SKTouchAction.Entered)
                 _viewModel.HoveredElementInfo = $"ID: {el.Id} \u03C3: {el.Conductivity:F2}, Wall: {el.IsWall}, Electrode: {el.IsElectrode}";
             MeshCanvas.InvalidateSurface();
@@ -288,6 +307,7 @@ public partial class MeshingPage : ContentPage
                     found = true;
                     if (_viewModel.InhomogenityEditing && e.MouseButton == SKMouseButton.Left && e.ActionType == SKTouchAction.Pressed)
                     {
+                        _viewModel.PushState();
                         el.Conductivity = _viewModel.InhomogenityValue;
                         _viewModel.RefreshConductivity();
                         MeshCanvas.InvalidateSurface();
@@ -309,16 +329,17 @@ public partial class MeshingPage : ContentPage
         e.Handled = true;
     }
 
-    private void ApplySelectionConductivity()
-    {
-        if (_viewModel.GetCurrentMesh() is not LBMMesh lbm)
-            return;
-
-        foreach (var id in _selectedCells)
+        private void ApplySelectionConductivity()
         {
-            var (sx, sy) = lbm.ToLattice(id);
-            lbm.GetElementAt(sx, sy).Conductivity = _viewModel.InhomogenityValue;
-        }
+            if (_viewModel.GetCurrentMesh() is not LBMMesh lbm)
+                return;
+
+            _viewModel.PushState();
+            foreach (var id in _selectedCells)
+            {
+                var (sx, sy) = lbm.ToLattice(id);
+                lbm.GetElementAt(sx, sy).Conductivity = _viewModel.InhomogenityValue;
+            }
         _selectedCells.Clear();
         _viewModel.RefreshConductivity();
         MeshCanvas.InvalidateSurface();


### PR DESCRIPTION
## Summary
- maintain undo and redo stacks for mesh edits
- add undo/redo controls to meshing page editing panel
- capture mesh state before editing operations and restore on undo/redo

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d7b579f083338c0a1c11061c6a58