### PR TITLE
feat: add 3D glass orb with mouse rotation

### DIFF
--- a/ElectricalImpedanceTomography/Controls/ImpedanceOrbView.cs
+++ b/ElectricalImpedanceTomography/Controls/ImpedanceOrbView.cs
@@ -17,6 +17,8 @@ namespace ElectricalImpedanceTomography.Controls
     public class ImpedanceOrbView : GraphicsView
     {
         private readonly OrbDrawable _drawable;
+        private double _lastPanX;
+        private double _lastPanY;
 
         public static readonly BindableProperty ModelProperty =
             BindableProperty.Create(nameof(Model), typeof(CurrentImpedanceModel), typeof(ImpedanceOrbView), propertyChanged: OnModelChanged);
@@ -40,6 +42,10 @@ namespace ElectricalImpedanceTomography.Controls
             pan.PanUpdated += OnPanUpdated;
             GestureRecognizers.Add(pan);
 
+            var pointer = new PointerGestureRecognizer();
+            pointer.PointerMoved += OnPointerMoved;
+            GestureRecognizers.Add(pointer);
+
             StartRippleAnimation();
         }
 
@@ -54,9 +60,35 @@ namespace ElectricalImpedanceTomography.Controls
 
         private void OnPanUpdated(object sender, PanUpdatedEventArgs e)
         {
-            if (e.StatusType == GestureStatus.Running)
+            if (e.StatusType == GestureStatus.Started)
             {
-                _drawable.Rotation += (float)e.TotalX * 0.1f;
+                _lastPanX = e.TotalX;
+                _lastPanY = e.TotalY;
+            }
+            else if (e.StatusType == GestureStatus.Running)
+            {
+                var deltaX = e.TotalX - _lastPanX;
+                var deltaY = e.TotalY - _lastPanY;
+                _lastPanX = e.TotalX;
+                _lastPanY = e.TotalY;
+
+                _drawable.RotationY += (float)deltaX * 0.01f;
+                _drawable.RotationX += (float)deltaY * 0.01f;
+                Invalidate();
+            }
+        }
+
+        private void OnPointerMoved(object sender, PointerEventArgs e)
+        {
+            var position = e.GetPosition(this);
+            if (position != null)
+            {
+                float radius = (float)(Math.Min(Width, Height) / 2f * 0.8f);
+                float limit = radius * 0.5f;
+                float relativeX = (float)(position.Value.X - Width / 2);
+                float relativeY = (float)(position.Value.Y - Height / 2);
+                _drawable.HighlightX = Math.Clamp(relativeX, -limit, limit);
+                _drawable.HighlightY = Math.Clamp(relativeY, -limit, limit);
                 Invalidate();
             }
         }
@@ -71,7 +103,7 @@ namespace ElectricalImpedanceTomography.Controls
                 if (newValue is CurrentImpedanceModel newModel)
                 {
                     newModel.PropertyChanged += view.OnModelPropertyChanged;
-                    view._drawable.Color = newModel.Color;
+                    view._drawable.OrbColor = newModel.Color;
                     view._drawable.Intensity = newModel.Intensity;
                 }
 
@@ -85,7 +117,7 @@ namespace ElectricalImpedanceTomography.Controls
                 return;
 
             if (e.PropertyName == nameof(CurrentImpedanceModel.Color))
-                _drawable.Color = Model.Color;
+                _drawable.OrbColor = Model.Color;
             else if (e.PropertyName == nameof(CurrentImpedanceModel.Intensity))
                 _drawable.Intensity = Model.Intensity;
 
