### PR TITLE
feat: enhance reconstruction controls

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -32,6 +32,7 @@ namespace BusinessLayer
 
         private double _gradientStepSize = 0.001;
         private double _regularizationWeight = 0.001;
+        private InitialDistributionTypes _initialDistributionType = InitialDistributionTypes.SlightlyDiffering;
 
         private bool _initialized = false;
 
@@ -59,7 +60,8 @@ namespace BusinessLayer
             _differentialEquationSolver = DifferentialEquationSolverFactory.Create(mesh, parameters.DifferentialEquationSolver, _numericSolver);
             _regularizer = RegularisationFactory.Create(parameters.RegularizationTechnique, _mesh);
             _errorMetric = ErrorMetricFactory.Create(parameters.ErrorMetric);
-            _numericOptimizer = NumericOptimizerFactory.Create(parameters.NumericOptimizer, ConductivityDistributionFactory.CreateSlightlyDiffering(mesh));
+            _initialDistributionType = parameters.InitialDistributionType;
+            _numericOptimizer = NumericOptimizerFactory.Create(parameters.NumericOptimizer, ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType));
 
             _inverseModel = InverseModelFactory.Create(_mesh, _numericOptimizer, _regularizer, _errorMetric, _differentialEquationSolver);
 
@@ -299,10 +301,8 @@ namespace BusinessLayer
             // Save the original distribution for the ReconstructionResult.
             ConductivityDistribution originalSigma = mesh.DeepCopy().GetConductivityDistribution();
 
-            // Start the reconstruction from a slightly perturbed homogeneous
-            // conductivity distribution.
-            ConductivityDistribution initialSigma = ConductivityDistributionFactory.CreateSlightlyDiffering(mesh, 0.95);
-            mesh.SetConductivityDistribution(initialSigma);
+            // Start the reconstruction from a user-specified initial conductivity distribution.
+            ConductivityDistribution initialSigma = mesh.GetConductivityDistribution();
 
             // Cache electrode and element information for repeated use.
             List<FEMElectrode> electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
@@ -401,8 +401,7 @@ namespace BusinessLayer
             EITMeasurement measurementFrames = SimulateLbmMeasurements(mesh, 1.0);
 
             ConductivityDistribution originalSigma = ((LBMMesh)mesh.DeepCopy()).GetConductivityDistribution();
-            ConductivityDistribution initialSigma = ConductivityDistributionFactory.CreateSlightlyDiffering(mesh, 0.95);
-            mesh.SetConductivityDistribution(initialSigma);
+            ConductivityDistribution initialSigma = mesh.GetConductivityDistribution();
 
             var electrodes = mesh.GetElectrodes().Cast<LBMElectrode>().ToList();
             int electrodeCount = electrodes.Count;
@@ -483,8 +482,8 @@ namespace BusinessLayer
             List<double[]> simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude);
             ConductivityDistribution originalConductivityDistribution = mesh.DeepCopy().GetConductivityDistribution();
 
-            // 2) Initialize conductivity (σ^{(0)}) to homogeneous distribution
-            ConductivityDistribution initialConductivityDistribution = ConductivityDistributionFactory.CreateSlightlyDiffering(mesh, 0.95);
+            // 2) Initialize conductivity (σ^{(0)}) based on user selection
+            ConductivityDistribution initialConductivityDistribution = ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
             mesh.SetConductivityDistribution(initialConductivityDistribution);
 
             List<FEMElectrode> electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
@@ -973,8 +972,8 @@ namespace BusinessLayer
 
             List<double[]> simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude);
             
-            // 2) Initialize conductivity (σ^{(0)}) to homogeneous distribution
-            ConductivityDistribution sigma = ConductivityDistributionFactory.CreateSlightlyDiffering(mesh, 0.95);
+            // 2) Initialize conductivity (σ^{(0)}) based on user selection
+            ConductivityDistribution sigma = ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
             mesh.SetConductivityDistribution(sigma);
 
             List<FEMElectrode> electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
@@ -1235,8 +1234,8 @@ namespace BusinessLayer
             _regularizer = RegularisationFactory.Create(RegularizationTechnique.ZeroOrderTikhonov, mesh.DeepCopy(), 0.0);
             _numericOptimizer = NumericOptimizerFactory.Create(NumericOptimizer.GradientBased, ConductivityDistributionFactory.CreateRandom(mesh));
 
