### PR TITLE
Live electrode updates and conductivity color map

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -306,7 +306,28 @@ namespace ElectricalImpedanceTomography.ViewModels
         partial void OnLayersChanged(int value) => AutoGenerateMesh();
 
         partial void OnBoundaryFEMVertexCountChanged(int value) => AutoGenerateMesh();
-        partial void OnElectrodeCountChanged(int value) => AutoGenerateMesh();
+        partial void OnElectrodeCountChanged(int value)
+        {
+            if (_currentMesh == null)
+            {
+                AutoGenerateMesh();
+                return;
+            }
+
+            if (_currentMesh is LBMMesh lbm)
+            {
+                lbm.PlaceEquidistantElectrodes(value);
+                RefreshLbmElectrodes();
+            }
+            else if (_currentMesh is FEMMesh fem)
+            {
+                fem.PlaceEquidistantElectrodes(value, ElectrodeContactImpedance, ElectrodeSize);
+            }
+
+            _currentMesh.Metadata.Parameters["electrodeCount"] = value.ToString();
+            Workspace.SetMesh(_currentMesh);
+            MeshChanged?.Invoke();
+        }
 
         partial void OnMeshSearchTextChanged(string value) => ApplyMeshFilter();
 

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -63,23 +63,15 @@ public partial class MeshingPage : ContentPage
         _viewModel.InvokeMeshChanged();
     }
 
-    private SKColor ColorForValue(double val, double min, double max)
+    private SKColor ColorForValue(double val, double max)
     {
-        double mid = (min + max) * 0.5;
-        if (val >= mid)
-        {
-            float t = (float)((val - mid) / (max - mid));
-            t = Math.Clamp(t, 0f, 1f);
-            byte r = (byte)(255 * t);
-            return new SKColor(r, 0, 0);
-        }
-        else
-        {
-            float t = (float)((mid - val) / (mid - min));
-            t = Math.Clamp(t, 0f, 1f);
-            byte b = (byte)(255 * t);
-            return new SKColor(0, 0, b);
-        }
+        if (max <= 1)
+            max = 1;
+        double t = (val - 1) / (max - 1);
+        t = Math.Clamp(t, 0.0, 1.0);
+        byte r = (byte)(255 * t);
+        byte b = (byte)(255 * (1 - t));
+        return new SKColor(r, 0, b);
     }
 
     private static async Task ShrinkViewAsync(VisualElement element)
@@ -154,8 +146,7 @@ public partial class MeshingPage : ContentPage
         _marginY = pad + (availH - usedH) / 2f;
 
         var elements = mesh.ElementsTyped;
-        double min = elements.Min(el => el.Conductivity);
-        double max = elements.Max(el => el.Conductivity);
+        double max = Math.Max(1.0, elements.Max(el => el.Conductivity));
 
         using var path = new SKPath();
         foreach (var el in elements)
@@ -165,7 +156,7 @@ public partial class MeshingPage : ContentPage
             var p3 = ToCanvas(el.Vertices[2]);
             path.Reset();
             path.MoveTo(p1); path.LineTo(p2); path.LineTo(p3); path.Close();
-            _femFill.Color = ColorForValue(el.Conductivity, min, max);
+            _femFill.Color = ColorForValue(el.Conductivity, max);
             canvas.DrawPath(path, _femFill);
             canvas.DrawPath(path, _femStroke);
         }

--- a/Utility/Classes/Meshing/FiniteElementMesh/FEMMesh.cs
+++ b/Utility/Classes/Meshing/FiniteElementMesh/FEMMesh.cs
@@ -82,6 +82,48 @@ namespace Utility.Classes.Meshing.FiniteElementMesh
             return vv.Potential;
         }
 
+        public void PlaceEquidistantElectrodes(int numElectrodes, double zContact, double length)
+        {
+            foreach (var v in Vertices)
+            {
+                v.IsElectrode = false;
+                v.ElectrodeId = -1;
+            }
+
+            _electrodes.Clear();
+
+            if (numElectrodes <= 0)
+                return;
+
+            var boundary = Vertices.Where(v => v.IsBoundary).ToList();
+            if (boundary.Count == 0)
+                return;
+
+            double cx = boundary.Average(v => v.X);
+            double cy = boundary.Average(v => v.Y);
+
+            boundary = boundary
+                .OrderBy(v => Math.Atan2(v.Y - cy, v.X - cx))
+                .ToList();
+
+            int count = boundary.Count;
+            numElectrodes = Math.Min(numElectrodes, count);
+            double step = count / (double)numElectrodes;
+            double pos = 0.0;
+            for (int i = 0; i < numElectrodes; i++)
+            {
+                int idx = (int)Math.Floor(pos) % count;
+                var v = boundary[idx];
+                v.IsElectrode = true;
+                v.ElectrodeId = i;
+                var el = new FEMElectrode(i, v.GlobalId, 0.0, zContact, 0.0);
+                el.Length = length;
+                el.FEMVertexIds.Add(v.GlobalId);
+                _electrodes.Add(el);
+                pos += step;
+            }
+        }
+
 
         /// <summary>
         /// Creates a deep copy of this FEMMesh, including vertices, elements,


### PR DESCRIPTION
## Summary
- Enable live electrode redistribution when the electrode count changes for both FEM and LBM meshes.
- Add FEM helper to place equidistant electrodes and update view model to reuse existing meshes.
- Color FEM elements using a blue-to-red gradient based on conductivity.

## Testing
- ⚠️ `dotnet test` *(command not found)*
- ⚠️ `apt-get update` *(403 Forbidden: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b83ccaee8883339d3cecbe23d82405