### PR TITLE
Handle original vs initial conductivity distributions in reconstruction

### DIFF
--- a/BusinessLayer/IReconstructionPersistence.cs
+++ b/BusinessLayer/IReconstructionPersistence.cs
@@ -8,6 +8,7 @@ namespace BusinessLayer
 {
     public interface IReconstructionPersistence
     {
+        void SetConductivityDistributions(ConductivityDistribution original, ConductivityDistribution initial);
         public void InitializeReconstruction(IMesh mesh, EITReconstructionParameters parameters, bool reinit);
 
         public ReconstructionFrame Step(double[] measurement, BoundaryCondition boundaryCondition, double gradientStepSize, double redularizationStepSize);

--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -31,6 +31,9 @@ namespace BusinessLayer
         private double _regularizationWeight = 0.001;
         private InitialDistributionTypes _initialDistributionType = InitialDistributionTypes.SlightlyDiffering;
 
+        private ConductivityDistribution? _originalSigma = null;
+        private ConductivityDistribution? _initialSigma = null;
+
         private bool _initialized = false;
 
         // --- Background reconstruction bookkeeping ---
@@ -49,6 +52,12 @@ namespace BusinessLayer
             _reconstructionRepository = reconstructionRepository;
         }
 
+        public void SetConductivityDistributions(ConductivityDistribution original, ConductivityDistribution initial)
+        {
+            _originalSigma = original;
+            _initialSigma = initial;
+        }
+
         public void InitializeReconstruction(IMesh mesh, EITReconstructionParameters parameters, bool reinit)
         {
             if(!_initialized || reinit)
@@ -60,7 +69,8 @@ namespace BusinessLayer
                 _regularizer = RegularisationFactory.Create(parameters.RegularizationTechnique, _mesh);
                 _errorMetric = ErrorMetricFactory.Create(parameters.ErrorMetric);
                 _initialDistributionType = parameters.InitialDistributionType;
-                _numericOptimizer = NumericOptimizerFactory.Create(parameters.NumericOptimizer, ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType));
+                var initSigma = _initialSigma ?? ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
+                _numericOptimizer = NumericOptimizerFactory.Create(parameters.NumericOptimizer, initSigma);
 
                 _inverseModel = InverseModelFactory.Create(_mesh, _numericOptimizer, _regularizer, _errorMetric, _differentialEquationSolver);
 
@@ -293,17 +303,20 @@ namespace BusinessLayer
 
             // --- Prepare reference data --------------------------------------------------
 
-            // Save the original distribution for the ReconstructionResult and
-            // generate synthetic measurements that represent the observed data
-            // for the inverse problem.
-            ConductivityDistribution originalSigma = mesh.DeepCopy().GetConductivityDistribution();
-            List<double[]> measurementFrames = SimulateFemMeasurements(mesh, 1.0);
+            ConductivityDistribution originalSigma = _originalSigma ?? mesh.DeepCopy().GetConductivityDistribution();
+            List<double[]> measurementFrames;
+            if (_originalSigma != null)
+            {
+                FEMMesh measMesh = (FEMMesh)mesh.DeepCopy();
+                measMesh.SetConductivityDistribution(originalSigma);
+                measurementFrames = SimulateFemMeasurements(measMesh, 1.0);
+            }
+            else
+            {
+                measurementFrames = SimulateFemMeasurements(mesh, 1.0);
+            }
 
-            // Replace the mesh conductivity with the user-selected initial
-            // distribution so that the simulated data differs from the
-            // observed measurements, yielding a non-zero adjoint source.
-            ConductivityDistribution initialSigma = ConductivityDistributionFactory
-                                                        .CreateInitialDistribution(mesh, _initialDistributionType);
+            ConductivityDistribution initialSigma = _initialSigma ?? ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
             mesh.SetConductivityDistribution(initialSigma);
 
             // Cache electrode and element information for repeated use.
@@ -399,11 +412,21 @@ namespace BusinessLayer
             if (_errorMetric == null)
                 throw new NullReferenceException("Error metric not initialised.");
 
-            // Simulated measurement frames taken as observed data.
-            EITMeasurement measurementFrames = SimulateLbmMeasurements(mesh, 1.0);
+            ConductivityDistribution originalSigma = _originalSigma ?? ((LBMMesh)mesh.DeepCopy()).GetConductivityDistribution();
+            EITMeasurement measurementFrames;
+            if (_originalSigma != null)
+            {
+                LBMMesh measMesh = (LBMMesh)mesh.DeepCopy();
+                measMesh.SetConductivityDistribution(originalSigma);
+                measurementFrames = SimulateLbmMeasurements(measMesh, 1.0);
+            }
+            else
+            {
+                measurementFrames = SimulateLbmMeasurements(mesh, 1.0);
+            }
 
-            ConductivityDistribution originalSigma = ((LBMMesh)mesh.DeepCopy()).GetConductivityDistribution();
-            ConductivityDistribution initialSigma = mesh.GetConductivityDistribution();
+            ConductivityDistribution initialSigma = _initialSigma ?? mesh.GetConductivityDistribution();
+            mesh.SetConductivityDistribution(initialSigma);
 
             var electrodes = mesh.GetElectrodes().Cast<LBMElectrode>().ToList();
             int electrodeCount = electrodes.Count;
@@ -481,11 +504,20 @@ namespace BusinessLayer
 
             _regularizationWeight = redularizationStepSize;
 
-            List<double[]> simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude);
-            ConductivityDistribution originalConductivityDistribution = mesh.DeepCopy().GetConductivityDistribution();
+            ConductivityDistribution originalConductivityDistribution = _originalSigma ?? mesh.DeepCopy().GetConductivityDistribution();
+            List<double[]> simulatedMeasurements;
+            if (_originalSigma != null)
+            {
+                FEMMesh measMesh = (FEMMesh)mesh.DeepCopy();
+                measMesh.SetConductivityDistribution(originalConductivityDistribution);
+                simulatedMeasurements = SimulateFemMeasurements(measMesh, excitationAmplitude);
+            }
+            else
+            {
+                simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude);
+            }
 
