### PR TITLE
Add reconstruction persistence and past reconstruction panel

### DIFF
--- a/BusinessLayer/IReconstructionPersistence.cs
+++ b/BusinessLayer/IReconstructionPersistence.cs
@@ -3,6 +3,7 @@ using Utility.Classes.Measurement;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Utility.Classes.ReconstructionParameters;
+using System.Collections.Generic;
 
 namespace BusinessLayer
 {
@@ -44,5 +45,10 @@ namespace BusinessLayer
         /// <param name="stepSize">Descent step size for updating conductances.</param>
         /// <returns>Reconstruction result after the update step.</returns>
         public ReconstructionResult InverseSolveStepGraph(FEMMesh mesh, double[] measurement, BoundaryCondition boundaryCondition, double stepSize);
+
+        // --- Persistence ---
+        void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters);
+        IEnumerable<ReconstructionInfo> GetReconstructions();
+        List<ReconstructionResult> LoadReconstruction(string filePath);
     }
 }

--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Numerics;
 using System.Linq;
+using System.Collections.Generic;
 using Utility.Classes;
 using Utility.Classes.Factories;
 using Utility.Classes.Measurement;
@@ -17,6 +18,7 @@ namespace BusinessLayer
     public class ReconstructionPersistence : IReconstructionPersistence
     {
         private readonly IDAQRepository _daqRepository;
+        private readonly IReconstructionRepository _reconstructionRepository;
 
         private InverseModel? _inverseModel = null;
         
@@ -30,9 +32,10 @@ namespace BusinessLayer
         private double _gradientStepSize = 0.001;
         private double _regularizationWeight = 0.001;
 
-        public ReconstructionPersistence(IDAQRepository daqRepository)
+        public ReconstructionPersistence(IDAQRepository daqRepository, IReconstructionRepository reconstructionRepository)
         {
             _daqRepository = daqRepository;
+            _reconstructionRepository = reconstructionRepository;
         }
 
 
@@ -675,6 +678,16 @@ namespace BusinessLayer
 
             return new ReconstructionResult(mesh, mesh.PotentialDistribution, mu, originalConductivityDistribution, sigma0, mesh.ConductivityDistribution);
         }
+
+        // --- Persistence ---
+        public void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters)
+            => _reconstructionRepository.SaveReconstruction(frames, name, parameters);
+
+        public IEnumerable<ReconstructionInfo> GetReconstructions()
+            => _reconstructionRepository.GetReconstructions();
+
+        public List<ReconstructionResult> LoadReconstruction(string filePath)
+            => _reconstructionRepository.LoadReconstruction(filePath);
     }
 }
 

--- a/DataAccessLayer/IReconstructionRepository.cs
+++ b/DataAccessLayer/IReconstructionRepository.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Utility.Classes;
+using Utility.Classes.ReconstructionParameters;
+
+namespace DataAccessLayer
+{
+    public interface IReconstructionRepository
+    {
+        void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters);
+        IEnumerable<ReconstructionInfo> GetReconstructions();
+        List<ReconstructionResult> LoadReconstruction(string filePath);
+    }
+}

