### PR TITLE
Fix async LBM reconstruction to avoid UI freeze and output frames

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -6,6 +6,7 @@ using Utility.Classes.Meshing.LatticeBoltzmannMesh;
 using Workspace = Utility.Classes.Application.Workspace;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace ElectricalImpedanceTomography.ViewModels
 {
@@ -87,24 +88,24 @@ namespace ElectricalImpedanceTomography.ViewModels
             return true;
         }
 
-        public void OnSolveForwardClicked(object sender, EventArgs e)
+        public async void OnSolveForwardClicked(object sender, EventArgs e)
         {
             InitializeReconstruction(force: true);
 
             if (_mesh is FEMMesh)
-                _reconstructionService.ForwardSolveStepFem();
+                await Task.Run(() => _reconstructionService.ForwardSolveStepFem());
             else if (_mesh is LBMMesh)
-                _reconstructionService.ForwardSolveStepLbm();
+                await Task.Run(() => _reconstructionService.ForwardSolveStepLbm());
         }
 
-        public void OnSolveInverseClicked(object sender, EventArgs e)
+        public async void OnSolveInverseClicked(object sender, EventArgs e)
         {
             InitializeReconstruction(force: true);
 
             if (_mesh is FEMMesh)
-                _reconstructionService.InverseSolveFem(MaxIterationCount, StepSize, RegularizationWeight, ExcitationCurrentAmplitude);
+                await Task.Run(() => _reconstructionService.InverseSolveFem(MaxIterationCount, StepSize, RegularizationWeight, ExcitationCurrentAmplitude));
             else if (_mesh is LBMMesh)
-                _reconstructionService.InverseSolveLbm(MaxIterationCount, StepSize, RegularizationWeight, ExcitationCurrentAmplitude);
+                await Task.Run(() => _reconstructionService.InverseSolveLbm(MaxIterationCount, StepSize, RegularizationWeight, ExcitationCurrentAmplitude));
         }
 
         private double CalculateResidual(ConductivityDistribution reconstructed, ConductivityDistribution original)

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -256,9 +256,16 @@ namespace ServiceLayer
             else if (_mesh is LBMMesh)
             {
                 var result = InverseSolveLbm(1, _stepSize, _regularizationWeight, _excitationAmplitude);
+
+                foreach (var frame in result.Frames)
+                {
+                    Workspace.AddReconstructionFrameToWorkspace(frame);
+                    ReconstructionFrameUpdated?.Invoke(this, frame);
+                }
+
                 ReconstructionUpdated?.Invoke(this, result);
                 _currentIteration++;
-                return null;
+                return result.Frames.LastOrDefault();
             }
 
             return null;


### PR DESCRIPTION
## Summary
- run LBM forward and inverse solves on background threads to keep UI responsive
- emit LBM reconstruction frames so the UI receives updates

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d3da95c8333a635cf266c798d4e