### PR TITLE
Fix boundary condition editing and toggle playback controls

### DIFF
--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -96,10 +96,23 @@
                           ColumnSpacing="15"
                           HorizontalOptions="Center">
                         <Border Grid.Column="0" HeightRequest="50" WidthRequest="50" Margin="5">
-                            <ImageButton Padding="3" Background="Transparent" HeightRequest="30" WidthRequest="30" Source="icon_play_green.png" Clicked="OnPlayButtonClicked"/>
+                            <ImageButton x:Name="PlayButton"
+                                         Padding="3"
+                                         Background="Transparent"
+                                         HeightRequest="30"
+                                         WidthRequest="30"
+                                         Source="icon_play_green.png"
+                                         IsVisible="True"
+                                         Clicked="OnPlayButtonClicked"/>
                         </Border>
                         <Border Grid.Column="1" HeightRequest="50" WidthRequest="50" Margin="5">
-                            <ImageButton Padding="3" Background="Transparent" HeightRequest="30" Source="icon_pause_blue.png" Clicked="OnPauseButtonClicked"/>    
+                            <ImageButton x:Name="PauseButton"
+                                         Padding="3"
+                                         Background="Transparent"
+                                         HeightRequest="30"
+                                         Source="icon_pause_blue.png"
+                                         IsVisible="False"
+                                         Clicked="OnPauseButtonClicked"/>
                         </Border>
                         <Border Grid.Column="2" HeightRequest="50" WidthRequest="50" Margin="5">
                             <ImageButton x:Name="StepButton"

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -54,6 +54,8 @@ public partial class ReconstructionPage : ContentPage
         _viewModel.ReconstructionUpdated += OnReconstructionUpdated;
 
         StepButton.IsEnabled = false;
+        PlayButton.IsVisible = true;
+        PauseButton.IsVisible = false;
     }
 
     private IMesh? GetMesh()
@@ -84,6 +86,8 @@ public partial class ReconstructionPage : ContentPage
             _hasStarted = true;
             _isPaused = false;
             StepButton.IsEnabled = false;
+            PlayButton.IsVisible = false;
+            PauseButton.IsVisible = true;
             return;
         }
 
@@ -92,6 +96,8 @@ public partial class ReconstructionPage : ContentPage
             _viewModel.ResumeReconstruction();
             _isPaused = false;
             StepButton.IsEnabled = false;
+            PlayButton.IsVisible = false;
+            PauseButton.IsVisible = true;
         }
         else
         {
@@ -105,6 +111,8 @@ public partial class ReconstructionPage : ContentPage
         _viewModel.PauseReconstruction();
         _isPaused = true;
         StepButton.IsEnabled = true;
+        PlayButton.IsVisible = true;
+        PauseButton.IsVisible = false;
     }
 
     private async void OnStepButtonClicked(object sender, EventArgs e)
@@ -123,6 +131,8 @@ public partial class ReconstructionPage : ContentPage
         _isPaused = false;
         _hasStarted = false;
         StepButton.IsEnabled = false;
+        PlayButton.IsVisible = true;
+        PauseButton.IsVisible = false;
     }
     #endregion
 
@@ -711,13 +721,23 @@ public partial class ReconstructionPage : ContentPage
         {
             var bc = new FEMBoundaryCondition(fem.GetElectrodes().Cast<FEMElectrode>().ToList());
             var popup = new BoundaryConditionsPopup(bc);
-            await this.ShowPopupAsync(popup);
+            var result = await this.ShowPopupAsync(popup) as BoundaryCondition;
+            if (result is FEMBoundaryCondition femBc)
+            {
+                fem.SetElectrodes(femBc.GetElectrodes().Cast<FEMElectrode>().ToList());
+                InvalidateAll();
+            }
         }
         else if (mesh is LBMMesh lbm)
         {
             var bc = new LBMBoundaryCondition(lbm.GetElectrodes().Cast<LBMElectrode>().ToList());
             var popup = new BoundaryConditionsPopup(bc);
-            await this.ShowPopupAsync(popup);
+            var result = await this.ShowPopupAsync(popup) as BoundaryCondition;
+            if (result is LBMBoundaryCondition lbmBc)
+            {
+                lbm.SetElectrodes(lbmBc.GetElectrodes().Cast<LBMElectrode>().ToList());
+                InvalidateAll();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- correctly apply edited boundary conditions back to the mesh before starting reconstruction
- toggle play/pause buttons so only the appropriate control is visible during simulation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e2fda3b88333ba6599f1a74e50a1