--- a/DataAccessLayer/ReconstructionRepository.cs
+++ b/DataAccessLayer/ReconstructionRepository.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Utility.Classes;
+using Utility.Classes.ReconstructionParameters;
+
+namespace DataAccessLayer
+{
+    public class ReconstructionRepository : IReconstructionRepository
+    {
+        private static string ReconDir => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                                                        "EITApplication", "Reconstructions");
+
+        public void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters)
+        {
+            if (frames == null || frames.Count == 0) throw new ArgumentException("No frames to save.", nameof(frames));
+            if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name required.", nameof(name));
+
+            var md = new ReconstructionMetadata
+            {
+                CreatedOn = DateTime.UtcNow,
+                FrameCount = frames.Count,
+                Parameters = new Dictionary<string, string>
+                {
+                    ["DifferentialEquationSolver"] = parameters.DifferentialEquationSolver.ToString(),
+                    ["RegularizationTechnique"] = parameters.RegularizationTechnique.ToString(),
+                    ["ErrorMetric"] = parameters.ErrorMetric.ToString(),
+                    ["NumericSolver"] = parameters.NumericSolver.ToString(),
+                    ["NumericOptimizer"] = parameters.NumericOptimizer.ToString(),
+                    ["Mesh"] = parameters.Mesh.ToString()
+                }
+            };
+
+            var doc = new XDocument(
+                new XElement("Reconstruction",
+                    new XAttribute("name", name),
+                    SerializeMetadata(md),
+                    new XElement("Frames",
+                        frames.Select((f, i) =>
+                            new XElement("Frame",
+                                new XAttribute("index", i),
+                                SerializeConductivity("Original", f.OriginalConductivityDistribution),
+                                SerializeConductivity("Initial", f.InitialConductivitiyDistribution),
+                                SerializeConductivity("Reconstructed", f.ReconstructedConductivityDistribution)
+                            ))
+                    )
+                )
+            );
+
+            Directory.CreateDirectory(ReconDir);
+            doc.Save(Path.Combine(ReconDir, $"{name}.eitrecon"));
+        }
+
+        public IEnumerable<ReconstructionInfo> GetReconstructions()
+        {
+            Directory.CreateDirectory(ReconDir);
+            foreach (var file in Directory.GetFiles(ReconDir, "*.eitrecon"))
+            {
+                ReconstructionInfo? info = null;
+                try
+                {
+                    var doc = XDocument.Load(file);
+                    var root = doc.Root;
+                    if (root == null) continue;
+                    var name = root.Attribute("name")?.Value ?? Path.GetFileNameWithoutExtension(file);
+                    var md = DeserializeMetadata(root.Element("Metadata"));
+                    info = new ReconstructionInfo(name, file, md);
+                }
+                catch
+                {
+                    // ignore invalid files
+                }
+
+                if (info != null)
+                    yield return info;
+            }
+        }
+
+        public List<ReconstructionResult> LoadReconstruction(string filePath)
+        {
+            if (!File.Exists(filePath))
+                throw new FileNotFoundException($"Reconstruction file not found: {filePath}");
+
+            var doc = XDocument.Load(filePath);
+            var root = doc.Root ?? throw new InvalidOperationException("Invalid reconstruction file.");
+
+            var frames = new List<ReconstructionResult>();
+            var framesEl = root.Element("Frames");
+            if (framesEl != null)
+            {
+                foreach (var frameEl in framesEl.Elements("Frame").OrderBy(f => (int)(f.Attribute("index") ?? 0)))
+                {
+                    var orig = DeserializeConductivity(frameEl.Element("Original"));
+                    var init = DeserializeConductivity(frameEl.Element("Initial"));
+                    var recon = DeserializeConductivity(frameEl.Element("Reconstructed"));
+                    frames.Add(new ReconstructionResult(new PotentialDistribution(new Dictionary<int, double>()),
+                                                        new PotentialDistribution(new Dictionary<int, double>()),
+                                                        orig, init, recon));
+                }
+            }
+            return frames;
+        }
+
+        private static XElement SerializeMetadata(ReconstructionMetadata metadata)
+        {
+            return new XElement("Metadata",
+                new XElement("CreatedOn", metadata.CreatedOn.ToString("o")),
+                new XElement("FrameCount", metadata.FrameCount),
+                new XElement("Parameters",
+                    metadata.Parameters.Select(p =>
+                        new XElement("Parameter",
+                            new XAttribute("key", p.Key),
+                            new XAttribute("value", p.Value)))
+                )
+            );
+        }
+
+        private static ReconstructionMetadata DeserializeMetadata(XElement? element)
+        {
+            var md = new ReconstructionMetadata();
+            if (element == null) return md;
+
+            md.CreatedOn = DateTime.Parse(element.Element("CreatedOn")?.Value ?? DateTime.UtcNow.ToString("o"));
+            md.FrameCount = int.Parse(element.Element("FrameCount")?.Value ?? "0");
+            var dict = new Dictionary<string, string>();
+            var parms = element.Element("Parameters");
+            if (parms != null)
+            {
+                foreach (var p in parms.Elements("Parameter"))
+                    dict[(string)(p.Attribute("key") ?? throw new NullReferenceException())] = (string)(p.Attribute("value") ?? throw new NullReferenceException());
+            }
+            md.Parameters = dict;
+            return md;
+        }
+
+        private static XElement SerializeConductivity(string name, ConductivityDistribution dist)
+        {
+            return new XElement(name,
+                dist.Conductivities.Select(kv =>
+                    new XElement("Value",
+                        new XAttribute("elementId", kv.Key),
+                        new XAttribute("sigma", kv.Value))));
+        }
+
+        private static ConductivityDistribution DeserializeConductivity(XElement? element)
+        {
+            var dict = element?.Elements("Value").ToDictionary(v => (int)(v.Attribute("elementId") ?? throw new NullReferenceException()),
+                                                              v => (double)(v.Attribute("sigma") ?? throw new NullReferenceException()))
+                       ?? new Dictionary<int, double>();
+            return new ConductivityDistribution(dict);
+        }
+    }
+}