-            // Initialize conductivity (σ^{(0)}) to homogeneous distribution
-            ConductivityDistribution sigma0 = ConductivityDistributionFactory.CreateSlightlyDiffering(mesh, 0.95);
+            // Initialize conductivity (σ^{(0)}) based on user selection
+            ConductivityDistribution sigma0 = ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
             mesh.SetConductivityDistribution(sigma0);
 
             // Create new boundary conditions that will be fed to the Finite Element Solver

--- a/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using Utility.Classes.ReconstructionParameters;
+using Utility.Classes.Factories;
 using Workspace = Utility.Classes.Application.Workspace;
 
 namespace ElectricalImpedanceTomography.ViewModels
@@ -20,6 +21,9 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         private static readonly NumericOptimizer[] NumericOptimizerValues = Enum.GetValues<NumericOptimizer>();
         public IEnumerable<NumericOptimizer> NumericOptimizerOptions => NumericOptimizerValues;
+
+        private static readonly InitialDistributionTypes[] InitialDistributionTypeValues = Enum.GetValues<InitialDistributionTypes>();
+        public IEnumerable<InitialDistributionTypes> InitialDistributionOptions => InitialDistributionTypeValues;
 
         [ObservableProperty]
         private EITReconstructionParameters reconstructionParameters = Workspace.GetReconstructionParameters();

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -80,7 +80,7 @@
                     
                         <!-- Parameter Configuration -->
                         <Border Grid.Column="1" Padding="5" Background="Transparent" Stroke="Gray">
-                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="5">
+                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="5">
                                 <Label Grid.Row="0" Text="Parameter Selection" FontAttributes="Bold" FontSize="Medium" Margin="0, 0, 0, 10"/>
                                 <Label Grid.Row="1" HorizontalOptions="Center" Text="Regularization Weight (θ)" FontFamily="SF Pro Text"/>
                                 <Entry Grid.Row="2" Text="{Binding RegularizationWeight}"/>
@@ -88,6 +88,8 @@
                                 <Entry Grid.Row="4" Text="{Binding StepSize}"/>
                                 <Label Grid.Row="5" HorizontalOptions="Center" Text="Max Iteration Count" FontFamily="SF Pro Text"/>
                                 <Entry Grid.Row="6" Text="{Binding MaxIterationCount}"/>
+                                <Label Grid.Row="7" HorizontalOptions="Center" Text="Initial Distribution" FontFamily="SF Pro Text"/>
+                                <Picker Grid.Row="8" ItemsSource="{Binding InitialDistributionOptions}" SelectedItem="{Binding ReconstructionParameters.InitialDistributionType}"/>
 
                             </Grid>
                         </Border>
@@ -199,6 +201,12 @@
                                 Minimum="0"
                                 Maximum="0"
                                 ValueChanged="OnPlaybackSliderValueChanged" />
+                        <Label x:Name="PlaybackFrameLabel"
+                               Grid.Row="1"
+                               Grid.Column="3"
+                               VerticalOptions="Center"
+                               Text="0 / 0"
+                               FontFamily="SF Pro Text"/>
                     </Grid>
                 </Border>
 
@@ -231,7 +239,7 @@
                             <Label Text="Conductivity Gradient" HorizontalOptions="Center" FontFamily="SF Pro Text"/>
                             <Border Stroke="DarkGray" StrokeThickness="2" Margin="10" HorizontalOptions="Center">
                                 <Grid RowDefinitions="Auto,Auto">
-                                    <skia:SKCanvasView x:Name="GradientDistributionCanvas" PaintSurface="OnGradientCanvasPaintSurface" HeightRequest="275" WidthRequest="275" Margin="10"/>
+                                    <skia:SKCanvasView x:Name="GradientDistributionCanvas" PaintSurface="OnGradientCanvasPaintSurface" EnableTouchEvents="True" Touch="OnGradientCanvasTouch" HeightRequest="275" WidthRequest="275" Margin="10"/>
                                     <skia:SKCanvasView Grid.Row="1" x:Name="GradientColorbarCanvas" PaintSurface="OnGradientColorbarPaintSurface" HeightRequest="20" WidthRequest="275"/>
                                 </Grid>
                             </Border>
@@ -255,7 +263,7 @@
                             <Label Text="Initial Conductivity Distribution" HorizontalOptions="Center" FontFamily="SF Pro Text"/>
                             <Border Stroke="DarkGray" StrokeThickness="2" Margin="10" HorizontalOptions="Center">
                                 <Grid RowDefinitions="Auto,Auto">
