### PR TITLE
Refactor custom perimeter mesh generation

### DIFF
--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -4,6 +4,7 @@ using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Utility.Classes.Factories;
+using System.Linq;
 
 namespace DataAccessLayer
 {
@@ -394,22 +395,26 @@ namespace DataAccessLayer
                     md.Parameters.TryGetValue("width", out var wStr);
                     md.Parameters.TryGetValue("height", out var hStr);
                     md.Parameters.TryGetValue("electrodeCount", out var elStr);
+                    md.Parameters.TryGetValue("layers", out var layersStr);
                     double width = double.Parse(wStr ?? "1");
                     double height = double.Parse(hStr ?? "1");
                     int electrodes = int.Parse(elStr ?? "16");
-                    return MeshFactory.CreateRectangularFEMMesh(width, height, electrodes);
+                    int layers = int.Parse(layersStr ?? "1");
+                    return MeshFactory.CreateRectangularFEMMesh(width, height, electrodes, layers);
                 }
                 string polygon = nameof(MeshFactory.CreatePolygonFEMMesh);
                 if (md.Generator == polygon || md.Generator == nameof(MeshFactory.CreateThoraxFEMMesh))
                 {
                     md.Parameters.TryGetValue("perimeter", out var pStr);
                     md.Parameters.TryGetValue("electrodeCount", out var elStr);
+                    md.Parameters.TryGetValue("layers", out var layersStr);
                     var points = (pStr ?? string.Empty).Split(';', StringSplitOptions.RemoveEmptyEntries)
                                     .Select(s => s.Split(','))
                                     .Select(parts => (double.Parse(parts[0]), double.Parse(parts[1])))
                                     .ToList();
                     int electrodes = int.Parse(elStr ?? "16");
-                    var mesh = MeshFactory.CreatePolygonFEMMesh(points, electrodes);
+                    int layers = int.Parse(layersStr ?? "1");
+                    var mesh = MeshFactory.CreatePolygonFEMMesh(points, layers, electrodes);
                     if (md.Generator == nameof(MeshFactory.CreateThoraxFEMMesh))
                         mesh.Metadata.Generator = nameof(MeshFactory.CreateThoraxFEMMesh);
                     return mesh;

--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -78,7 +78,6 @@ namespace ElectricalImpedanceTomography.ViewModels
         private readonly Stack<IMesh> _undoStack = new();
         private readonly Stack<IMesh> _redoStack = new();
         private IList<(double x, double y)>? _drawnPerimeter;
-        private IList<(double x, double y)>? _drawnElectrodes;
 
         public event Action? MeshChanged;
 
@@ -89,13 +88,10 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public IMesh? GetCurrentMesh() => _currentMesh;
 
-        public void SetCustomPolygon(IList<(double x, double y)> perimeter, IList<(double x, double y)> electrodes)
+        public void SetCustomPolygon(IList<(double x, double y)> perimeter)
         {
             _drawnPerimeter = perimeter;
-            _drawnElectrodes = electrodes;
             SelectedGeometry = GeometryType.Custom;
-            if (electrodes.Count > 0)
-                ElectrodeCount = electrodes.Count;
         }
 
         public void SaveMesh()
@@ -186,51 +182,17 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             if (_drawnPerimeter != null && _drawnPerimeter.Count > 2)
             {
-                var mesh = MeshFactory.CreatePolygonFEMMesh(_drawnPerimeter, _drawnElectrodes?.Count ?? ElectrodeCount);
-                if (_drawnElectrodes != null && _drawnElectrodes.Count > 0)
-                    AssignElectrodes(mesh, _drawnElectrodes);
+                var mesh = MeshFactory.CreatePolygonFEMMesh(_drawnPerimeter, Layers, ElectrodeCount);
                 _drawnPerimeter = null;
-                _drawnElectrodes = null;
                 return mesh;
             }
 
             return SelectedGeometry switch
             {
                 GeometryType.Circular => MeshFactory.CreateCircularFEMMesh(Layers, BoundaryFEMVertexCount, ElectrodeCount),
-                GeometryType.Rectangular => MeshFactory.CreateRectangularFEMMesh(Nx, Ny, ElectrodeCount),
+                GeometryType.Rectangular => MeshFactory.CreateRectangularFEMMesh(Nx, Ny, ElectrodeCount, Layers),
                 _ => MeshFactory.CreateCircularFEMMesh(Layers, BoundaryFEMVertexCount, ElectrodeCount)
             };
-        }
-
-        private void AssignElectrodes(FEMMesh mesh, IList<(double x, double y)> positions)
-        {
-            var boundary = mesh.Vertices.Where(v => v.IsBoundary).ToList();
-            var electrodes = new List<FEMElectrode>();
-            for (int i = 0; i < positions.Count && i < boundary.Count; i++)
-            {
-                var pos = positions[i];
-                int nearest = 0;
-                double best = double.MaxValue;
-                for (int j = 0; j < boundary.Count; j++)
-                {
-                    var v = boundary[j];
-                    double dx = v.X - pos.x;
-                    double dy = v.Y - pos.y;
-                    double d = dx * dx + dy * dy;
-                    if (d < best)
-                    {
-                        best = d;
-                        nearest = j;
-                    }
-                }
-                var vert = boundary[nearest];
-                vert.IsElectrode = true;
-                vert.ElectrodeId = i;
-                var el = new FEMElectrode(i, vert.GlobalId, 0.0, ElectrodeContactImpedance, 0.0);
-                el.FEMVertexIds.Add(vert.GlobalId);
-                electrodes.Add(el);
-            }
-            mesh.SetElectrodes(electrodes);
         }
 
         private LBMMesh GenerateLBMMesh()