--- a/DataAccessLayer/Settings.cs
+++ b/DataAccessLayer/Settings.cs
@@ -8,7 +8,8 @@ namespace DataAccessLayer
         {
             return Utility.Composition.Settings.ApplyContainerRegistration()
                 .RegisterType<IDAQRepository, DAQRepository>()
-                .RegisterType<IMeshRepository, MeshRepository>();
+                .RegisterType<IMeshRepository, MeshRepository>()
+                .RegisterType<IReconstructionRepository, ReconstructionRepository>();
 
         }
     }

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -4,6 +4,8 @@ using Utility.Classes;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Workspace = Utility.Classes.Application.Workspace;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace ElectricalImpedanceTomography.ViewModels
 {
@@ -25,6 +27,15 @@ namespace ElectricalImpedanceTomography.ViewModels
         [ObservableProperty]
         private bool oppositeDrivePattern = false;
 
+        [ObservableProperty]
+        private string name = string.Empty;
+
+        [ObservableProperty]
+        private string reconstructionSearchText = string.Empty;
+
+        public ObservableCollection<ReconstructionInfo> AvailableReconstructions { get; } = [];
+        public ObservableCollection<ReconstructionInfo> FilteredReconstructions { get; } = [];
+
         public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
 
         public ReconstructionPageViewModel(IReconstructionService reconstructionService)
@@ -36,6 +47,8 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             _reconstructionService.ReconstructionUpdated += OnServiceReconstructionUpdated;
         }
+
+        partial void OnReconstructionSearchTextChanged(string value) => ApplyReconstructionFilter();
 
         private void UpdateMesh() => _mesh = Workspace.GetMesh();
         private void UpdateReconstructionParameters() => ReconstructionParameters = Workspace.GetReconstructionParameters();
@@ -123,6 +136,38 @@ namespace ElectricalImpedanceTomography.ViewModels
             Residual = CalculateResidual(result.ReconstructedConductivityDistribution,
                                          result.OriginalConductivityDistribution);
             ReconstructionUpdated?.Invoke(this, result);
+        }
+
+        public void SaveReconstruction()
+        {
+            var results = Workspace.GetReconstructionResults();
+            if (results.Count == 0 || string.IsNullOrWhiteSpace(Name))
+                return;
+            _reconstructionService.SaveReconstruction(results, Name, ReconstructionParameters);
+            LoadAvailableReconstructions();
+        }
+
+        public void LoadReconstruction(string filePath)
+        {
+            var frames = _reconstructionService.LoadReconstruction(filePath);
+            Workspace.SetReconstructionResults(frames);
+        }
+
+        public void LoadAvailableReconstructions()
+        {
+            AvailableReconstructions.Clear();
+            foreach (var r in _reconstructionService.GetReconstructions())
+                AvailableReconstructions.Add(r);
+            ApplyReconstructionFilter();
+        }
+
+        private void ApplyReconstructionFilter()
+        {
+            FilteredReconstructions.Clear();
+            foreach (var r in AvailableReconstructions.Where(r =>
+                         string.IsNullOrWhiteSpace(ReconstructionSearchText) ||
+                         r.Name.Contains(ReconstructionSearchText, StringComparison.OrdinalIgnoreCase)))
+                FilteredReconstructions.Add(r);
         }
     }
 }

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -4,6 +4,7 @@
              xmlns:viewmodels="clr-namespace:ElectricalImpedanceTomography.ViewModels"
              xmlns:controls="clr-namespace:ElectricalImpedanceTomography.Controls"
              xmlns:skia="clr-namespace:SkiaSharp.Views.Maui.Controls;assembly=SkiaSharp.Views.Maui.Controls"