@@ -105,26 +137,80 @@ namespace ElectricalImpedanceTomography.Controls
 
         private class OrbDrawable : IDrawable
         {
-            public Color Color { get; set; } = Colors.CornflowerBlue;
+            public Color OrbColor { get; set; } = Colors.CornflowerBlue;
             public float Intensity { get; set; }
             public float Ripple { get; set; }
             public float Scale { get; set; } = 0.9f;
-            public float Rotation { get; set; }
+            public float RotationX { get; set; }
+            public float RotationY { get; set; }
+            public float HighlightX { get; set; }
+            public float HighlightY { get; set; }
 
             public void Draw(ICanvas canvas, RectF dirtyRect)
             {
                 canvas.SaveState();
 
                 canvas.Translate(dirtyRect.Center.X, dirtyRect.Center.Y);
-                canvas.Rotate(Rotation);
                 canvas.Scale(Scale, Scale);
 
                 float radius = Math.Min(dirtyRect.Width, dirtyRect.Height) / 2f * 0.8f;
-                var fillColor = Color.WithAlpha(0.5f + 0.5f * Intensity);
-                canvas.FillColor = fillColor;
+                float highlightX = HighlightX + (float)(Math.Sin(RotationY) * radius * 0.5f);
+                float highlightY = HighlightY + (float)(Math.Sin(RotationX) * radius * 0.5f);
+
+                float alpha = 0.5f + 0.5f * Intensity;
+                var centerColor = Color.FromRgba(
+                    OrbColor.Red + (1 - OrbColor.Red) * 0.3f,
+                    OrbColor.Green + (1 - OrbColor.Green) * 0.3f,
+                    OrbColor.Blue + (1 - OrbColor.Blue) * 0.3f,
+                    alpha);
+                var edgeColor = Color.FromRgba(
+                    OrbColor.Red * 0.6f,
+                    OrbColor.Green * 0.6f,
+                    OrbColor.Blue * 0.6f,
+                    alpha);
+
+                var basePaint = new RadialGradientPaint
+                {
+                    Center = new Point(highlightX, highlightY),
+                    Radius = radius,
+                    GradientStops = new[]
+                    {
+                        new PaintGradientStop(0f, centerColor),
+                        new PaintGradientStop(1f, edgeColor)
+                    }
+                };
+
+                canvas.SetFillPaint(basePaint, new RectF(-radius, -radius, radius * 2, radius * 2));
                 canvas.FillCircle(0, 0, radius);
 
-                canvas.StrokeColor = Color.WithAlpha(0.3f);
+                canvas.SaveState();
+                canvas.ClipCircle(0, 0, radius);
+
+                float highlightCenterX = highlightX - radius * 0.3f;
+                float highlightCenterY = highlightY - radius * 0.3f;
+                float highlightRadius = radius * 0.6f;
+
+                var highlightPaint = new RadialGradientPaint
+                {
+                    Center = new Point(highlightCenterX, highlightCenterY),
+                    Radius = highlightRadius,
+                    GradientStops = new[]
+                    {
+                        new PaintGradientStop(0f, Colors.White.WithAlpha(0.7f)),
+                        new PaintGradientStop(1f, Colors.White.WithAlpha(0f))
+                    }
+                };
+
+                canvas.SetFillPaint(highlightPaint, new RectF(highlightCenterX - highlightRadius, highlightCenterY - highlightRadius, highlightRadius * 2, highlightRadius * 2));
+                canvas.FillCircle(highlightCenterX, highlightCenterY, highlightRadius);
+
+                canvas.RestoreState();
+
+                canvas.StrokeColor = Colors.White.WithAlpha(0.3f);
+                canvas.StrokeSize = 1;
+                canvas.DrawCircle(0, 0, radius);
+
+                canvas.StrokeColor = OrbColor.WithAlpha(0.3f);
                 canvas.StrokeSize = 2;
                 canvas.DrawCircle(0, 0, radius + Ripple * 20);
 
@@ -133,4 +219,3 @@ namespace ElectricalImpedanceTomography.Controls
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- Render impedance orb with radial gradients and highlight for a glassy 3D effect
- Allow dragging with mouse/pan to rotate orb in 3D space
- Fix gradient stops to use PaintGradientStop and resolve compile errors
- Track pointer movement so orb highlight follows the cursor

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1eb0611c8333a90433f09c9de6da