@@ -239,7 +201,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             {
                 var mesh = MeshFactory.CreateLBMMeshFromPerimeter(Nx, Ny, _drawnPerimeter, ElectrodeCount);
                 _drawnPerimeter = null;
-                _drawnElectrodes = null;
                 return mesh;
             }
             return SelectedGeometry switch

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -33,7 +33,6 @@ public partial class MeshingPage : ContentPage
 
     // drawing state for custom FEM meshes
     private readonly List<SKPoint> _outlinePoints = new();
-    private readonly List<SKPoint> _electrodePoints = new();
     private readonly HashSet<int> _selectedCells = new();
     private bool _isDrawing;
     private bool _outlineClosed;
@@ -51,7 +50,6 @@ public partial class MeshingPage : ContentPage
         {
             _selectedCells.Clear();
             _outlinePoints.Clear();
-            _electrodePoints.Clear();
             _outlineClosed = false;
             MeshCanvas.InvalidateSurface();
         };
@@ -180,7 +178,6 @@ public partial class MeshingPage : ContentPage
         {
             if (sender is VisualElement v) await ShrinkViewAsync(v);
             _outlinePoints.Clear();
-            _electrodePoints.Clear();
             _selectedCells.Clear();
             _outlineClosed = false;
             _isDrawing = false;
@@ -237,9 +234,6 @@ public partial class MeshingPage : ContentPage
 
             foreach (var p in _outlinePoints)
                 canvas.DrawCircle(p, 3f, _pointFill);
-
-            foreach (var p in _electrodePoints)
-                canvas.DrawCircle(p, 4f, _electrodeFill);
         }
 
     private async void OnAddNoiseTapped(object sender, TappedEventArgs e)
@@ -423,7 +417,6 @@ public partial class MeshingPage : ContentPage
             if (!_isDrawing)
             {
                 _outlinePoints.Clear();
-                _electrodePoints.Clear();
                 _outlineClosed = false;
                 _isDrawing = true;
                 _outlinePoints.Add(e.Location);
@@ -442,10 +435,6 @@ public partial class MeshingPage : ContentPage
                     _outlinePoints.Add(e.Location);
                 }
             }
-        }
-        else if (e.MouseButton == SKMouseButton.Right && _outlineClosed)
-        {
-            _electrodePoints.Add(e.Location);
         }
         MeshCanvas.InvalidateSurface();
         e.Handled = true;
@@ -572,16 +561,14 @@ public partial class MeshingPage : ContentPage
                     (double)Math.Round(p.X / w * _viewModel.Nx),
                     (double)Math.Round(p.Y / h * _viewModel.Ny)
                 )).ToList();
