### PR TITLE
Enhance reconstruction visualization with partial and full results

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -37,6 +37,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         public ObservableCollection<ReconstructionInfo> FilteredReconstructions { get; } = [];
 
         public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
+        public event EventHandler<ReconstructionFrame>? ReconstructionFrameUpdated;
 
         public ReconstructionPageViewModel(IReconstructionService reconstructionService)
         {
@@ -46,6 +47,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             ReconstructionParameters = Workspace.GetReconstructionParameters();
 
             _reconstructionService.ReconstructionUpdated += OnServiceReconstructionUpdated;
+            _reconstructionService.ReconstructionFrameUpdated += OnServiceFrameUpdated;
         }
 
         partial void OnReconstructionSearchTextChanged(string value) => ApplyReconstructionFilter();
@@ -124,7 +126,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public void StopReconstruction() => _reconstructionService.StopBackgroundReconstruction();
 
-        public Task<ReconstructionResult?> StepReconstructionAsync()
+        public Task<ReconstructionFrame?> StepReconstructionAsync()
         {
             InitializeReconstruction();
             return _reconstructionService.StepReconstructionAsync();
@@ -138,6 +140,9 @@ namespace ElectricalImpedanceTomography.ViewModels
             ReconstructionUpdated?.Invoke(this, result);
         }
 