+             xmlns:models="clr-namespace:Utility.Classes;assembly=Utility"
              x:Class="ElectricalImpedanceTomography.Views.ReconstructionPage"
              Title="ReconstructionPage"
              Shell.NavBarIsVisible="False"
@@ -22,7 +23,7 @@
         <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="1" CurrentPageName="ReconstructionPage"/>
 
         <!-- Main Grid For Page display -->
-        <Grid Grid.Row="1" ColumnDefinitions="Auto, Auto" ColumnSpacing="10">
+        <Grid Grid.Row="1" ColumnDefinitions="Auto, Auto, Auto" ColumnSpacing="10">
             <!-- Left hand Side controls-->
             <Border BackgroundColor="Transparent" Stroke="Gray" Margin="5" Padding="10">
                 <Grid RowDefinitions="Auto, Auto, Auto, Auto" RowSpacing="10">
@@ -84,15 +85,18 @@
                         </Grid>
                     </Border>
 
-                    <Grid Grid.Row="3" ColumnDefinitions="*, *">
-                        <Button Grid.Column="0" Text="Save" Margin="5" BackgroundColor="LightGreen" FontFamily="SF Pro Text" FontAttributes="Bold" Clicked="OnSaveClicked"/>
-                        <Button Grid.Column="1" Text="Load" Margin="5" BackgroundColor="LightBlue" FontFamily="SF Pro Text" FontAttributes="Bold" Clicked="OnLoadClicked"/>
-                    </Grid>
+                    <VerticalStackLayout Grid.Row="3" Spacing="5">
+                        <Entry Text="{Binding Name}" Placeholder="Name"/>
+                        <Grid ColumnDefinitions="*, *">
+                            <Button Grid.Column="0" Text="Save" Margin="5" BackgroundColor="LightGreen" FontFamily="SF Pro Text" FontAttributes="Bold" Clicked="OnSaveClicked"/>
+                            <Button Grid.Column="1" Text="Load" Margin="5" BackgroundColor="LightBlue" FontFamily="SF Pro Text" FontAttributes="Bold" Clicked="OnLoadClicked"/>
+                        </Grid>
+                    </VerticalStackLayout>
                     
                 </Grid>
             </Border>
                 
-        <!-- Right hand Side -->
+        <!-- Center Content -->
             <Grid Grid.Column="1" RowDefinitions="Auto, Auto" HorizontalOptions="Center">
 
                 <!-- Control Panel to control reconstruction -->
@@ -296,6 +300,32 @@
                     </Border>
                 </Grid>
             </Grid>
+            <Border Grid.Column="2" StrokeShape="RoundRectangle 5" Margin="5" WidthRequest="250">
+                <VerticalStackLayout Margin="2" Spacing="10">
+                    <Label Text="Past Reconstructions" HorizontalOptions="Center"/>
+                    <SearchBar Placeholder="Search" Text="{Binding ReconstructionSearchText}" Margin="5"/>
+                    <Border StrokeShape="RoundRectangle 10">
+                        <ScrollView>
+                            <VerticalStackLayout Spacing="2" BindableLayout.ItemsSource="{Binding FilteredReconstructions}">
+                                <BindableLayout.ItemTemplate>
+                                    <DataTemplate x:DataType="models:ReconstructionInfo">
+                                        <Border StrokeShape="RoundRectangle 5" Padding="4" Stroke="Transparent">
+                                            <Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto, Auto, Auto" ColumnSpacing="5">
+                                                <Label Grid.Column="0" Grid.Row="0" Text="{Binding Name}" FontAttributes="Bold" FontSize="Small"/>
+                                                <Label Grid.Column="0" Grid.Row="1" Text="{Binding Metadata.CreatedOn, StringFormat='Saved: {0:G}'}" FontSize="10"/>
+                                                <Label Grid.Column="0" Grid.Row="2" Text="{Binding ParameterSummary}" FontSize="10"/>
+                                            </Grid>
+                                            <Border.GestureRecognizers>
+                                                <TapGestureRecognizer Tapped="OnReconstructionSelected"/>
+                                            </Border.GestureRecognizers>
+                                        </Border>
+                                    </DataTemplate>
+                                </BindableLayout.ItemTemplate>
+                            </VerticalStackLayout>
+                        </ScrollView>
+                    </Border>
+                </VerticalStackLayout>
+            </Border>
         </Grid>
     </Grid>
 </ContentPage>

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -8,6 +8,7 @@ using Utility.Classes.Measurement;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Workspace = Utility.Classes.Application.Workspace;
+using System.Linq;
 
 namespace ElectricalImpedanceTomography.Views;
 
