### PR TITLE
Handle LBM inverse solve and update reconstruction load

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -135,8 +135,8 @@ namespace BusinessLayer
 
         public PotentialDistribution ForwardSolveStepFem()
         {
-            if(_mesh is not LBMMesh mesh)
-                throw new TypeInitializationException("Mesh should be of type LBMMesh to use LBM solver!", new Exception("Invalid type in solver!"));
+            if (_mesh is not FEMMesh mesh)
+                throw new TypeInitializationException("Mesh should be of type FEMMesh to use FEM solver!", new Exception("Invalid type in solver!"));
 
             if (_differentialEquationSolver == null)
                 throw new NullReferenceException("Differential equation solver is null, check calling code!");
@@ -530,7 +530,7 @@ namespace BusinessLayer
                     double[] dObs = simulatedMeasurements[exc];
 
                     // Perform an inverse solve step and extract partial results
-                    var frame = InverseSolveStepFem(mesh, bc, dObs);
+                    var frame = InverseSolveStepFem(mesh, bc, dObs, gradientStepSize);
 
                     // Get the gradient expression from the inverse solve step
                     var dataGrad = frame.ConductivityGradient;
@@ -595,9 +595,22 @@ namespace BusinessLayer
             return new ReconstructionResult(mesh, originalConductivityDistribution, initialConductivityDistribution, reconstructedConductivityDistribution, frames);
         }
 
-        public ReconstructionResult InverseSolveLbm(int maxIterationCount, double gradientStepSize, double redularizationStepSize)
+        public ReconstructionResult InverseSolveLbm(int maxIterationCount,
+                                                    double gradientStepSize,
+                                                    double redularizationStepSize,
+                                                    double excitationAmplitude,
+                                                    double tolerance = 1e-6)
         {
-            throw new NotImplementedException();
+            if (_mesh is not LBMMesh mesh)
+                throw new TypeInitializationException("Mesh should be of type LBMMesh to use LBM solver!", new Exception("Invalid type in solver!"));
+
+            if (_regularizer == null)
+                throw new NullReferenceException("Regularizer is null, check calling code!");
+
+            _gradientStepSize = gradientStepSize;
+            _regularizationWeight = redularizationStepSize;
+
+            return RunLbmReconstruction(mesh, maxIterationCount);
         }
 
         private double CalculateTotalMisiftFem(FEMMesh mesh, List<double[]> simulatedMeasurements, FEMBoundaryCondition bc, double excitationAmplitude)

--- a/DataAccessLayer/ReconstructionRepository.cs
+++ b/DataAccessLayer/ReconstructionRepository.cs
@@ -94,9 +94,10 @@ namespace DataAccessLayer
                     var orig = DeserializeConductivity(frameEl.Element("Original"));
                     var init = DeserializeConductivity(frameEl.Element("Initial"));
                     var recon = DeserializeConductivity(frameEl.Element("Reconstructed"));
-                    frames.Add(new ReconstructionResult(new PotentialDistribution(new Dictionary<int, double>()),
-                                                        new PotentialDistribution(new Dictionary<int, double>()),
-                                                        orig, init, recon));
+                    frames.Add(new ReconstructionResult(orig,
+                                                        init,
+                                                        recon,
+                                                        new List<ReconstructionFrame>()));
                 }
             }
             return frames;

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -623,7 +623,7 @@ public partial class ReconstructionPage : ContentPage
             ComputeFemTransform(fem, new SKImageInfo((int)view.CanvasSize.Width, (int)view.CanvasSize.Height));
             var verts = fem.Vertices;
             var nearest = verts.OrderBy(v => (ToCanvas(v) - e.Location).LengthSquared).First();
-            var pd = (_currentResult?.CurrentPotentialDistribution ?? fem.GetPotentialDistribution());
+            var pd = _currentResult?.GetMesh()?.GetPotentialDistribution() ?? fem.GetPotentialDistribution();
             double val = pd.GetPotential(nearest.GlobalId);
             _hoverPotentialLines = new[] { $"GID: {nearest.GlobalId}", $"Φ: {val:F3}" };
             _hoverPotentialPt = e.Location;
@@ -638,7 +638,7 @@ public partial class ReconstructionPage : ContentPage
             if (e.ActionType == SKTouchAction.Released)
             { _hoverPotentialLines = null; _hoverPotentialPt = null; view.InvalidateSurface(); e.Handled = true; return; }
             var el = lbm.GetElementAt(col, row);
-            var pd = (_currentResult?.CurrentPotentialDistribution ?? lbm.GetPotentialDistribution());
+            var pd = _currentResult?.GetMesh()?.GetPotentialDistribution() ?? lbm.GetPotentialDistribution();
             double val = pd.Potentials[el.Id];
             _hoverPotentialLines = new[] { $"ID: {el.Id}", $"Φ: {val:F3}" };
             _hoverPotentialPt = e.Location;


### PR DESCRIPTION
## Summary
- Deserialize reconstruction frames with correct constructor and empty frame list
- Pass gradient step size in FEM inverse solve and implement LBM inverse solve
- Resolve potential distribution usage in reconstruction page view

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6bf5b8608333a0fe48a00d414071