-                                    <skia:SKCanvasView x:Name="InitialDistributionCanvas" PaintSurface="OnInitialCanvasPaintSurface" HeightRequest="275" WidthRequest="275" Margin="10"/>
+                                    <skia:SKCanvasView x:Name="InitialDistributionCanvas" PaintSurface="OnInitialCanvasPaintSurface" EnableTouchEvents="True" Touch="OnInitialCanvasTouch" HeightRequest="275" WidthRequest="275" Margin="10"/>
                                     <skia:SKCanvasView Grid.Row="1" x:Name="InitialColorbarCanvas" PaintSurface="OnInitialColorbarPaintSurface" HeightRequest="20" WidthRequest="275"/>
                                 </Grid>
                             </Border>

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -8,6 +8,7 @@ using Utility.Classes.Measurement;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Workspace = Utility.Classes.Application.Workspace;
+using System;
 using System.Linq;
 
 namespace ElectricalImpedanceTomography.Views;
@@ -163,7 +164,7 @@ public partial class ReconstructionPage : ContentPage
             PlaybackSlider.Value = PlaybackSlider.Maximum;
         }
         _sliderChanging = false;
-        Dispatcher.Dispatch(InvalidateAll);
+        Dispatcher.Dispatch(() => { InvalidateAll(); UpdatePlaybackLabel(); });
     }
 
     private void OnReconstructionFrameUpdated(object? sender, ReconstructionFrame frame)
@@ -185,6 +186,7 @@ public partial class ReconstructionPage : ContentPage
             PotentialColorbarCanvas.InvalidateSurface();
             AdjointColorbarCanvas.InvalidateSurface();
             GradientColorbarCanvas.InvalidateSurface();
+            UpdatePlaybackLabel();
         });
     }
 
@@ -723,6 +725,98 @@ public partial class ReconstructionPage : ContentPage
             view.InvalidateSurface(); e.Handled = true;
         }
     }