@@ -54,6 +55,12 @@ public partial class ReconstructionPage : ContentPage
         StepButton.IsEnabled = false;
         PlayButton.IsVisible = true;
         PauseButton.IsVisible = false;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        _viewModel.LoadAvailableReconstructions();
     }
 
     private IMesh? GetMesh()
@@ -676,12 +683,31 @@ public partial class ReconstructionPage : ContentPage
 
     private void OnSaveClicked(object sender, EventArgs e)
     {
-
+        _viewModel.SaveReconstruction();
     }
 
     private void OnLoadClicked(object sender, EventArgs e)
     {
+        _viewModel.LoadAvailableReconstructions();
+    }
 
+    private void OnReconstructionSelected(object sender, TappedEventArgs e)
+    {
+        if (sender is Border border && border.BindingContext is ReconstructionInfo info)
+        {
+            _viewModel.LoadReconstruction(info.FilePath);
+            var results = Workspace.GetReconstructionResults();
+            _currentResult = results.LastOrDefault();
+            PlaybackSlider.Maximum = results.Count > 0 ? results.Count - 1 : 0;
+            PlaybackSlider.Value = PlaybackSlider.Maximum;
+            if (_currentResult != null)
+            {
+                _viewModel.IterationCount = results.Count;
+                _viewModel.Residual = CalculateResidual(_currentResult.ReconstructedConductivityDistribution,
+                                                       _currentResult.OriginalConductivityDistribution);
+            }
+            Dispatcher.Dispatch(InvalidateAll);
+        }
     }
 
     private void OnPlaybackSliderValueChanged(object sender, ValueChangedEventArgs e)