-                _viewModel.SetCustomPolygon(perimeter, new List<(double, double)>());
+                _viewModel.SetCustomPolygon(perimeter);
             }
             else
             {
                 var perimeter = outline.Select(p => ((double)p.X, (double)p.Y)).ToList();
-                var electrodes = _electrodePoints.Select(p => ((double)p.X, (double)p.Y)).ToList();
-                _viewModel.SetCustomPolygon(perimeter, electrodes);
+                _viewModel.SetCustomPolygon(perimeter);
             }
             _outlinePoints.Clear();
-            _electrodePoints.Clear();
             _outlineClosed = false;
         }
         _viewModel.GenerateMesh();

--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -4,6 +4,7 @@ using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Utility.Classes.Application;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Utility.Classes.Factories
 {
@@ -240,10 +241,12 @@ namespace Utility.Classes.Factories
 
         /// <summary>
         /// Create a FEM mesh based on an ordered list of perimeter points forming a single loop.
-        /// The algorithm connects every consecutive boundary point with the centroid, producing
-        /// a fan triangulation.  Electrodes are placed on equally spaced boundary vertices.
+        /// The algorithm creates concentric scaled copies of the perimeter, distributes vertices
+        /// across the layers and performs a Delaunay triangulation. Electrodes are placed on
+        /// equally spaced boundary vertices. If electrodeCount exceeds the number of boundary
+        /// vertices it is clamped accordingly.
         /// </summary>
-        public static FEMMesh CreatePolygonFEMMesh(IList<(double x, double y)> perimeter, int electrodeCount = 16)
+        public static FEMMesh CreatePolygonFEMMesh(IList<(double x, double y)> perimeter, int layers, int electrodeCount = 16)
         {
             ValidatePerimeter(perimeter);
 
@@ -255,35 +258,55 @@ namespace Utility.Classes.Factories
             var center = new FEMVertex(vid++, cx, cy);
             vertices.Add(center);
 
-            for (int i = 0; i < perimeter.Count; i++)
+            for (int layer = 1; layer <= layers; layer++)
             {
-                var p = perimeter[i];
-                vertices.Add(new FEMVertex(vid++, p.x, p.y)
+                double t = (double)layer / layers;
+                for (int i = 0; i < perimeter.Count; i++)
                 {
-                    IsBoundary = true,
-                    BoundaryId = i
-                });
+                    var p = perimeter[i];
+                    double nx = cx + (p.x - cx) * t;
+                    double ny = cy + (p.y - cy) * t;
+                    vertices.Add(new FEMVertex(vid++, nx, ny)
+                    {
+                        IsBoundary = (layer == layers),
+                        BoundaryId = (layer == layers ? i : -1)
+                    });
+                }
             }
+
+            var triVerts = vertices.Select(v => new TriFEMVertex(v)).ToArray();
+            var delaunay = DelaunayTriangulation<TriFEMVertex, DefaultTriangulationCell<TriFEMVertex>>.Create(triVerts, 1e-3);
 
             var elements = new List<FEMElement>();
             int eid = 0;
-            for (int i = 0; i < perimeter.Count; i++)
+            foreach (var cell in delaunay.Cells)
             {
-                var v2 = vertices[i + 1];
-                var v3 = vertices[i + 2 > perimeter.Count ? 1 : i + 2];
-                elements.Add(new FEMElement(eid++, center, v2, v3));
+                var a = cell.Vertices[0].Original;
+                var b = cell.Vertices[1].Original;
+                var c = cell.Vertices[2].Original;
+
+                double mx = (a.X + b.X + c.X) / 3.0;
+                double my = (a.Y + b.Y + c.Y) / 3.0;
+                if (!IsPointInPolygon(mx, my, perimeter))
+                    continue;
+
+                elements.Add(new FEMElement(eid++, a, b, c));
             }
 
             var mesh = new FEMMesh(vertices, elements);
 
-            var boundaryVerts = vertices.Skip(1).ToList();
+            var boundaryVerts = vertices.Where(v => v.IsBoundary).OrderBy(v => v.BoundaryId).ToList();
             electrodeCount = Math.Min(electrodeCount, boundaryVerts.Count);
-            int step = Math.Max(boundaryVerts.Count / electrodeCount, 1);
+            double step = boundaryVerts.Count / (double)electrodeCount;
+            double pos = 0.0;
 
             var electrodes = new List<FEMElectrode>();
             for (int e = 0; e < electrodeCount; e++)
             {
-                var v = boundaryVerts[e * step];
+                int idx = (int)Math.Round(pos, MidpointRounding.AwayFromZero);
+                if (idx >= boundaryVerts.Count)
+                    idx = boundaryVerts.Count - 1;
+                var v = boundaryVerts[idx];
                 v.IsElectrode = true;
                 v.ElectrodeId = e;
 
@@ -295,6 +318,8 @@ namespace Utility.Classes.Factories
                     voltage: 1.0);
                 el.FEMVertexIds.Add(v.GlobalId);
                 electrodes.Add(el);
+
+                pos += step;
             }
 
             mesh.SetElectrodes(electrodes);