-            // 2) Initialize conductivity (σ^{(0)}) based on user selection
-            ConductivityDistribution initialConductivityDistribution = ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
+            ConductivityDistribution initialConductivityDistribution = _initialSigma ?? ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
             mesh.SetConductivityDistribution(initialConductivityDistribution);
 
             List<FEMElectrode> electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
@@ -720,15 +752,24 @@ namespace BusinessLayer
             if (_inverseModel == null || _mesh == null || mesh == null || _differentialEquationSolver == null || _errorMetric == null)
                 throw new NullReferenceException();
 
-            ConductivityDistribution originalConductivityDistribution = ((LBMMesh)mesh.DeepCopy()).GetConductivityDistribution();
+            ConductivityDistribution originalConductivityDistribution = _originalSigma ?? ((LBMMesh)mesh.DeepCopy()).GetConductivityDistribution();
             mesh = (LBMMesh)mesh.DeepCopy();
 
             var electrodes = mesh.GetElectrodes().Cast<LBMElectrode>().ToList();
 
             LBMBoundaryCondition bc = new(electrodes);
 
-            // --- Simulate Measurements for the Inverse Solver ---
-            EITMeasurement measurementFrames = SimulateLbmMeasurements(mesh, 1.0);
+            EITMeasurement measurementFrames;
+            if (_originalSigma != null)
+            {
+                LBMMesh measMesh = (LBMMesh)mesh.DeepCopy();
+                measMesh.SetConductivityDistribution(originalConductivityDistribution);
+                measurementFrames = SimulateLbmMeasurements(measMesh, 1.0);
+            }
+            else
+            {
+                measurementFrames = SimulateLbmMeasurements(mesh, 1.0);
+            }
 
             // Container to hold partial results from reconstrucion
             List<ReconstructionFrame> frames = [];
@@ -766,9 +807,10 @@ namespace BusinessLayer
 
             ConductivityDistribution reconstructedConductivityDistribution = mesh.GetConductivityDistribution();
 
+            var initialConductivityDistribution = _initialSigma ?? mesh.GetConductivityDistribution();
             return new ReconstructionResult((LBMMesh)_mesh,
                                             originalConductivityDistribution,
-                                            originalConductivityDistribution,
+                                            initialConductivityDistribution,
                                             reconstructedConductivityDistribution,
                                             frames);
         }

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -429,12 +429,12 @@ public partial class ReconstructionPage : ContentPage
         var mesh = GetMesh();
         if (mesh is FEMMesh fem)
         {
-            var cd = _currentResult?.OriginalConductivityDistribution ?? fem.GetConductivityDistribution();
+            var cd = _currentResult?.OriginalConductivityDistribution ?? Workspace.GetOriginalConductivityDistribution() ?? fem.GetConductivityDistribution();
             DrawFemConductivity(e, fem, cd, _hoverOriginalLines, _hoverOriginalPt);
         }
         else if (mesh is LBMMesh lbm)
         {
-            var cd = _currentResult?.OriginalConductivityDistribution ?? lbm.GetConductivityDistribution();
+            var cd = _currentResult?.OriginalConductivityDistribution ?? Workspace.GetOriginalConductivityDistribution() ?? lbm.GetConductivityDistribution();
             DrawLbmField(e, lbm, cd.Conductivities, false, _hoverOriginalLines, _hoverOriginalPt);
         }
     }
