### PR TITLE
Enable electrode dragging on mesh canvas

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -5,6 +5,8 @@ using Utility.Classes.Factories;
 using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
+using System.Linq;
+using System.Collections.Generic;
 
 using Workspace = Utility.Classes.Application.Workspace;
 
@@ -243,6 +245,22 @@ namespace ElectricalImpedanceTomography.ViewModels
             foreach (var el in mesh.ElementsTyped)
                 if (el.IsElectrode)
                     electrodes.Add(new LBMElectrode(id++, el.Id, 0.0, 0.0, ElectrodeContactImpedance));
+            mesh.SetElectrodes(electrodes);
+        }
+
+        public void RefreshFemElectrodes()
+        {
+            if (_currentMesh is not FEMMesh mesh) return;
+            var verts = mesh.Vertices.Where(v => v.IsElectrode).ToList();
+            var electrodes = new List<FEMElectrode>();
+            for (int i = 0; i < verts.Count; i++)
+            {
+                var v = verts[i];
+                v.ElectrodeId = i;
+                var el = new FEMElectrode(i, v.GlobalId, 0.0, ElectrodeContactImpedance, 0.0);
+                el.FEMVertexIds.Add(v.GlobalId);
+                electrodes.Add(el);
+            }
             mesh.SetElectrodes(electrodes);
         }
 

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -40,6 +40,10 @@ public partial class MeshingPage : ContentPage
     private bool _isDrawing;
     private bool _outlineClosed;
 
+    // dragging state
+    private LBMElement? _draggedLbmElectrode;
+    private FEMVertex? _draggedFemVertex;
+
     public MeshingPage()
     {
         InitializeComponent();
@@ -240,10 +244,36 @@ public partial class MeshingPage : ContentPage
                 return;
             }
             var el = lbm.GetElementAt(x, y);
+            if (_draggedLbmElectrode != null)
+            {
+                if (e.ActionType == SKTouchAction.Moved)
+                {
+                    if (el != _draggedLbmElectrode && !el.IsWall)
+                    {
+                        _draggedLbmElectrode.IsElectrode = false;
+                        el.IsElectrode = true;
+                        _draggedLbmElectrode = el;
+                        _viewModel.RefreshLbmElectrodes();
+                        MeshCanvas.InvalidateSurface();
+                    }
+                }
+                else if (e.ActionType == SKTouchAction.Released)
+                {
+                    _draggedLbmElectrode = null;
+                }
+                e.Handled = true;
+                return;
+            }
+
+            if (!_viewModel.InhomogenityEditing && e.MouseButton == SKMouseButton.Left && e.ActionType == SKTouchAction.Pressed && el.IsElectrode)
+            {
+                _draggedLbmElectrode = el;
+                e.Handled = true;
+                return;
+            }
 
             if (_viewModel.InhomogenityEditing)
             {
-
                 if (e.MouseButton == SKMouseButton.Right && e.ActionType == SKTouchAction.Pressed)
                 {
                     el.Conductivity = _viewModel.InhomogenityValue;
@@ -257,7 +287,6 @@ public partial class MeshingPage : ContentPage
             }
             else
             {
-
                 if (e.MouseButton == SKMouseButton.Left && e.ActionType == SKTouchAction.Pressed)
                 {
                     el.IsWall = !el.IsWall;
@@ -276,6 +305,39 @@ public partial class MeshingPage : ContentPage
         }
         else if (mesh is FEMMesh fem)
         {
+            if (_draggedFemVertex != null)
+            {
+                if (e.ActionType == SKTouchAction.Moved)
+                {
+                    var target = FindNearestBoundaryVertex(e.Location, fem);
+                    if (target != null && target != _draggedFemVertex)
+                    {
+                        _draggedFemVertex.IsElectrode = false;
+                        target.IsElectrode = true;
+                        _draggedFemVertex = target;
+                        _viewModel.RefreshFemElectrodes();
+                        MeshCanvas.InvalidateSurface();
+                    }
+                }
+                else if (e.ActionType == SKTouchAction.Released)
+                {
+                    _draggedFemVertex = null;
+                }
+                e.Handled = true;
+                return;
+            }
+
+            if (e.ActionType == SKTouchAction.Pressed && e.MouseButton == SKMouseButton.Left)
+            {
+                var hit = FindElectrodeAt(e.Location, fem);
+                if (hit != null)
+                {
+                    _draggedFemVertex = hit;
+                    e.Handled = true;
+                    return;
+                }
+            }
+
             var pt = e.Location;
             bool found = false;
             foreach (var el in fem.ElementsTyped)
@@ -377,6 +439,38 @@ public partial class MeshingPage : ContentPage
         float u = (dot11 * dot02 - dot01 * dot12) * invDen;
         float v = (dot00 * dot12 - dot01 * dot02) * invDen;
         return (u >= 0) && (v >= 0) && (u + v <= 1);
+    }
+
+    private FEMVertex? FindElectrodeAt(SKPoint canvasPoint, FEMMesh mesh)
+    {
+        foreach (var v in mesh.Vertices.Where(v => v.IsElectrode))
+        {
+            var cp = ToCanvas(v);
+            float dx = cp.X - canvasPoint.X;
+            float dy = cp.Y - canvasPoint.Y;
+            if (Math.Sqrt(dx * dx + dy * dy) <= 8f)
+                return v;
+        }
+        return null;
+    }
+
+    private FEMVertex? FindNearestBoundaryVertex(SKPoint canvasPoint, FEMMesh mesh)
+    {
+        FEMVertex? nearest = null;
+        float best = float.MaxValue;
+        foreach (var v in mesh.Vertices.Where(v => v.IsBoundary))
+        {
+            var cp = ToCanvas(v);
+            float dx = cp.X - canvasPoint.X;
+            float dy = cp.Y - canvasPoint.Y;
+            float dist = (float)Math.Sqrt(dx * dx + dy * dy);
+            if (dist < best)
+            {
+                best = dist;
+                nearest = v;
+            }
+        }
+        return nearest;
     }
 
     private async void OnSaveClicked(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- Detect drag gestures on MeshCanvas to reposition LBM and FEM electrodes
- Refresh electrodes in view model and redraw canvas after drag
- Snap dragged FEM electrodes to nearest boundary vertex for mesh validity

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d7bd2e488333a54acd9199a9d188