### PR TITLE
Implement one-shot reconstruction cycle on play button

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -140,6 +140,14 @@ namespace ElectricalImpedanceTomography.ViewModels
             return _reconstructionService.StepReconstructionAsync();
         }
 
+        public Task<ReconstructionResult?> RunFullReconstructionCycleAsync()
+        {
+            InitializeReconstruction();
+            return _reconstructionService.RunFullReconstructionCycleAsync(StepSize,
+                                                                          RegularizationWeight,
+                                                                          ExcitationCurrentAmplitude);
+        }
+
         private void OnServiceReconstructionUpdated(object? sender, ReconstructionResult result)
         {
             IterationCount++;

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -36,7 +36,6 @@ public partial class ReconstructionPage : ContentPage
     private PotentialDisplayMode _potMode = PotentialDisplayMode.Default;
 
     private bool _isPaused = false;
-    private bool _hasStarted = false;
     private bool _sliderChanging = false;
 
     public ReconstructionPage()
@@ -98,33 +97,19 @@ public partial class ReconstructionPage : ContentPage
         }
 
         await AnimateButtonAsync(sender);
-        if (!_hasStarted)
-        {
-            _viewModel.StartBackgroundReconstruction();
-            _hasStarted = true;
-            _isPaused = false;
-            StepButton.IsEnabled = false;
-            PlayerBackButton.IsEnabled = false;
-            PlayerForwardButton.IsEnabled = false;
-            PlayButton.IsVisible = false;
-            PauseButton.IsVisible = true;
-            return;
-        }
+        StepButton.IsEnabled = false;
+        PlayerBackButton.IsEnabled = false;
+        PlayerForwardButton.IsEnabled = false;
+        PlayButton.IsEnabled = false;
+        _isPaused = false;
 
-        if (_isPaused)
-        {
-            _viewModel.ResumeReconstruction();
-            _isPaused = false;
-            StepButton.IsEnabled = false;
-            PlayerBackButton.IsEnabled = false;
-            PlayerForwardButton.IsEnabled = false;
-            PlayButton.IsVisible = false;
-            PauseButton.IsVisible = true;
-        }
-        else
-        {
-            await DisplayAlert("Reconstruction Running", "You should either pause or stop reconstruction to start a new one.", "OK");
-        }
+        await _viewModel.RunFullReconstructionCycleAsync();
+
+        _isPaused = true;
+        StepButton.IsEnabled = true;
+        PlayerBackButton.IsEnabled = true;
+        PlayerForwardButton.IsEnabled = true;
+        PlayButton.IsEnabled = true;
     }
 
     private async void OnPauseButtonClicked(object sender, EventArgs e)
@@ -153,12 +138,10 @@ public partial class ReconstructionPage : ContentPage
         await AnimateButtonAsync(sender);
         _viewModel.StopReconstruction();
         _isPaused = false;
-        _hasStarted = false;
         StepButton.IsEnabled = false;
         PlayerBackButton.IsEnabled = false;
         PlayerForwardButton.IsEnabled = false;
-        PlayButton.IsVisible = true;
-        PauseButton.IsVisible = false;
+        PlayButton.IsEnabled = true;
     }
     #endregion
 

--- a/ServiceLayer/IReconstructionService.cs
+++ b/ServiceLayer/IReconstructionService.cs
@@ -22,6 +22,10 @@ namespace ServiceLayer
         void StopBackgroundReconstruction();
         Task<ReconstructionFrame?> StepReconstructionAsync();
 
+        Task<ReconstructionResult?> RunFullReconstructionCycleAsync(double stepSize,
+                                                                    double regularizationWeight,
+                                                                    double excitationAmplitude);
+
         // --- LBM Reconstruction ---
         PotentialDistribution ForwardSolveStepLbm();
         ReconstructionResult InverseSolveLbm(int maxIterationCount,

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -311,6 +311,64 @@ namespace ServiceLayer
             return frame;
         }
 
+        public async Task<ReconstructionResult?> RunFullReconstructionCycleAsync(double stepSize,
+                                                                               double regularizationWeight,
+                                                                               double excitationAmplitude)
+        {
+            _stepSize = stepSize;
+            _regularizationWeight = regularizationWeight;
+            _excitationAmplitude = excitationAmplitude;
+            _currentCycleFrames.Clear();
+
+            return await Task.Run(() =>
+            {
+                if (_mesh is FEMMesh femMesh)
+                {
+                    if (_simulatedMeasurements.Count == 0)
+                        _simulatedMeasurements = _reconstructionPersistence.SimulateFemMeasurements(femMesh, _excitationAmplitude);
+
+                    var electrodes = femMesh.GetElectrodes().Cast<FEMElectrode>().ToList();
+                    var bc = new FEMBoundaryCondition(electrodes);
+
+                    foreach (var measurement in _simulatedMeasurements)
+                    {
+                        var frame = _reconstructionPersistence.Step(measurement, bc, _stepSize, _regularizationWeight);
+                        Workspace.AddReconstructionFrameToWorkspace(frame);
+                        _currentCycleFrames.Add(frame);
+                        ReconstructionFrameUpdated?.Invoke(this, frame);
+                    }
+
+                    var result = new ReconstructionResult(_mesh!.GetMesh(), _originalSigma!, _initialSigma!, _mesh!.GetConductivityDistribution(), _currentCycleFrames.ToList());
+                    Workspace.AddReconstructionResultToWorkspace(result);
+                    ReconstructionUpdated?.Invoke(this, result);
+                    _currentCycleFrames.Clear();
+                    return result;
+                }
+                else if (_mesh is LBMMesh lbmMesh)
+                {
+                    var meas = _reconstructionPersistence.SimulateLbmMeasurements(lbmMesh, _excitationAmplitude);
+                    var electrodes = lbmMesh.GetElectrodes().Cast<LBMElectrode>().ToList();
+                    var bc = new LBMBoundaryCondition(electrodes);
+
+                    foreach (var measurement in meas.Frames)
+                    {
+                        var frame = _reconstructionPersistence.Step(measurement, bc, _stepSize, _regularizationWeight);
+                        Workspace.AddReconstructionFrameToWorkspace(frame);
+                        _currentCycleFrames.Add(frame);
+                        ReconstructionFrameUpdated?.Invoke(this, frame);
+                    }
+
+                    var result = new ReconstructionResult(_mesh!.GetMesh(), _originalSigma!, _initialSigma!, _mesh!.GetConductivityDistribution(), _currentCycleFrames.ToList());
+                    Workspace.AddReconstructionResultToWorkspace(result);
+                    ReconstructionUpdated?.Invoke(this, result);
+                    _currentCycleFrames.Clear();
+                    return result;
+                }
+
+                return null;
+            });
+        }
+
         #endregion
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add service interface and implementation for running a full reconstruction cycle including measurement simulation
- expose new cycle trigger in ReconstructionPageViewModel
- rework ReconstructionPage play button to run full cycle task and re-enable playback controls when finished

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc39b0afc833396650b4ecaf62580