### PR TITLE
Add keyboard accelerators across UI pages

### DIFF
--- a/ElectricalImpedanceTomography/Views/MainPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml
@@ -178,9 +178,10 @@
                             </VerticalStackLayout>
                         </ScrollView>
                         <Grid Grid.Row="2" ColumnDefinitions="*,Auto" ColumnSpacing="5" Margin="5">
-                            <Entry Grid.Column="0" 
-                                   Text="{Binding ConsoleInput}"                                    
-                                   FontFamily="Consolas"/>
+                            <Entry Grid.Column="0"
+                                   Text="{Binding ConsoleInput}"
+                                   FontFamily="Consolas"
+                                   Completed="OnConsoleEntryCompleted"/>
                             <ImageButton Grid.Column="1"                                         
                                          HeightRequest="20"
                                          Source="icon_next_blue.png"

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
@@ -164,6 +164,12 @@ namespace ElectricalImpedanceTomography.Views
 
         }
 
+        private void OnConsoleEntryCompleted(object sender, EventArgs e)
+        {
+            if (!string.IsNullOrWhiteSpace(_viewModel.ConsoleInput))
+                _viewModel.SendConsoleMessageCommand.Execute(null);
+        }
+
         private void OnDebugLogChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             if (ConsoleScroll == null || ConsoleStack == null)

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -8,6 +8,11 @@
              xmlns:models="clr-namespace:Utility.Classes.Meshing;assembly=Utility"
              Title="MeshingPage"
              x:DataType="viewmodels:MeshingPageViewModel">
+    <ContentPage.KeyboardAccelerators>
+        <KeyboardAccelerator Key="Z" Modifiers="Ctrl" Invoked="OnUndoAcceleratorInvoked" />
+        <KeyboardAccelerator Key="Y" Modifiers="Ctrl" Invoked="OnRedoAcceleratorInvoked" />
+        <KeyboardAccelerator Key="S" Modifiers="Ctrl" Invoked="OnSaveAcceleratorInvoked" />
+    </ContentPage.KeyboardAccelerators>
     <ContentPage.Resources>
         <Style TargetType="Label">
             <Setter Property="FontFamily" Value="SF Pro Text"/>

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -212,6 +212,28 @@ public partial class MeshingPage : ContentPage
         MeshCanvas.InvalidateSurface();
     }
 
+    private void OnUndoAcceleratorInvoked(object sender, KeyboardAcceleratorInvokedEventArgs e)
+    {
+        _viewModel.Undo();
+        MeshCanvas.InvalidateSurface();
+    }
+
+    private void OnRedoAcceleratorInvoked(object sender, KeyboardAcceleratorInvokedEventArgs e)
+    {
+        _viewModel.Redo();
+        MeshCanvas.InvalidateSurface();
+    }
+
+    private async void OnSaveAcceleratorInvoked(object sender, KeyboardAcceleratorInvokedEventArgs e)
+    {
+        var name = await DisplayPromptAsync("Save Mesh", "Name", initialValue: _viewModel.Name);
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            _viewModel.Name = name;
+            _viewModel.SaveMesh();
+        }
+    }
+
     private void DrawFEMPreview(SKCanvas canvas)
     {
         if (_outlinePoints.Count < 2)

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -9,6 +9,11 @@
              Title="ReconstructionPage"
              Shell.NavBarIsVisible="False"
              x:DataType="viewmodels:ReconstructionPageViewModel">
+    <ContentPage.KeyboardAccelerators>
+        <KeyboardAccelerator Key="Space" Invoked="OnPlayPauseAcceleratorInvoked" />
+        <KeyboardAccelerator Key="Right" Invoked="OnStepAcceleratorInvoked" />
+        <KeyboardAccelerator Key="Escape" Invoked="OnStopAcceleratorInvoked" />
+    </ContentPage.KeyboardAccelerators>
     <ContentPage.Resources>
         <Style TargetType="Border">
             <Setter Property="BackgroundColor" Value="#1A1A1A"/>
@@ -132,7 +137,12 @@
                                          IsEnabled="False"/>
                         </Border>
                         <Border Grid.Column="2" HeightRequest="50" WidthRequest="50" Margin="5">
-                            <ImageButton Padding="3" Background="Transparent" HeightRequest="30" Source="icon_stop_red.png" Clicked="OnStopButtonClicked"/>    
+                            <ImageButton x:Name="StopButton"
+                                         Padding="3"
+                                         Background="Transparent"
+                                         HeightRequest="30"
+                                         Source="icon_stop_red.png"
+                                         Clicked="OnStopButtonClicked"/>
                         </Border>
                     
                         <Label Grid.Column="3" HorizontalOptions="Center" VerticalOptions="Center" FontFamily="SF Pro Text" Text="{Binding IterationCount, StringFormat='Iteration: {0}'}"/>

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -146,6 +146,25 @@ public partial class ReconstructionPage : ContentPage
     }
     #endregion
 
+    private void OnPlayPauseAcceleratorInvoked(object sender, KeyboardAcceleratorInvokedEventArgs e)
+    {
+        if (PlayButton.IsVisible)
+            OnPlayButtonClicked(PlayButton, EventArgs.Empty);
+        else
+            OnPauseButtonClicked(PauseButton, EventArgs.Empty);
+    }
+
+    private void OnStepAcceleratorInvoked(object sender, KeyboardAcceleratorInvokedEventArgs e)
+    {
+        if (StepButton.IsEnabled)
+            OnStepButtonClicked(StepButton, EventArgs.Empty);
+    }
+
+    private void OnStopAcceleratorInvoked(object sender, KeyboardAcceleratorInvokedEventArgs e)
+    {
+        OnStopButtonClicked(StopButton, EventArgs.Empty);
+    }
+
     private void OnReconstructionUpdated(object? sender, ReconstructionResult result)
     {
         _currentResult = result;


### PR DESCRIPTION
## Summary
- Send console commands with Enter key on main page
- Map Ctrl+Z/Y/S to undo, redo, and save on meshing page
- Use Space, Right Arrow, and Escape for play/pause, step, and stop on reconstruction page

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6151a22988333b906d395c50f8f4d