+        private void OnServiceFrameUpdated(object? sender, ReconstructionFrame frame)
+            => ReconstructionFrameUpdated?.Invoke(this, frame);
+
         public void SaveReconstruction()
         {
             var results = Workspace.GetReconstructionResults();
@@ -149,8 +154,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public void LoadReconstruction(string filePath)
         {
-            var frames = _reconstructionService.LoadReconstruction(filePath);
-            Workspace.SetReconstructionResults(frames);
+            _reconstructionService.LoadReconstruction(filePath);
         }
 
         public void LoadAvailableReconstructions()

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -200,135 +200,74 @@
                 </Border>
 
                 <!-- Displays for reconstruction steps -->
-                <Grid Grid.Row="1" Margin="3" RowDefinitions="Auto, Auto, Auto, Auto" ColumnDefinitions="Auto, Auto" HorizontalOptions="Center" VerticalOptions="Center">
+                <Grid Grid.Row="1" Margin="3" RowDefinitions="Auto, Auto" ColumnDefinitions="Auto" HorizontalOptions="Center" VerticalOptions="Center">
+                    <!-- Partial results -->
+                    <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,Auto" HorizontalOptions="Center">
+                        <!-- Calculated Potential -->
+                        <VerticalStackLayout Grid.Column="0" HorizontalOptions="Center">
+                            <Label Text="Calculated Potential Distribution" HorizontalOptions="Center" FontFamily="SF Pro Text"/>
+                            <Border Stroke="DarkGray" StrokeThickness="2" Margin="10" HorizontalOptions="Center">
+                                <Grid RowDefinitions="Auto,Auto">
+                                    <skia:SKCanvasView x:Name="PotentialDistributionCanvas" PaintSurface="OnPotentialCanvasPaintSurface" EnableTouchEvents="True" Touch="OnPotentialCanvasTouch" HeightRequest="350" WidthRequest="350" Margin="10"/>
+                                    <skia:SKCanvasView Grid.Row="1" x:Name="PotentialColorbarCanvas" PaintSurface="OnPotentialColorbarPaintSurface" HeightRequest="40" WidthRequest="350"/>
+                                </Grid>
+                            </Border>
+                        </VerticalStackLayout>
+                        <!-- Adjoint Potential -->
+                        <VerticalStackLayout Grid.Column="1" HorizontalOptions="Center">
+                            <Label Text="Adjoint Potential Distribution" HorizontalOptions="Center" FontFamily="SF Pro Text"/>
+                            <Border Stroke="DarkGray" StrokeThickness="2" Margin="10" HorizontalOptions="Center">
+                                <Grid RowDefinitions="Auto,Auto">
+                                    <skia:SKCanvasView x:Name="AdjointDistributionCanvas" PaintSurface="OnAdjointCanvasPaintSurface" EnableTouchEvents="True" Touch="OnAdjointCanvasTouch" HeightRequest="350" WidthRequest="350" Margin="10"/>
+                                    <skia:SKCanvasView Grid.Row="1" x:Name="AdjointColorbarCanvas" PaintSurface="OnAdjointColorbarPaintSurface" HeightRequest="40" WidthRequest="350"/>
+                                </Grid>
+                            </Border>
+                        </VerticalStackLayout>
+                        <!-- Gradient -->
+                        <VerticalStackLayout Grid.Column="2" HorizontalOptions="Center">
+                            <Label Text="Conductivity Gradient" HorizontalOptions="Center" FontFamily="SF Pro Text"/>
+                            <Border Stroke="DarkGray" StrokeThickness="2" Margin="10" HorizontalOptions="Center">
+                                <Grid RowDefinitions="Auto,Auto">
+                                    <skia:SKCanvasView x:Name="GradientDistributionCanvas" PaintSurface="OnGradientCanvasPaintSurface" HeightRequest="350" WidthRequest="350" Margin="10"/>
+                                    <skia:SKCanvasView Grid.Row="1" x:Name="GradientColorbarCanvas" PaintSurface="OnGradientColorbarPaintSurface" HeightRequest="40" WidthRequest="350"/>
+                                </Grid>
+                            </Border>
+                        </VerticalStackLayout>
+                    </Grid>
 
-                    <!-- Original DIstribution Canvas -->
-                    <Label Grid.Row="0" 
-                           Grid.Column="0"
-                           Text="Original Distribution" 
-                           HorizontalOptions="Center" 
-                           VerticalOptions="Start"
-                           FontFamily="SF Pro Text"/>
-                    <Border Grid.Row="1"
-                            Grid.Column="0"
-                            Stroke="DarkGray"
-                            StrokeThickness="2"
-                            Margin="10"
-                            HorizontalOptions="Center"
-                            VerticalOptions="Center">
-                        <Grid ColumnDefinitions="Auto,40">
-                            <skia:SKCanvasView x:Name="OriginalDistributionCanvas"
-                                               PaintSurface="OnOriginalCanvasPaintSurface"
-                                               EnableTouchEvents="True"
-                                               Touch="OnOriginalCanvasTouch"
-                                               HeightRequest="350"
-                                               WidthRequest="350"
-                                               Margin="10" />
-                            <skia:SKCanvasView Grid.Column="1"
-                                               x:Name="OriginalColorbarCanvas"
-                                               PaintSurface="OnOriginalColorbarPaintSurface"
-                                               EnableTouchEvents="True"
-                                               Touch="OnOriginalCanvasTouch"
-                                               WidthRequest="40"
-                                               HeightRequest="350" />
-                        </Grid>
-                    </Border>
-
-                    <!-- Calculated Potential Canvas -->
-                    <Label Grid.Row="0" 
-                           Grid.Column="1"
-                           Text="Calculated Potential" 
-                           HorizontalOptions="Center" 
-                           VerticalOptions="Start"
-                           FontFamily="SF Pro Text"/>
-                    <Border Grid.Row="1"
-                            Grid.Column="1"
-                            Stroke="DarkGray"
-                            StrokeThickness="2"
-                            Margin="10"
-                            HorizontalOptions="Center"
-                            VerticalOptions="Center">
-                        <Grid ColumnDefinitions="Auto,40">
-                            <skia:SKCanvasView x:Name="PotentialDistributionCanvas"
-                                               PaintSurface="OnPotentialCanvasPaintSurface"
-                                               EnableTouchEvents="True"
-                                               Touch="OnPotentialCanvasTouch"
-                                               HeightRequest="350"
-                                               WidthRequest="350"
-                                               Margin="10" />
-                            <skia:SKCanvasView Grid.Column="1"
-                                               x:Name="PotentialColorbarCanvas"
-                                               PaintSurface="OnPotentialColorbarPaintSurface"
-                                               EnableTouchEvents="True"
-                                               Touch="OnPotentialCanvasTouch"
-                                               WidthRequest="40"
-                                               HeightRequest="350" />
-                        </Grid>
-                    </Border>
-
-                    <!-- Reconstruced Canvas -->
-                    <Label Grid.Row="2" 
-                           Grid.Column="0"
-                           Text="Reconstructed Distribution" 
-                           HorizontalOptions="Center" 
-                           VerticalOptions="Start"
-                           FontFamily="SF Pro Text"/>
-                    <Border Grid.Row="3"
-                            Grid.Column="0"
-                            Stroke="DarkGray"
-                            StrokeThickness="2"
-                            Margin="10"
-                            HorizontalOptions="Center"
-                            VerticalOptions="Center">
-                        <Grid ColumnDefinitions="Auto,40">
-                            <skia:SKCanvasView x:Name="ReconstructedDistributionCanvas"
-                                                PaintSurface="OnReconstructedCanvasPaintSurface"
-                                                EnableTouchEvents="True"
-                                                Touch="OnReconstructedCanvasTouch"
-                                                HeightRequest="350"
-                                                WidthRequest="350"
-                                                Margin="10" />
-                            <skia:SKCanvasView Grid.Column="1"
-                                               x:Name="ReconstructedColorbarCanvas"
-                                               PaintSurface="OnReconstructedColorbarPaintSurface"
-                                               EnableTouchEvents="True"
-                                               Touch="OnReconstructedCanvasTouch"
-                                               WidthRequest="40"
-                                               HeightRequest="350" />
-                        </Grid>
-                    </Border>
-
-                    <!-- Reconstruced Canvas -->
-                    <Label Grid.Row="2" 
-                           Grid.Column="1"
-                           Text="Adjoint Potential Distribution" 
-                           HorizontalOptions="Center" 
-                           VerticalOptions="Start"
-                           FontFamily="SF Pro Text"/>
-                    <Border Grid.Row="3"
-                            Grid.Column="1"
-                            Stroke="DarkGray"
-                            StrokeThickness="2"
-                            Margin="10"
-                            HorizontalOptions="Center"
-                            VerticalOptions="Center">
-                        <Grid ColumnDefinitions="Auto,40">
-                            <skia:SKCanvasView x:Name="AdjointDistributionCanvas"
-                                                PaintSurface="OnAdjointCanvasPaintSurface"
-                                                EnableTouchEvents="True"
-                                                Touch="OnAdjointCanvasTouch"
-                                                HeightRequest="350"
-                                                WidthRequest="350"
-                                                Margin="10" />
-                            <skia:SKCanvasView Grid.Column="1"
-                                               x:Name="AdjointColorbarCanvas"
-                                               PaintSurface="OnAdjointColorbarPaintSurface"
-                                               EnableTouchEvents="True"
-                                               Touch="OnAdjointCanvasTouch"
-                                               WidthRequest="40"
-                                               HeightRequest="350" />
-                        </Grid>
-                    </Border>
+                    <!-- Full results -->
+                    <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,Auto" HorizontalOptions="Center">
+                        <!-- Original -->
+                        <VerticalStackLayout Grid.Column="0" HorizontalOptions="Center">
+                            <Label Text="Original Conductivity Distribution" HorizontalOptions="Center" FontFamily="SF Pro Text"/>
+                            <Border Stroke="DarkGray" StrokeThickness="2" Margin="10" HorizontalOptions="Center">
+                                <Grid RowDefinitions="Auto,Auto">
+                                    <skia:SKCanvasView x:Name="OriginalDistributionCanvas" PaintSurface="OnOriginalCanvasPaintSurface" EnableTouchEvents="True" Touch="OnOriginalCanvasTouch" HeightRequest="350" WidthRequest="350" Margin="10"/>
+                                    <skia:SKCanvasView Grid.Row="1" x:Name="OriginalColorbarCanvas" PaintSurface="OnOriginalColorbarPaintSurface" HeightRequest="40" WidthRequest="350"/>
+                                </Grid>
+                            </Border>
+                        </VerticalStackLayout>
+                        <!-- Initial -->
+                        <VerticalStackLayout Grid.Column="1" HorizontalOptions="Center">
+                            <Label Text="Initial Conductivity Distribution" HorizontalOptions="Center" FontFamily="SF Pro Text"/>
+                            <Border Stroke="DarkGray" StrokeThickness="2" Margin="10" HorizontalOptions="Center">
+                                <Grid RowDefinitions="Auto,Auto">
+                                    <skia:SKCanvasView x:Name="InitialDistributionCanvas" PaintSurface="OnInitialCanvasPaintSurface" HeightRequest="350" WidthRequest="350" Margin="10"/>
+                                    <skia:SKCanvasView Grid.Row="1" x:Name="InitialColorbarCanvas" PaintSurface="OnInitialColorbarPaintSurface" HeightRequest="40" WidthRequest="350"/>
+                                </Grid>
+                            </Border>
+                        </VerticalStackLayout>
+                        <!-- Reconstructed -->
+                        <VerticalStackLayout Grid.Column="2" HorizontalOptions="Center">
+                            <Label Text="Reconstructed Conductivity Distribution" HorizontalOptions="Center" FontFamily="SF Pro Text"/>
+                            <Border Stroke="DarkGray" StrokeThickness="2" Margin="10" HorizontalOptions="Center">
+                                <Grid RowDefinitions="Auto,Auto">
+                                    <skia:SKCanvasView x:Name="ReconstructedDistributionCanvas" PaintSurface="OnReconstructedCanvasPaintSurface" EnableTouchEvents="True" Touch="OnReconstructedCanvasTouch" HeightRequest="350" WidthRequest="350" Margin="10"/>
+                                    <skia:SKCanvasView Grid.Row="1" x:Name="ReconstructedColorbarCanvas" PaintSurface="OnReconstructedColorbarPaintSurface" HeightRequest="40" WidthRequest="350"/>
+                                </Grid>
+                            </Border>
+                        </VerticalStackLayout>
+                    </Grid>
                 </Grid>
             </Grid>
             <Border Grid.Column="2" StrokeShape="RoundRectangle 5" Margin="5" WidthRequest="250" HorizontalOptions="End">

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -18,6 +18,7 @@ public partial class ReconstructionPage : ContentPage
     public event EventHandler<int>? PotentialModeChanged;
 
     private ReconstructionResult? _currentResult;
+    private ReconstructionFrame? _currentFrame;
 
     // FEM transform helpers
     private float _scale, _marginX, _marginY, _meshWidth, _meshHeight, _minX, _minY, _canvasHeight;
@@ -27,6 +28,8 @@ public partial class ReconstructionPage : ContentPage
     private string[]? _hoverPotentialLines; private SKPoint? _hoverPotentialPt;
     private string[]? _hoverReconstructedLines; private SKPoint? _hoverReconstructedPt;
     private string[]? _hoverAdjointLines; private SKPoint? _hoverAdjointPt;
+    private string[]? _hoverInitialLines; private SKPoint? _hoverInitialPt;
+    private string[]? _hoverGradientLines; private SKPoint? _hoverGradientPt;
 
     private enum PotentialDisplayMode { Default, Grayscale, Inverted, Heatmap, Rainbow }
     private PotentialDisplayMode _potMode = PotentialDisplayMode.Default;
@@ -51,6 +54,7 @@ public partial class ReconstructionPage : ContentPage
         PotentialModeChanged += OnPotentialModeChanged;
 
         _viewModel.ReconstructionUpdated += OnReconstructionUpdated;
+        _viewModel.ReconstructionFrameUpdated += OnReconstructionFrameUpdated;
 
         StepButton.IsEnabled = false;
         PlayButton.IsVisible = true;
@@ -150,15 +154,38 @@ public partial class ReconstructionPage : ContentPage
     private void OnReconstructionUpdated(object? sender, ReconstructionResult result)
     {
         _currentResult = result;
+        _currentFrame = result.Frames.LastOrDefault();
         _sliderChanging = true;
-        var results = Workspace.GetReconstructionResults();
-        if (results.Count > 0)
+        var frames = Workspace.GetReconstructionFrames();
+        if (frames.Count > 0)
         {
-            PlaybackSlider.Maximum = results.Count - 1;
+            PlaybackSlider.Maximum = frames.Count - 1;
             PlaybackSlider.Value = PlaybackSlider.Maximum;
         }
         _sliderChanging = false;
         Dispatcher.Dispatch(InvalidateAll);
+    }
+
+    private void OnReconstructionFrameUpdated(object? sender, ReconstructionFrame frame)
+    {
+        _currentFrame = frame;
+        _sliderChanging = true;
+        var frames = Workspace.GetReconstructionFrames();
+        if (frames.Count > 0)
+        {
+            PlaybackSlider.Maximum = frames.Count - 1;
+            PlaybackSlider.Value = PlaybackSlider.Maximum;
+        }
+        _sliderChanging = false;
+        Dispatcher.Dispatch(() =>
+        {
+            PotentialDistributionCanvas.InvalidateSurface();
+            AdjointDistributionCanvas.InvalidateSurface();
+            GradientDistributionCanvas.InvalidateSurface();
+            PotentialColorbarCanvas.InvalidateSurface();
+            AdjointColorbarCanvas.InvalidateSurface();
+            GradientColorbarCanvas.InvalidateSurface();
+        });
     }
 
     #region Drawing helpers
@@ -336,7 +363,7 @@ public partial class ReconstructionPage : ContentPage
     private void DrawColorBar(SKCanvas canvas, SKImageInfo info, double min, double max, bool isPotential)
     {
         canvas.Clear(SKColor.Parse("#1E1E1E"));
-        var rect = new SKRect(0, 0, info.Width, info.Height - 20);
+        var rect = new SKRect(0, 0, info.Width, info.Height);
         int steps = 256;
         var colors = new SKColor[steps];
         var positions = new float[steps];
@@ -349,8 +376,8 @@ public partial class ReconstructionPage : ContentPage
         }
         using var paint = new SKPaint
         {
-            Shader = SKShader.CreateLinearGradient(new SKPoint(rect.Left, rect.Top),
-                                                   new SKPoint(rect.Left, rect.Bottom),
+            Shader = SKShader.CreateLinearGradient(new SKPoint(rect.Left, rect.Bottom),
+                                                   new SKPoint(rect.Right, rect.Bottom),
                                                    colors,
                                                    positions,
                                                    SKShaderTileMode.Clamp)
@@ -359,8 +386,9 @@ public partial class ReconstructionPage : ContentPage
         using var border = new SKPaint { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1 };
         canvas.DrawRect(rect, border);
         using var text = new SKPaint { Color = SKColors.White, TextSize = 14, IsAntialias = true };
-        canvas.DrawText(max.ToString("F2"), rect.Left + 2, 14, text);
-        canvas.DrawText(min.ToString("F2"), rect.Left + 2, info.Height - 2, text);
+        canvas.DrawText(min.ToString("F2"), rect.Left, rect.Bottom - 2, text);
+        float w = text.MeasureText(max.ToString("F2"));
+        canvas.DrawText(max.ToString("F2"), rect.Right - w, rect.Bottom - 2, text);
     }
     #endregion
 
@@ -383,9 +411,8 @@ public partial class ReconstructionPage : ContentPage
 
     private void OnPotentialCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
-        _currentResult ??= Workspace.GetReconstructionResults().LastOrDefault();
         var mesh = GetMesh();
-        var pd = _currentResult?.CurrentPotentialDistribution ?? mesh?.GetPotentialDistribution();
+        var pd = _currentFrame?.CalculatedPotentialDistribution ?? mesh?.GetPotentialDistribution();
         if (mesh is FEMMesh fem && pd != null)
             DrawFemPotential(e, fem, pd, _hoverPotentialLines, _hoverPotentialPt);
         else if (mesh is LBMMesh lbm && pd != null)
@@ -394,7 +421,6 @@ public partial class ReconstructionPage : ContentPage
 
     private void OnReconstructedCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
-        _currentResult ??= Workspace.GetReconstructionResults().LastOrDefault();
         var mesh = GetMesh();
         var cd = _currentResult?.ReconstructedConductivityDistribution ?? mesh?.GetConductivityDistribution();
         if (mesh is FEMMesh fem && cd != null)
@@ -405,13 +431,32 @@ public partial class ReconstructionPage : ContentPage
 
     private void OnAdjointCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
-        _currentResult ??= Workspace.GetReconstructionResults().LastOrDefault();
         var mesh = GetMesh();
-        var pd = _currentResult?.CurrentAdjointDistribution ?? mesh?.GetPotentialDistribution();
+        var pd = _currentFrame?.CalculatedAdjointDistribution ?? mesh?.GetPotentialDistribution();
         if (mesh is FEMMesh fem && pd != null)
             DrawFemPotential(e, fem, pd, _hoverAdjointLines, _hoverAdjointPt);
         else if (mesh is LBMMesh lbm && pd != null)
             DrawLbmField(e, lbm, pd.Potentials, true, _hoverAdjointLines, _hoverAdjointPt);
+    }
+
+    private void OnInitialCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    {
+        var mesh = GetMesh();
+        var cd = _currentResult?.InitialConductivitiyDistribution ?? mesh?.GetConductivityDistribution();
+        if (mesh is FEMMesh fem && cd != null)
+            DrawFemConductivity(e, fem, cd, _hoverInitialLines, _hoverInitialPt);
+        else if (mesh is LBMMesh lbm && cd != null)
+            DrawLbmField(e, lbm, cd.Conductivities, false, _hoverInitialLines, _hoverInitialPt);
+    }
+
+    private void OnGradientCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    {
+        var mesh = GetMesh();
+        var cd = _currentFrame?.ConductivityGradient;
+        if (mesh is FEMMesh fem && cd != null)
+            DrawFemConductivity(e, fem, cd, _hoverGradientLines, _hoverGradientPt);
+        else if (mesh is LBMMesh lbm && cd != null)
+            DrawLbmField(e, lbm, cd.Conductivities, false, _hoverGradientLines, _hoverGradientPt);
     }
 
     private void OnOriginalColorbarPaintSurface(object sender, SKPaintSurfaceEventArgs e)
@@ -438,9 +483,8 @@ public partial class ReconstructionPage : ContentPage
 
     private void OnPotentialColorbarPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
-        _currentResult ??= Workspace.GetReconstructionResults().LastOrDefault();
         var mesh = GetMesh();
-        var pd = _currentResult?.CurrentPotentialDistribution ?? mesh?.GetPotentialDistribution();
+        var pd = _currentFrame?.CalculatedPotentialDistribution ?? mesh?.GetPotentialDistribution();
         if (pd != null)
         {
             double min = pd.Potentials.Values.Min();
@@ -452,7 +496,6 @@ public partial class ReconstructionPage : ContentPage
 
     private void OnReconstructedColorbarPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
-        _currentResult ??= Workspace.GetReconstructionResults().LastOrDefault();
         var mesh = GetMesh();
         if (mesh is FEMMesh fem)
         {
@@ -474,15 +517,47 @@ public partial class ReconstructionPage : ContentPage
 
     private void OnAdjointColorbarPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
-        _currentResult ??= Workspace.GetReconstructionResults().LastOrDefault();
         var mesh = GetMesh();
-        var pd = _currentResult?.CurrentAdjointDistribution ?? mesh?.GetPotentialDistribution();
+        var pd = _currentFrame?.CalculatedAdjointDistribution ?? mesh?.GetPotentialDistribution();
         if (pd != null)
         {
             double min = pd.Potentials.Values.Min();
             double max = pd.Potentials.Values.Max();
             if (Math.Abs(max - min) < 1e-12) max = min + 1e-12;
             DrawColorBar(e.Surface.Canvas, e.Info, min, max, true);
+        }
+    }
+
+    private void OnInitialColorbarPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    {
+        var mesh = GetMesh();
+        if (mesh is FEMMesh fem)
+        {
+            var cd = _currentResult?.InitialConductivitiyDistribution ?? fem.GetConductivityDistribution();
+            double min = cd.Conductivities.Values.Min();
+            double max = cd.Conductivities.Values.Max();
+            if (Math.Abs(max - min) < 1e-12) max = min + 1e-12;
+            DrawColorBar(e.Surface.Canvas, e.Info, min, max, false);
+        }
+        else if (mesh is LBMMesh lbm)
+        {
+            var cd = _currentResult?.InitialConductivitiyDistribution ?? lbm.GetConductivityDistribution();
+            double min = cd.Conductivities.Values.Min();
+            double max = cd.Conductivities.Values.Max();
+            if (Math.Abs(max - min) < 1e-12) max = min + 1e-12;
+            DrawColorBar(e.Surface.Canvas, e.Info, min, max, false);
+        }
+    }
+
+    private void OnGradientColorbarPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    {
+        var cd = _currentFrame?.ConductivityGradient;
+        if (cd != null)
+        {
+            double min = cd.Conductivities.Values.Min();
+            double max = cd.Conductivities.Values.Max();
+            if (Math.Abs(max - min) < 1e-12) max = min + 1e-12;
+            DrawColorBar(e.Surface.Canvas, e.Info, min, max, false);
         }
     }
     #endregion
@@ -661,13 +736,17 @@ public partial class ReconstructionPage : ContentPage
     private void InvalidateAll()
     {
         OriginalDistributionCanvas.InvalidateSurface();
-        PotentialDistributionCanvas.InvalidateSurface();
+        InitialDistributionCanvas.InvalidateSurface();
         ReconstructedDistributionCanvas.InvalidateSurface();
+        PotentialDistributionCanvas.InvalidateSurface();
         AdjointDistributionCanvas.InvalidateSurface();
+        GradientDistributionCanvas.InvalidateSurface();
         OriginalColorbarCanvas.InvalidateSurface();
-        PotentialColorbarCanvas.InvalidateSurface();
+        InitialColorbarCanvas.InvalidateSurface();
         ReconstructedColorbarCanvas.InvalidateSurface();
+        PotentialColorbarCanvas.InvalidateSurface();
         AdjointColorbarCanvas.InvalidateSurface();
+        GradientColorbarCanvas.InvalidateSurface();
     }
 
     private static double CalculateResidual(ConductivityDistribution reconstructed, ConductivityDistribution original)
@@ -699,7 +778,9 @@ public partial class ReconstructionPage : ContentPage
             _viewModel.LoadReconstruction(info.FilePath);
             var results = Workspace.GetReconstructionResults();
             _currentResult = results.LastOrDefault();
-            PlaybackSlider.Maximum = results.Count > 0 ? results.Count - 1 : 0;
+            var frames = Workspace.GetReconstructionFrames();
+            _currentFrame = frames.LastOrDefault();
+            PlaybackSlider.Maximum = frames.Count > 0 ? frames.Count - 1 : 0;
             PlaybackSlider.Value = PlaybackSlider.Maximum;
             if (_currentResult != null)
             {
@@ -735,15 +816,32 @@ public partial class ReconstructionPage : ContentPage
         if (_sliderChanging)
             return;
 
-        var results = Workspace.GetReconstructionResults();
+        var frames = Workspace.GetReconstructionFrames();
         int index = (int)Math.Round(e.NewValue);
-        if (index >= 0 && index < results.Count)
+        if (index >= 0 && index < frames.Count)
         {
-            var result = results[index];
-            _currentResult = result;
-            _viewModel.IterationCount = index + 1;
-            _viewModel.Residual = CalculateResidual(result.ReconstructedConductivityDistribution,
-                                                   result.OriginalConductivityDistribution);
+            _currentFrame = frames[index];
+            var results = Workspace.GetReconstructionResults();
+            ReconstructionResult? res = null;
+            int cumulative = 0;
+            int iter = 0;
+            foreach (var r in results)
+            {
+                cumulative += r.Frames.Count;
+                iter++;
+                if (index < cumulative)
+                {
+                    res = r;
+                    break;
+                }
+            }
+            if (res != null)
+            {
+                _currentResult = res;
+                _viewModel.IterationCount = iter;
+                _viewModel.Residual = CalculateResidual(res.ReconstructedConductivityDistribution,
+                                                       res.OriginalConductivityDistribution);
+            }
             Dispatcher.Dispatch(InvalidateAll);
         }
     }

--- a/ServiceLayer/IReconstructionService.cs
+++ b/ServiceLayer/IReconstructionService.cs
@@ -15,11 +15,12 @@ namespace ServiceLayer
 
         // --- Background reconstruction control ---
         event EventHandler<ReconstructionResult> ReconstructionUpdated;
+        event EventHandler<ReconstructionFrame> ReconstructionFrameUpdated;
         void StartBackgroundReconstruction(int maxIterationCount, double stepSize, double regularizationWeight, double excitationAmplitude);
         void PauseBackgroundReconstruction();
         void ResumeBackgroundReconstruction();
         void StopBackgroundReconstruction();
-        Task<ReconstructionResult?> StepReconstructionAsync();
+        Task<ReconstructionFrame?> StepReconstructionAsync();
 
         // --- LBM Reconstruction ---
         PotentialDistribution SolveLbmForward();

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -33,8 +33,13 @@ namespace ServiceLayer
         private double _excitationAmplitude;
         private List<double[]> _simulatedMeasurements = new();
         private int _simMeasurementIndex;
+        private List<ReconstructionFrame> _currentCycleFrames = new();
+        private ConductivityDistribution? _originalSigma;
+        private ConductivityDistribution? _initialSigma;
+        private int _framesPerCycle;
 
         public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
+        public event EventHandler<ReconstructionFrame>? ReconstructionFrameUpdated;
 
         public ReconstructionService(IReconstructionPersistence reconstructionPersistence, ILogger logger)
         {
@@ -102,7 +107,18 @@ namespace ServiceLayer
                 _mesh = mesh;
                 _simulatedMeasurements.Clear();
                 _simMeasurementIndex = 0;
+                _currentCycleFrames.Clear();
+                Workspace.ClearReconstructionFrames();
+                Workspace.SetReconstructionResults(new List<ReconstructionResult>());
                 _reconstructionPersistence.InitializeReconstruction(mesh, parameters);
+                _originalSigma = ((Mesh)mesh.DeepCopy()).GetConductivityDistribution();
+                _initialSigma = mesh.GetConductivityDistribution();
+                if (mesh is FEMMesh fem)
+                    _framesPerCycle = fem.GetElectrodes().Count;
+                else if (mesh is LBMMesh lbm)
+                    _framesPerCycle = lbm.GetElectrodes().Count;
+                else
+                    _framesPerCycle = 1;
             }
             catch(Exception ex)
             {
@@ -181,7 +197,7 @@ namespace ServiceLayer
 
         #region Background reconstruction
 
-        private ReconstructionResult? PerformInverseStep()
+        private ReconstructionFrame? PerformInverseStep()
         {
             if (_mesh is FEMMesh femMesh)
             {
@@ -194,13 +210,29 @@ namespace ServiceLayer
                 var electrodes = femMesh.GetElectrodes().Cast<FEMElectrode>().ToList();
                 var bc = new FEMBoundaryCondition(electrodes);
 
-                var result = InverseSolveStepFem(femMesh, measurement, bc, _stepSize);
+                var frame = _reconstructionPersistence.Step(measurement, bc, _stepSize, _regularizationWeight);
                 _simMeasurementIndex++;
-                return result;
+                Workspace.AddReconstructionFrameToWorkspace(frame);
+                _currentCycleFrames.Add(frame);
+                ReconstructionFrameUpdated?.Invoke(this, frame);
+
+                if (_simMeasurementIndex % _framesPerCycle == 0)
+                {
+                    var result = new ReconstructionResult(_mesh!, _originalSigma!, _initialSigma!, _mesh!.GetConductivityDistribution(), _currentCycleFrames.ToList());
+                    Workspace.AddReconstructionResultToWorkspace(result);
+                    ReconstructionUpdated?.Invoke(this, result);
+                    _currentCycleFrames.Clear();
+                    _currentIteration++;
+                }
+
+                return frame;
             }
             else if (_mesh is LBMMesh)
             {
-                return SolveLbmInverse(1);
+                var result = SolveLbmInverse(1);
+                ReconstructionUpdated?.Invoke(this, result);
+                _currentIteration++;
+                return null;
             }
 
             return null;
@@ -216,13 +248,7 @@ namespace ServiceLayer
                     continue;
                 }
 
-                var result = PerformInverseStep();
-                if (result != null)
-                {
-                    _currentIteration++;
-                    ReconstructionUpdated?.Invoke(this, result);
-                }
-
+                PerformInverseStep();
                 await Task.Yield();
             }
         }
@@ -250,15 +276,10 @@ namespace ServiceLayer
             _isPaused = false;
         }
 