+
+    private async void OnInitialCanvasTouch(object sender, SKTouchEventArgs e)
+    {
+        if (e.MouseButton == SKMouseButton.Right && e.ActionType == SKTouchAction.Pressed)
+        { await ShowDisplayModeMenu(); e.Handled = true; return; }
+        var mesh = GetMesh(); if (mesh == null) return; var view = (SKCanvasView)sender;
+        if (mesh is FEMMesh fem)
+        {
+            if (e.ActionType == SKTouchAction.Released)
+            { _hoverInitialLines = null; _hoverInitialPt = null; view.InvalidateSurface(); e.Handled = true; return; }
+            ComputeFemTransform(fem, new SKImageInfo((int)view.CanvasSize.Width, (int)view.CanvasSize.Height));
+            _hoverInitialLines = null;
+            var cd = (_currentResult?.InitialConductivitiyDistribution ?? fem.GetConductivityDistribution());
+            foreach (var elem in fem.GetElements().Cast<FEMElement>())
+            {
+                var c0 = ToCanvas(elem.Vertices[0]);
+                var c1 = ToCanvas(elem.Vertices[1]);
+                var c2 = ToCanvas(elem.Vertices[2]);
+                if (PointInTriangle(e.Location, c0, c1, c2, out _, out _, out _))
+                {
+                    double val = cd.GetConductivity(elem.Id);
+                    _hoverInitialLines = new[] { $"Elem: {elem.Id}", $"σ: {val:F3}" };
+                    _hoverInitialPt = e.Location;
+                    break;
+                }
+            }
+            view.InvalidateSurface(); e.Handled = true;
+        }
+        else if (mesh is LBMMesh lbm)
+        {
+            float cw = view.CanvasSize.Width / lbm.Nx; float ch = view.CanvasSize.Height / lbm.Ny;
+            int col = (int)(e.Location.X / cw); int row = (int)(e.Location.Y / ch);
+            col = Math.Clamp(col, 0, lbm.Nx - 1); row = Math.Clamp(row, 0, lbm.Ny - 1);
+            if (e.ActionType == SKTouchAction.Released)
+            { _hoverInitialLines = null; _hoverInitialPt = null; view.InvalidateSurface(); e.Handled = true; return; }
+            var el = lbm.GetElementAt(col, row);
+            var cd = (_currentResult?.InitialConductivitiyDistribution ?? lbm.GetConductivityDistribution());
+            double val = cd.Conductivities[el.Id];
+            _hoverInitialLines = new[] { $"ID: {el.Id}", $"σ: {val:F3}" };
+            _hoverInitialPt = e.Location;
+            view.InvalidateSurface(); e.Handled = true;
+        }
+    }
+
+    private async void OnGradientCanvasTouch(object sender, SKTouchEventArgs e)
+    {
+        if (e.MouseButton == SKMouseButton.Right && e.ActionType == SKTouchAction.Pressed)
+        { await ShowDisplayModeMenu(); e.Handled = true; return; }
+        var mesh = GetMesh(); if (mesh == null) return; var view = (SKCanvasView)sender;
+        if (mesh is FEMMesh fem)
+        {
+            if (e.ActionType == SKTouchAction.Released)
+            { _hoverGradientLines = null; _hoverGradientPt = null; view.InvalidateSurface(); e.Handled = true; return; }
+            ComputeFemTransform(fem, new SKImageInfo((int)view.CanvasSize.Width, (int)view.CanvasSize.Height));
+            _hoverGradientLines = null;
+            var cd = _currentFrame?.ConductivityGradient;
+            if (cd != null)
+            {
+                foreach (var elem in fem.GetElements().Cast<FEMElement>())
+                {
+                    var c0 = ToCanvas(elem.Vertices[0]);
+                    var c1 = ToCanvas(elem.Vertices[1]);
+                    var c2 = ToCanvas(elem.Vertices[2]);
+                    if (PointInTriangle(e.Location, c0, c1, c2, out _, out _, out _))
+                    {
+                        double val = cd.GetConductivity(elem.Id);
+                        _hoverGradientLines = new[] { $"Elem: {elem.Id}", $"∂σ: {val:F3}" };
+                        _hoverGradientPt = e.Location;
+                        break;
+                    }
+                }
+            }
+            view.InvalidateSurface(); e.Handled = true;
+        }
+        else if (mesh is LBMMesh lbm)
+        {
+            float cw = view.CanvasSize.Width / lbm.Nx; float ch = view.CanvasSize.Height / lbm.Ny;
+            int col = (int)(e.Location.X / cw); int row = (int)(e.Location.Y / ch);
+            col = Math.Clamp(col, 0, lbm.Nx - 1); row = Math.Clamp(row, 0, lbm.Ny - 1);
+            if (e.ActionType == SKTouchAction.Released)
+            { _hoverGradientLines = null; _hoverGradientPt = null; view.InvalidateSurface(); e.Handled = true; return; }
+            var el = lbm.GetElementAt(col, row);
+            var cd = _currentFrame?.ConductivityGradient;
+            if (cd != null)
+            {
+                double val = cd.Conductivities[el.Id];
+                _hoverGradientLines = new[] { $"ID: {el.Id}", $"∂σ: {val:F3}" };
+                _hoverGradientPt = e.Location;
+            }
+            view.InvalidateSurface(); e.Handled = true;
+        }
+    }
     #endregion
 
     private async Task ShowDisplayModeMenu()
@@ -788,7 +882,7 @@ public partial class ReconstructionPage : ContentPage
                 _viewModel.Residual = CalculateResidual(_currentResult.ReconstructedConductivityDistribution,
                                                        _currentResult.OriginalConductivityDistribution);
             }
-            Dispatcher.Dispatch(InvalidateAll);
+            Dispatcher.Dispatch(() => { InvalidateAll(); UpdatePlaybackLabel(); });
         }
     }
 
@@ -842,8 +936,15 @@ public partial class ReconstructionPage : ContentPage
                 _viewModel.Residual = CalculateResidual(res.ReconstructedConductivityDistribution,
                                                        res.OriginalConductivityDistribution);
             }
-            Dispatcher.Dispatch(InvalidateAll);
+            Dispatcher.Dispatch(() => { InvalidateAll(); UpdatePlaybackLabel(); });
         }
+    }
+
+    private void UpdatePlaybackLabel()
+    {
+        int total = (int)Math.Round(PlaybackSlider.Maximum) + 1;
+        int current = (int)Math.Round(PlaybackSlider.Value) + 1;
+        PlaybackFrameLabel.Text = $"{current} / {total}";
     }
 
     private async void OnSolveForwardClicked(object sender, EventArgs e)

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -10,6 +10,7 @@ using Utility.Classes.Measurement;
 using Utility.Classes.Meshing.FiniteElementMesh;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Utility.Classes.ReconstructionParameters;
+using Utility.Classes.Factories;
 using Utility.Logger;
 
 using Workspace = Utility.Classes.Application.Workspace;