--- a/ServiceLayer/IReconstructionService.cs
+++ b/ServiceLayer/IReconstructionService.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Meshing.FiniteElementMesh;
@@ -10,28 +11,26 @@ namespace ServiceLayer
 {
     public interface IReconstructionService
     {
-        public void InitializeReconstruction(IMesh mesh, EITReconstructionParameters parameters);
+        void InitializeReconstruction(IMesh mesh, EITReconstructionParameters parameters);
 
         // --- Background reconstruction control ---
-        public event EventHandler<ReconstructionResult> ReconstructionUpdated;
-        public void StartBackgroundReconstruction(int maxIterationCount, double stepSize, double regularizationWeight, double excitationAmplitude);
-        public void PauseBackgroundReconstruction();
-        public void ResumeBackgroundReconstruction();
-        public void StopBackgroundReconstruction();
-        public Task<ReconstructionResult?> StepReconstructionAsync();
+        event EventHandler<ReconstructionResult> ReconstructionUpdated;
+        void StartBackgroundReconstruction(int maxIterationCount, double stepSize, double regularizationWeight, double excitationAmplitude);
+        void PauseBackgroundReconstruction();
+        void ResumeBackgroundReconstruction();
+        void StopBackgroundReconstruction();
+        Task<ReconstructionResult?> StepReconstructionAsync();
 
         // --- LBM Reconstruction ---
-
-        public PotentialDistribution SolveLbmForward();
-        public ReconstructionResult SolveLbmInverse(int maxIterationCount);
-        public EITMeasurement SimulateLbmMeasurements(LBMMesh mesh, double excitaionAmplitude);
+        PotentialDistribution SolveLbmForward();
+        ReconstructionResult SolveLbmInverse(int maxIterationCount);
+        EITMeasurement SimulateLbmMeasurements(LBMMesh mesh, double excitaionAmplitude);
 
         // --- FEM Reconstruction
-
-        public FEMMesh SolveFemForward(FEMMesh mesh);
-        public FEMMesh SolveFemInverse(FEMMesh mesh, int maxIterCount, double stepSize, double regularization);
-        public ReconstructionResult InverseSolveStepFem(FEMMesh mesh, double[] measurement, BoundaryCondition boundaryCondition, double stepSize);
-        public List<double[]> SimulateFemMeasurements(FEMMesh mesh, double excitationAmplitude);
+        FEMMesh SolveFemForward(FEMMesh mesh);
+        FEMMesh SolveFemInverse(FEMMesh mesh, int maxIterCount, double stepSize, double regularization);
+        ReconstructionResult InverseSolveStepFem(FEMMesh mesh, double[] measurement, BoundaryCondition boundaryCondition, double stepSize);
+        List<double[]> SimulateFemMeasurements(FEMMesh mesh, double excitationAmplitude);
 
         // --- Graph-based Reconstruction ---
         /// <summary>
@@ -41,7 +40,7 @@ namespace ServiceLayer
         /// </summary>
         /// <param name="mesh">Mesh to be solved.</param>
         /// <returns>Mesh with updated potentials.</returns>
-        public FEMMesh SolveGraphForward(FEMMesh mesh);
+        FEMMesh SolveGraphForward(FEMMesh mesh);
 
         /// <summary>
         ///     Performs a single graph-based inverse iteration driven by the
@@ -52,6 +51,11 @@ namespace ServiceLayer
         /// <param name="boundaryCondition">Applied current pattern.</param>
         /// <param name="stepSize">Gradient-descent step size.</param>
         /// <returns>Reconstruction result after updating the mesh.</returns>
-        public ReconstructionResult InverseSolveStepGraph(FEMMesh mesh, double[] measurement, BoundaryCondition boundaryCondition, double stepSize);
+        ReconstructionResult InverseSolveStepGraph(FEMMesh mesh, double[] measurement, BoundaryCondition boundaryCondition, double stepSize);
+
+        // --- Persistence ---
+        void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters);
+        IEnumerable<ReconstructionInfo> GetReconstructions();
+        List<ReconstructionResult> LoadReconstruction(string filePath);
     }
 }

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -315,5 +315,53 @@ namespace ServiceLayer
                 throw;
             }
         }
+
+        // --- Persistence ---
+        public void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters)
+        {
+            try
+            {
+                _reconstructionPersistence.SaveReconstruction(frames, name, parameters);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Console.WriteLine(ex.Message);
+                Debug.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        public IEnumerable<ReconstructionInfo> GetReconstructions()
+        {
+            try
+            {
+                return _reconstructionPersistence.GetReconstructions();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Console.WriteLine(ex.Message);
+                Debug.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        public List<ReconstructionResult> LoadReconstruction(string filePath)
+        {
+            try
+            {
+                var frames = _reconstructionPersistence.LoadReconstruction(filePath);
+                Workspace.SetReconstructionResults(frames);
+                return frames;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Console.WriteLine(ex.Message);
+                Debug.WriteLine(ex.Message);
+                throw;
+            }
+        }
     }
 }

--- a/Utility/Classes/ReconstructionInfo.cs
+++ b/Utility/Classes/ReconstructionInfo.cs
@@ -1,0 +1,9 @@
+using System.Linq;
+
+namespace Utility.Classes
+{
+    public record ReconstructionInfo(string Name, string FilePath, ReconstructionMetadata Metadata)
+    {
+        public string ParameterSummary => string.Join(", ", Metadata.Parameters.Select(p => $"{p.Key}={p.Value}"));
+    }
+}

--- a/Utility/Classes/ReconstructionMetadata.cs
+++ b/Utility/Classes/ReconstructionMetadata.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace Utility.Classes
+{
+    public class ReconstructionMetadata
+    {
+        public DateTime CreatedOn { get; set; } = DateTime.UtcNow;
+        public Dictionary<string, string> Parameters { get; set; } = [];
+        public int FrameCount { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- implement data layer to save and load reconstruction frames with metadata
- expose persistence APIs through business/service layers and view model
- add right-side 'Past Reconstructions' panel with search to reconstruction page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fcd70fe083339cd6f09a1f9c2597