-        public async Task<ReconstructionResult?> StepReconstructionAsync()
+        public async Task<ReconstructionFrame?> StepReconstructionAsync()
         {
-            var result = await Task.Run(PerformInverseStep);
-            if (result != null)
-            {
-                _currentIteration++;
-                ReconstructionUpdated?.Invoke(this, result);
-            }
-            return result;
+            var frame = await Task.Run(PerformInverseStep);
+            return frame;
         }
 
         #endregion
@@ -353,6 +374,7 @@ namespace ServiceLayer
             {
                 var frames = _reconstructionPersistence.LoadReconstruction(filePath);
                 Workspace.SetReconstructionResults(frames);
+                Workspace.SetReconstructionFrames(frames.SelectMany(r => r.Frames).ToList());
                 return frames;
             }
             catch (Exception ex)

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -1,4 +1,6 @@
-﻿using Utility.Classes.ReconstructionParameters;
+﻿using System.Collections.Generic;
+using Utility.Classes;
+using Utility.Classes.ReconstructionParameters;
 
 namespace Utility.Classes.Application
 {
@@ -13,6 +15,7 @@ namespace Utility.Classes.Application
         private static double _regularizationWeight = 1e-3;
 
         private static List<ReconstructionResult> _reconstructionResults = [];
+        private static List<ReconstructionFrame> _reconstructionFrames = [];
         private static List<WorkspaceMessage> _messages = [];
         public static event Action<WorkspaceMessage>? MessageAdded;
 
@@ -39,11 +42,13 @@ namespace Utility.Classes.Application
         public static void SetReconstructionParameters(EITReconstructionParameters eITReconstructionParameters) => _reconstructionParameters = eITReconstructionParameters;
         public static void SetMesh(IMesh? mesh) => _mesh = mesh;
         public static void SetReconstructionResults(List<ReconstructionResult> results) => _reconstructionResults = results;
+        public static void SetReconstructionFrames(List<ReconstructionFrame> frames) => _reconstructionFrames = frames;
 
         public static User GetUser() => _user;
         public static EITReconstructionParameters GetReconstructionParameters() => _reconstructionParameters;
         public static IMesh? GetMesh() => _mesh;
         public static List<ReconstructionResult> GetReconstructionResults() => _reconstructionResults;
+        public static List<ReconstructionFrame> GetReconstructionFrames() => _reconstructionFrames;
 
         public static int MaxIterationCount
         {
@@ -65,6 +70,8 @@ namespace Utility.Classes.Application
 
         public static void AddReconstructionResultToWorkspace(ReconstructionResult reconstructionResult) => _reconstructionResults.Add(reconstructionResult);
         public static void RemoveReconstructionResultFromWorkspace(int index) => _reconstructionResults.RemoveAt(index);
+        public static void AddReconstructionFrameToWorkspace(ReconstructionFrame frame) => _reconstructionFrames.Add(frame);
+        public static void ClearReconstructionFrames() => _reconstructionFrames.Clear();
 
         private static void AddMessage(string message, WorkspaceMessageType type = WorkspaceMessageType.Log)
         {


### PR DESCRIPTION
## Summary
- Store and manage reconstruction frames in `Workspace` for playback and partial result tracking
- Expose frame updates in `ReconstructionService` and view model, updating canvases and slider
- Redesign reconstruction page to show potential, adjoint, gradient, and conductivity distributions with horizontal colorbars and working frame slider

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc693cc5bc8333a99c4d78eb87004a