@@ -495,7 +495,7 @@ public partial class ReconstructionPage : ContentPage
         var mesh = GetMesh();
         if (mesh is FEMMesh fem)
         {
-            var cd = _currentResult?.OriginalConductivityDistribution ?? fem.GetConductivityDistribution();
+            var cd = _currentResult?.OriginalConductivityDistribution ?? Workspace.GetOriginalConductivityDistribution() ?? fem.GetConductivityDistribution();
             double min = cd.Conductivities.Values.Min();
             double max = cd.Conductivities.Values.Max();
             if (Math.Abs(max - min) < 1e-12) max = min + 1e-12;
@@ -503,7 +503,7 @@ public partial class ReconstructionPage : ContentPage
         }
         else if (mesh is LBMMesh lbm)
         {
-            var cd = _currentResult?.OriginalConductivityDistribution ?? lbm.GetConductivityDistribution();
+            var cd = _currentResult?.OriginalConductivityDistribution ?? Workspace.GetOriginalConductivityDistribution() ?? lbm.GetConductivityDistribution();
             double min = cd.Conductivities.Values.Min();
             double max = cd.Conductivities.Values.Max();
             if (Math.Abs(max - min) < 1e-12) max = min + 1e-12;
@@ -608,7 +608,7 @@ public partial class ReconstructionPage : ContentPage
             }
             ComputeFemTransform(fem, new SKImageInfo((int)view.CanvasSize.Width, (int)view.CanvasSize.Height));
             _hoverOriginalLines = null; _hoverOriginalPt = null;
-            var cd = (_currentResult?.OriginalConductivityDistribution ?? fem.GetConductivityDistribution());
+            var cd = (_currentResult?.OriginalConductivityDistribution ?? Workspace.GetOriginalConductivityDistribution() ?? fem.GetConductivityDistribution());
             foreach (var elem in fem.GetElements().Cast<FEMElement>())
             {
                 var c0 = ToCanvas(elem.Vertices[0]);
@@ -633,7 +633,7 @@ public partial class ReconstructionPage : ContentPage
             if (e.ActionType == SKTouchAction.Released)
             { _hoverOriginalLines = null; _hoverOriginalPt = null; view.InvalidateSurface(); e.Handled = true; return; }
             var el = lbm.GetElementAt(col, row);
-            var cd = (_currentResult?.OriginalConductivityDistribution ?? lbm.GetConductivityDistribution());
+            var cd = (_currentResult?.OriginalConductivityDistribution ?? Workspace.GetOriginalConductivityDistribution() ?? lbm.GetConductivityDistribution());
             double val = cd.Conductivities[el.Id];
             _hoverOriginalLines = new[] { $"ID: {el.Id}", $"σ: {val:F3}" };
             _hoverOriginalPt = e.Location;

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -119,11 +119,12 @@ namespace ServiceLayer
 
                 Workspace.SetReconstructionResults(new List<ReconstructionResult>());
 
-                _reconstructionPersistence.InitializeReconstruction(mesh, parameters, reinit);
                 _originalSigma = mesh.DeepCopy().GetConductivityDistribution();
                 _initialSigma = ConductivityDistributionFactory.CreateInitialDistribution(mesh, parameters.InitialDistributionType);
-
                 mesh.SetConductivityDistribution(_initialSigma);
+                Workspace.SetOriginalConductivityDistribution(_originalSigma);
+                _reconstructionPersistence.SetConductivityDistributions(_originalSigma, _initialSigma);
+                _reconstructionPersistence.InitializeReconstruction(mesh, parameters, reinit);
 
                 _framesPerCycle = (mesh.GetElectrodes().Count > 0) ? mesh.GetElectrodes().Count : 1;
             }

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -17,6 +17,7 @@ namespace Utility.Classes.Application
         private static List<ReconstructionResult> _reconstructionResults = [];
         private static List<ReconstructionFrame> _reconstructionFrames = [];
         private static List<WorkspaceMessage> _messages = [];
+        private static ConductivityDistribution? _originalConductivityDistribution = null;
         public static event Action<WorkspaceMessage>? MessageAdded;
 
         private static bool _initialized = false; 
@@ -43,12 +44,14 @@ namespace Utility.Classes.Application
         public static void SetMesh(IMesh? mesh) => _mesh = mesh;
         public static void SetReconstructionResults(List<ReconstructionResult> results) => _reconstructionResults = results;
         public static void SetReconstructionFrames(List<ReconstructionFrame> frames) => _reconstructionFrames = frames;
+        public static void SetOriginalConductivityDistribution(ConductivityDistribution? sigma) => _originalConductivityDistribution = sigma;
 
         public static User GetUser() => _user;
         public static EITReconstructionParameters GetReconstructionParameters() => _reconstructionParameters;
         public static IMesh? GetMesh() => _mesh;
         public static List<ReconstructionResult> GetReconstructionResults() => _reconstructionResults;
         public static List<ReconstructionFrame> GetReconstructionFrames() => _reconstructionFrames;
+        public static ConductivityDistribution? GetOriginalConductivityDistribution() => _originalConductivityDistribution;
 
         public static int MaxIterationCount
         {


### PR DESCRIPTION
## Summary
- Preserve separate original and initial conductivity fields
- Use original conductivity when simulating measurements and initial as reconstruction start
- Fix UI to display the true original distribution when no result is present

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68be848befe4833393c55f0295720f0d