@@ -333,6 +358,7 @@ namespace Utility.Classes.Factories
             mesh.Metadata.Generator = nameof(CreatePolygonFEMMesh);
             mesh.Metadata.Parameters["electrodeCount"] = electrodeCount.ToString();
             mesh.Metadata.Parameters["perimeter"] = string.Join(";", perimeter.Select(p => $"{p.x},{p.y}"));
+            mesh.Metadata.Parameters["layers"] = layers.ToString();
 
             return mesh;
         }
@@ -340,7 +366,7 @@ namespace Utility.Classes.Factories
         /// <summary>
         /// Convenience wrapper that builds a rectangular FEM mesh from corner points.
         /// </summary>
-        public static FEMMesh CreateRectangularFEMMesh(double width, double height, int electrodeCount = 16)
+        public static FEMMesh CreateRectangularFEMMesh(double width, double height, int electrodeCount = 16, int layers = 1)
         {
             var hw = width / 2.0;
             var hh = height / 2.0;
@@ -351,23 +377,25 @@ namespace Utility.Classes.Factories
                 ( hw,  hh),
                 (-hw,  hh)
             };
-            var mesh = CreatePolygonFEMMesh(pts, electrodeCount);
+            var mesh = CreatePolygonFEMMesh(pts, layers, electrodeCount);
             mesh.Metadata.Generator = nameof(CreateRectangularFEMMesh);
             mesh.Metadata.Parameters["width"] = width.ToString();
             mesh.Metadata.Parameters["height"] = height.ToString();
             mesh.Metadata.Parameters["electrodeCount"] = electrodeCount.ToString();
+            mesh.Metadata.Parameters["layers"] = layers.ToString();
             return mesh;
         }
 
         /// <summary>
         /// Create a FEM mesh from an arbitrary thorax-shaped perimeter.
         /// </summary>
-        public static FEMMesh CreateThoraxFEMMesh(IList<(double x, double y)> perimeter, int electrodeCount = 16)
+        public static FEMMesh CreateThoraxFEMMesh(IList<(double x, double y)> perimeter, int electrodeCount = 16, int layers = 1)
         {
-            var mesh = CreatePolygonFEMMesh(perimeter, electrodeCount);
+            var mesh = CreatePolygonFEMMesh(perimeter, layers, electrodeCount);
             mesh.Metadata.Generator = nameof(CreateThoraxFEMMesh);
             mesh.Metadata.Parameters["electrodeCount"] = electrodeCount.ToString();
             mesh.Metadata.Parameters["perimeter"] = string.Join(";", perimeter.Select(p => $"{p.x},{p.y}"));
+            mesh.Metadata.Parameters["layers"] = layers.ToString();
             return mesh;
         }
 


### PR DESCRIPTION
## Summary
- Remove manual electrode placement in mesh drawing and rely on electrode count
- Build FEM meshes from custom perimeters using layered geometry and Delaunay triangulation
- Persist layer information in mesh metadata and repository loading

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b8391a3e588333832ada8a9d5b291e