@@ -121,7 +122,8 @@ namespace ServiceLayer
                 Workspace.SetReconstructionResults(new List<ReconstructionResult>());
                 _reconstructionPersistence.InitializeReconstruction(mesh, parameters);
                 _originalSigma = ((Mesh)mesh.DeepCopy()).GetConductivityDistribution();
-                _initialSigma = mesh.GetConductivityDistribution();
+                _initialSigma = ConductivityDistributionFactory.CreateInitialDistribution(mesh, parameters.InitialDistributionType);
+                mesh.SetConductivityDistribution(_initialSigma);
                 if (mesh is FEMMesh fem)
                     _framesPerCycle = fem.GetElectrodes().Count;
                 else if (mesh is LBMMesh lbm)

--- a/Utility/Classes/Factories/ConductivityDistributionFactory.cs
+++ b/Utility/Classes/Factories/ConductivityDistributionFactory.cs
@@ -1,5 +1,7 @@
 ﻿using Utility.Classes.Meshing.FiniteElementMesh;
+using System;
 using Workspace = Utility.Classes.Application.Workspace;
+using Utility.Classes;
 
 namespace Utility.Classes.Factories
 {
@@ -126,6 +128,19 @@ namespace Utility.Classes.Factories
             Workspace.AddLogMessage("ConductivityDistributionFactory", "Created from FEMMesh ConductivityDistribution object.");
 
             return new ConductivityDistribution(conductivityDistribution);
+        }
+
+        public static ConductivityDistribution CreateInitialDistribution(IMesh mesh, InitialDistributionTypes type)
+        {
+            return type switch
+            {
+                InitialDistributionTypes.Homogeneous => CreateHomogeneous(mesh),
+                InitialDistributionTypes.Random => CreateRandom(mesh),
+                InitialDistributionTypes.SlightlyDiffering => CreateSlightlyDiffering(mesh, 0.95),
+                InitialDistributionTypes.RandomSlightlyDiffering =>
+                    CreateRandomSlightlyDiffering(mesh, Math.Max(1, mesh.GetElements().Count / 10), 0.95),
+                _ => CreateHomogeneous(mesh)
+            };
         }
     }
 }

--- a/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
+++ b/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using Utility.Classes.Meshing;
+using Utility.Classes.Factories;
 
 namespace Utility.Classes.ReconstructionParameters
 {
@@ -13,8 +14,11 @@ namespace Utility.Classes.ReconstructionParameters
         private ErrorMetric errorMetric = ErrorMetric.L2;
         [ObservableProperty]
         private NumericSolver numericSolver = NumericSolver.LUDecomposition;
-        [ObservableProperty] 
+        [ObservableProperty]
         private NumericOptimizer numericOptimizer = NumericOptimizer.GradientBased;
+
+        [ObservableProperty]
+        private InitialDistributionTypes initialDistributionType = InitialDistributionTypes.SlightlyDiffering;
 
         public MeshType Mesh = MeshType.FEM;
 
@@ -25,20 +29,23 @@ namespace Utility.Classes.ReconstructionParameters
             ErrorMetric = ErrorMetric.L2;
             NumericSolver = NumericSolver.LUDecomposition;
             NumericOptimizer = NumericOptimizer.GradientBased;
+            InitialDistributionType = InitialDistributionTypes.SlightlyDiffering;
             Mesh = MeshType.FEM;
         }
 
         public EITReconstructionParameters(DifferentialEquationSolver differentialEquationSolver, 
-                                           RegularizationTechnique regularizationTechnique, 
-                                           ErrorMetric errorMetric, 
-                                           NumericSolver numericSolver, 
-                                           NumericOptimizer numericOptimizer)
+                                           RegularizationTechnique regularizationTechnique,
+                                           ErrorMetric errorMetric,
+                                           NumericSolver numericSolver,
+                                           NumericOptimizer numericOptimizer,
+                                           InitialDistributionTypes initialDistributionType = InitialDistributionTypes.SlightlyDiffering)
         {
             DifferentialEquationSolver = differentialEquationSolver;
             RegularizationTechnique = regularizationTechnique;
             ErrorMetric = errorMetric;
             NumericSolver = numericSolver;
             NumericOptimizer = numericOptimizer;
+            InitialDistributionType = initialDistributionType;
 
             Mesh = (differentialEquationSolver == DifferentialEquationSolver.FiniteElementMethod) ? MeshType.FEM : MeshType.LBM;
         }


### PR DESCRIPTION
## Summary
- add hover element info to gradient and initial canvases
- allow choosing initial conductivity distribution type
- show playback frame index and count next to slider

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bca87f33f88333b722c678c5e6f791