### PR TITLE
Add SharpHook-based keyboard shortcuts across pages

### DIFF
--- a/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
+++ b/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
@@ -59,14 +59,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Maui" Version="9.0.0" />
-		<PackageReference Include="CommunityToolkit.Maui.Core" Version="9.0.0" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-		<PackageReference Include="OxyPlot.Maui.Skia" Version="1.1.0" />
-		<PackageReference Include="SkiaSharp" Version="3.119.0" />
-	</ItemGroup>
+                <PackageReference Include="CommunityToolkit.Maui" Version="9.0.0" />
+                <PackageReference Include="CommunityToolkit.Maui.Core" Version="9.0.0" />
+                <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+                <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
+                <PackageReference Include="OxyPlot.Maui.Skia" Version="1.1.0" />
+                <PackageReference Include="SkiaSharp" Version="3.119.0" />
+                <PackageReference Include="SharpHook.Reactive" Version="5.0.0" />
+        </ItemGroup>
 
         <ItemGroup>
           <ProjectReference Include="..\ServiceLayer\ServiceLayer.csproj" />

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
@@ -7,6 +7,11 @@ using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using System.Linq;
 using System.Collections.Specialized;
 using Microsoft.Maui.ApplicationModel;
+using SharpHook;
+using SharpHook.Native;
+using SharpHook.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Disposables;
 
 namespace ElectricalImpedanceTomography.Views
 {
@@ -25,6 +30,9 @@ namespace ElectricalImpedanceTomography.Views
         private readonly SKPaint _electrodeFill = new() { Style = SKPaintStyle.Fill, Color = SKColors.Yellow };
 
         private float _scale, _marginX, _marginY, _minX, _minY, _meshWidth, _meshHeight;
+
+        private SimpleReactiveGlobalHook? _hook;
+        private CompositeDisposable? _hookSubscriptions;
 
         public MainPage()
         {
@@ -45,6 +53,27 @@ namespace ElectricalImpedanceTomography.Views
             if (ConsoleScroll != null && ConsoleStack != null)
                 MainThread.BeginInvokeOnMainThread(async () =>
                     await ConsoleScroll.ScrollToAsync(0, ConsoleStack.Height, false));
+
+            _hook = new SimpleReactiveGlobalHook();
+            _hookSubscriptions = new CompositeDisposable
+            {
+                _hook.KeyPressed
+                    .Where(e => e.Data.KeyCode == KeyCode.VcEnter)
+                    .Subscribe(_ =>
+                    {
+                        if (!string.IsNullOrWhiteSpace(_viewModel.ConsoleInput))
+                            MainThread.BeginInvokeOnMainThread(() =>
+                                _viewModel.SendConsoleMessageCommand.Execute(null));
+                    })
+            };
+            _ = _hook.RunAsync();
+        }
+
+        protected override void OnDisappearing()
+        {
+            base.OnDisappearing();
+            _hookSubscriptions?.Dispose();
+            _hook?.Dispose();
         }
 
         private void OnLoadMeasurementClicked(object sender, EventArgs e)

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -5,6 +5,12 @@ using System.Linq;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Utility.Classes.Meshing;
+using Microsoft.Maui.ApplicationModel;
+using SharpHook;
+using SharpHook.Native;
+using SharpHook.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Disposables;
 
 namespace ElectricalImpedanceTomography.Views;
 
@@ -39,6 +45,9 @@ public partial class MeshingPage : ContentPage
     private LBMElement? _draggedLbmElectrode;
     private FEMVertex? _draggedFemVertex;
 
+    private SimpleReactiveGlobalHook? _hook;
+    private CompositeDisposable? _hookSubscriptions;
+
     public MeshingPage()
     {
         InitializeComponent();
@@ -51,8 +60,38 @@ public partial class MeshingPage : ContentPage
     {
         base.OnAppearing();
         _viewModel.LoadAvailableMeshes();
-        _viewModel.GenerateMesh();
-        _viewModel.InvokeMeshChanged();
+       _viewModel.GenerateMesh();
+       _viewModel.InvokeMeshChanged();
+
+        _hook = new SimpleReactiveGlobalHook();
+        _hookSubscriptions = new CompositeDisposable
+        {
+            _hook.KeyPressed
+                .Where(e => e.Data.Mask.HasFlag(ModifierMask.Control) && e.Data.KeyCode == KeyCode.VcZ)
+                .Subscribe(_ => MainThread.BeginInvokeOnMainThread(() =>
+                {
+                    _viewModel.Undo();
+                    MeshCanvas.InvalidateSurface();
+                })),
+            _hook.KeyPressed
+                .Where(e => e.Data.Mask.HasFlag(ModifierMask.Control) && e.Data.KeyCode == KeyCode.VcY)
+                .Subscribe(_ => MainThread.BeginInvokeOnMainThread(() =>
+                {
+                    _viewModel.Redo();
+                    MeshCanvas.InvalidateSurface();
+                })),
+            _hook.KeyPressed
+                .Where(e => e.Data.Mask.HasFlag(ModifierMask.Control) && e.Data.KeyCode == KeyCode.VcS)
+                .Subscribe(_ => MainThread.BeginInvokeOnMainThread(() => OnSaveClicked(this, EventArgs.Empty)))
+        };
+        _ = _hook.RunAsync();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        _hookSubscriptions?.Dispose();
+        _hook?.Dispose();
     }
 
     private SKColor ColorForValue(double val, double min, double max)

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -9,6 +9,12 @@ using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Workspace = Utility.Classes.Application.Workspace;
 using System.Linq;
+using Microsoft.Maui.ApplicationModel;
+using SharpHook;
+using SharpHook.Native;
+using SharpHook.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Disposables;
 
 namespace ElectricalImpedanceTomography.Views;
 
@@ -34,6 +40,9 @@ public partial class ReconstructionPage : ContentPage
     private bool _isPaused = false;
     private bool _hasStarted = false;
     private bool _sliderChanging = false;
+
+    private SimpleReactiveGlobalHook? _hook;
+    private CompositeDisposable? _hookSubscriptions;
 
     public ReconstructionPage()
     {
@@ -61,6 +70,34 @@ public partial class ReconstructionPage : ContentPage
     {
         base.OnAppearing();
         _viewModel.LoadAvailableReconstructions();
+
+        _hook = new SimpleReactiveGlobalHook();
+        _hookSubscriptions = new CompositeDisposable
+        {
+            _hook.KeyPressed
+                .Where(e => e.Data.KeyCode == KeyCode.VcSpace)
+                .Subscribe(_ => MainThread.BeginInvokeOnMainThread(() =>
+                {
+                    if (PlayButton.IsVisible)
+                        OnPlayButtonClicked(PlayButton, EventArgs.Empty);
+                    else
+                        OnPauseButtonClicked(PauseButton, EventArgs.Empty);
+                })),
+            _hook.KeyPressed
+                .Where(e => e.Data.KeyCode == KeyCode.VcRight)
+                .Subscribe(_ => MainThread.BeginInvokeOnMainThread(() => OnStepButtonClicked(StepButton, EventArgs.Empty))),
+            _hook.KeyPressed
+                .Where(e => e.Data.KeyCode == KeyCode.VcEscape)
+                .Subscribe(_ => MainThread.BeginInvokeOnMainThread(() => OnStopButtonClicked(PlayButton, EventArgs.Empty)))
+        };
+        _ = _hook.RunAsync();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        _hookSubscriptions?.Dispose();
+        _hook?.Dispose();
     }
 
     private IMesh? GetMesh()


### PR DESCRIPTION
## Summary
- add SharpHook.Reactive dependency for global key handling
- map Enter to send console commands on the main page
- wire Ctrl+Z/Ctrl+Y/Ctrl+S to undo/redo/save on the meshing page
- hook Space/Right/Escape to play-step-stop reconstruction

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b60dc0c0fc833398dafebe3fcec940