### PR TITLE
Auto-generate and list meshes

### DIFF
--- a/BusinessLayer/DAQPersistence.cs
+++ b/BusinessLayer/DAQPersistence.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using DataAccessLayer;
 using Utility.Classes;
 using Utility.Classes.Measurement;
+using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 
@@ -77,6 +79,11 @@ namespace BusinessLayer
         public LBMMesh LoadLBMMesh(string filePath)
         {
             return _meshRepository.LoadLBMMesh(filePath);
+        }
+
+        public IEnumerable<MeshInfo> GetMeshes()
+        {
+            return _meshRepository.GetMeshes();
         }
 
         public bool ConnectHardware()

--- a/BusinessLayer/IDAQPersistence.cs
+++ b/BusinessLayer/IDAQPersistence.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using Utility.Classes.Measurement;
+using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 
@@ -20,6 +22,7 @@ namespace BusinessLayer
         void SaveLBMMesh(LBMMesh mesh, string name);
         FEMMesh LoadFEMMesh(string filePath);
         LBMMesh LoadLBMMesh(string filePath);
+        IEnumerable<MeshInfo> GetMeshes();
         bool ConnectHardware();
         bool DisconnectHardware();
     }

--- a/DataAccessLayer/IMeshRepository.cs
+++ b/DataAccessLayer/IMeshRepository.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 
@@ -9,5 +11,6 @@ namespace DataAccessLayer
         void SaveLBMMesh(LBMMesh mesh, string name);
         FEMMesh LoadFEMMesh(string filePath);
         LBMMesh LoadLBMMesh(string filePath);
+        IEnumerable<MeshInfo> GetMeshes();
     }
 }

--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -34,6 +34,27 @@ namespace DataAccessLayer
             SaveDocument(doc, name, "lbm");
         }
 
+        public IEnumerable<MeshInfo> GetMeshes()
+        {
+            Directory.CreateDirectory(MeshDir);
+            foreach (var file in Directory.GetFiles(MeshDir, "*.eitmesh"))
+            {
+                try
+                {
+                    var doc = XDocument.Load(file);
+                    var root = doc.Root;
+                    if (root == null) continue;
+                    var name = root.Attribute("name")?.Value ?? Path.GetFileNameWithoutExtension(file);
+                    var md = DeserializeMetadata(root.Element("Metadata"));
+                    yield return new MeshInfo(name, file, md);
+                }
+                catch
+                {
+                    // ignore invalid files
+                }
+            }
+        }
+
         public FEMMesh LoadFEMMesh(string filePath)
         {
             if (!File.Exists(filePath))

--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -1,14 +1,15 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ServiceLayer;
+using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using Utility.Classes;
 using Utility.Classes.Factories;
 using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
-using System.Linq;
-using System.Collections.Generic;
 
 using Workspace = Utility.Classes.Application.Workspace;
 
@@ -69,6 +70,12 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         [ObservableProperty]
         private string hoveredElementInfo = string.Empty;
+
+        [ObservableProperty]
+        private string meshSearchText = string.Empty;
+
+        public ObservableCollection<MeshInfo> AvailableMeshes { get; } = new();
+        public ObservableCollection<MeshInfo> FilteredMeshes { get; } = new();
 
         private IMesh? _currentMesh;
         private readonly Stack<IMesh> _undoStack = new();
@@ -338,11 +345,33 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         partial void OnNyChanged(int value) => AutoGenerateMesh();
 
+        partial void OnLayersChanged(int value) => AutoGenerateMesh();
+
+        partial void OnBoundaryFEMVertexCountChanged(int value) => AutoGenerateMesh();
+
+        partial void OnMeshSearchTextChanged(string value) => ApplyMeshFilter();
+
         private void AutoGenerateMesh()
         {
-            if (SelectedMeshType != MeshType.LBM) return;
             GenerateMesh();
             MeshChanged?.Invoke();
+        }
+
+        public void LoadAvailableMeshes()
+        {
+            AvailableMeshes.Clear();
+            foreach (var m in _daqService.GetMeshes())
+                AvailableMeshes.Add(m);
+            ApplyMeshFilter();
+        }
+
+        private void ApplyMeshFilter()
+        {
+            FilteredMeshes.Clear();
+            foreach (var m in AvailableMeshes.Where(m =>
+                         string.IsNullOrWhiteSpace(MeshSearchText) ||
+                         m.Name.Contains(MeshSearchText, StringComparison.OrdinalIgnoreCase)))
+                FilteredMeshes.Add(m);
         }
     }
 }

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -5,6 +5,7 @@
              xmlns:skia="clr-namespace:SkiaSharp.Views.Maui.Controls;assembly=SkiaSharp.Views.Maui.Controls"
              xmlns:viewmodels="clr-namespace:ElectricalImpedanceTomography.ViewModels"
              xmlns:controls="clr-namespace:ElectricalImpedanceTomography.Controls"
+             xmlns:models="clr-namespace:Utility.Classes.Meshing;assembly=Utility"
              Title="MeshingPage"
              x:DataType="viewmodels:MeshingPageViewModel">
     <ContentPage.Resources>
@@ -23,7 +24,7 @@
     </ContentPage.Resources>
     <Grid RowDefinitions="Auto, *">
         <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="1" CurrentPageName="MeshingPage"/>
-        <Grid Grid.Row="1" ColumnDefinitions="Auto, *">
+        <Grid Grid.Row="1" ColumnDefinitions="Auto, *, Auto">
 
             <!-- Left control Panel FEM -->
             <Border StrokeShape="RoundRectangle 5" IsVisible="{Binding IsFEM}">
@@ -322,6 +323,26 @@
                            Margin="10" />
                 </Border>
             </Grid>
+
+            <Border Grid.Column="2" StrokeShape="RoundRectangle 5" Margin="5">
+                <VerticalStackLayout Spacing="5" Margin="5">
+                    <Label Text="Available Meshes" HorizontalOptions="Center" FontAttributes="Bold"/>
+                    <SearchBar Placeholder="Search" Text="{Binding MeshSearchText}"/>
+                    <CollectionView ItemsSource="{Binding FilteredMeshes}" SelectionMode="Single" SelectionChanged="OnMeshSelected">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="models:MeshInfo">
+                                <Border Stroke="Gray" Margin="2" Padding="4">
+                                    <VerticalStackLayout Spacing="2">
+                                        <Label Text="{Binding Name}" FontAttributes="Bold" FontSize="Small"/>
+                                        <Label Text="{Binding Metadata.CreatedOn, StringFormat='Created: {0:G}'}" FontSize="10"/>
+                                        <Label Text="{Binding ParameterSummary}" FontSize="10"/>
+                                    </VerticalStackLayout>
+                                </Border>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+            </Border>
         </Grid>
     </Grid>
 </ContentPage>

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -1,6 +1,7 @@
 using ElectricalImpedanceTomography.ViewModels;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
+using System.Linq;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Utility.Classes.Meshing;
@@ -44,6 +45,14 @@ public partial class MeshingPage : ContentPage
         _viewModel = Utility.Composition.Container.ResolveObject<MeshingPageViewModel>();
         BindingContext = _viewModel;
         _viewModel.MeshChanged += () => { _selectedCells.Clear(); MeshCanvas.InvalidateSurface(); };
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        _viewModel.LoadAvailableMeshes();
+        _viewModel.GenerateMesh();
+        _viewModel.MeshChanged?.Invoke();
     }
 
     private SKColor ColorForValue(double val, double min, double max)
@@ -514,6 +523,15 @@ public partial class MeshingPage : ContentPage
         if (file != null)
         {
             _viewModel.LoadMesh(file.FullPath);
+            MeshCanvas.InvalidateSurface();
+        }
+    }
+
+    private void OnMeshSelected(object sender, SelectionChangedEventArgs e)
+    {
+        if (e.CurrentSelection.FirstOrDefault() is MeshInfo info)
+        {
+            _viewModel.LoadMesh(info.FilePath);
             MeshCanvas.InvalidateSurface();
         }
     }

--- a/ServiceLayer/DAQService.cs
+++ b/ServiceLayer/DAQService.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using BusinessLayer;
 using System.Diagnostics;
+using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Utility.Classes.Measurement;
@@ -190,6 +192,21 @@ namespace ServiceLayer
             try
             {
                 return _daqPersistence.LoadLBMMesh(filePath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        public IEnumerable<MeshInfo> GetMeshes()
+        {
+            try
+            {
+                return _daqPersistence.GetMeshes();
             }
             catch (Exception ex)
             {

--- a/ServiceLayer/IDAQService.cs
+++ b/ServiceLayer/IDAQService.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using Utility.Classes.Measurement;
+using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 
@@ -20,6 +22,7 @@ namespace ServiceLayer
         void SaveLBMMesh(LBMMesh mesh, string name);
         FEMMesh LoadFEMMesh(string filePath);
         LBMMesh LoadLBMMesh(string filePath);
+        IEnumerable<MeshInfo> GetMeshes();
         bool ConnectHardware();
         bool DisconnectHardware();
     }

--- a/Utility/Classes/Meshing/MeshInfo.cs
+++ b/Utility/Classes/Meshing/MeshInfo.cs
@@ -1,0 +1,9 @@
+using System.Linq;
+
+namespace Utility.Classes.Meshing
+{
+    public record MeshInfo(string Name, string FilePath, MeshMetadata Metadata)
+    {
+        public string ParameterSummary => string.Join(", ", Metadata.Parameters.Select(p => $"{p.Key}={p.Value}"));
+    }
+}


### PR DESCRIPTION
## Summary
- Auto-generate mesh when layers or boundary vertex count change and on page load
- Add mesh database browser with search on meshing page
- Provide data-access pipeline to enumerate saved meshes

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a5cd4c048333b5760a18559bf965