### PR TITLE
Add FEM mesh support for Wasserstein-2 error metric

### DIFF
--- a/Utility/Classes/ReconstructionParameters/ErrorMetric.cs
+++ b/Utility/Classes/ReconstructionParameters/ErrorMetric.cs
@@ -1,5 +1,7 @@
 ﻿using Google.OrTools.LinearSolver;
+using Utility.Classes.Meshing;
 using Utility.Classes.Meshing.LatticeBoltzmannMesh;
+using Utility.Classes.Meshing.FiniteElementMesh;
 
 namespace Utility.Classes.ReconstructionParameters
 {
@@ -108,22 +110,36 @@ namespace Utility.Classes.ReconstructionParameters
 
         private OptimalTransportResult SolveOT(IMesh mesh, double[] measured, double[] simulated)
         {
-            if (mesh is not LBMMesh lbm)
-                throw new ArgumentException("Wasserstein-2 currently implemented for LBMMesh because it needs lattice coordinates.");
-
-            // (1) Pick electrodes, filter to *measuring* ones and ignore NaNs.
-            var all = lbm.GetElectrodes().Cast<LBMElectrode>().OrderBy(e => e.Id).ToList();
+            // (1) Gather electrodes and coordinate provider
+            var all = mesh.GetElectrodes().OrderBy(e => e.Id).ToList();
             if (all.Count != measured.Length || all.Count != simulated.Length)
                 throw new ArgumentException("Electrode count must match data length.");
 
-            var (a, aLoc, aIndexMap) = BuildDistribution(simulated, all, lbm); // source: simulated
-            var (b, bLoc, _) = BuildDistribution(measured, all, lbm); // target: measured
+            Func<Electrode, (double x, double y)> coord;
+            if (mesh is LBMMesh lbm)
+                coord = e =>
+                {
+                    var le = (LBMElectrode)e;
+                    var (x, y) = ToXY(lbm, le.GridId);
+                    return (x, y);
+                };
+            else if (mesh is FEMMesh fem)
+                coord = e =>
+                {
+                    var fe = (FEMElectrode)e;
+                    return GetCoord(fem, fe);
+                };
+            else
+                throw new ArgumentException("Wasserstein-2 currently implemented for LBMMesh or FEMMesh because it needs electrode coordinates.");
+
+            var (a, aLoc, aIndexMap) = BuildDistribution(simulated, all, coord); // source: simulated
+            var (b, bLoc, _) = BuildDistribution(measured, all, coord); // target: measured
 
             // If nothing valid (e.g., all NaN), return zero
             if (a.Length == 0 || b.Length == 0)
                 return new OptimalTransportResult(measured, simulated, 0.0, new double[all.Count]);
 
-            // (2) Cost matrix c_{ij} = squared Euclidean distance on lattice
+            // (2) Cost matrix c_{ij} = squared Euclidean distance on coordinates
             int m = a.Length, n = b.Length;
             double[,] C = new double[m, n];
             for (int i = 0; i < m; i++)
@@ -179,11 +195,11 @@ namespace Utility.Classes.ReconstructionParameters
             return new OptimalTransportResult(measured, simulated, optimal, phiFull);
         }
 
-        private static (double[] mass, List<(int x, int y)> loc, List<(int srcIdx, int electrodeIdx)> indexMap)
-            BuildDistribution(double[] raw, List<LBMElectrode> electrodes, LBMMesh mesh)
+        private static (double[] mass, List<(double x, double y)> loc, List<(int srcIdx, int electrodeIdx)> indexMap)
+            BuildDistribution(double[] raw, List<Electrode> electrodes, Func<Electrode, (double x, double y)> getCoord)
         {
             var vals = new List<double>();
-            var coords = new List<(int x, int y)>();
+            var coords = new List<(double x, double y)>();
             var map = new List<(int, int)>();
 
             double minVal = double.PositiveInfinity;
@@ -196,13 +212,13 @@ namespace Utility.Classes.ReconstructionParameters
 
                 minVal = Math.Min(minVal, v);
                 vals.Add(v);
-                coords.Add(ToXY(mesh, e.GridId));
+                coords.Add(getCoord(e));
                 map.Add((vals.Count - 1, i)); // (index in 'vals', electrode index)
             }
 
             // Shift to nonnegative, then normalize to probability
             if (vals.Count == 0)
-                return (Array.Empty<double>(), new List<(int, int)>(), new List<(int, int)>());
+                return (Array.Empty<double>(), new List<(double, double)>(), new List<(int, int)>());
 
             if (minVal < 0.0)
                 for (int k = 0; k < vals.Count; k++) vals[k] -= minVal;
@@ -222,12 +238,26 @@ namespace Utility.Classes.ReconstructionParameters
             return (vals.ToArray(), coords, map);
         }
 
-        private static (int x, int y) ToXY(LBMMesh mesh, int gridId)
+        private static (double x, double y) ToXY(LBMMesh mesh, int gridId)
         {
             // Prefer mesh API if public; otherwise decode (id = y*Nx + x)
             int x = gridId % mesh.Nx;
             int y = gridId / mesh.Nx;
             return (x, y);
+        }
+
+        private static (double x, double y) GetCoord(FEMMesh mesh, FEMElectrode e)
+        {
+            if (!e.PointElectrode && e.FEMVertexIds != null && e.FEMVertexIds.Count > 0)
+            {
+                var verts = mesh.Vertices.Where(v => e.FEMVertexIds.Contains(v.GlobalId)).ToList();
+                double x = verts.Average(v => v.X);
+                double y = verts.Average(v => v.Y);
+                return (x, y);
+            }
+
+            var vtx = mesh.Vertices.First(v => v.GlobalId == e.MeshId);
+            return (vtx.X, vtx.Y);
         }
 
         private sealed class OptimalTransportResult

--- a/Utility/Tests/ErrorMetricTests.cs
+++ b/Utility/Tests/ErrorMetricTests.cs
@@ -1,4 +1,5 @@
 ﻿using Utility.Classes.ReconstructionParameters;
+using Utility.Classes.Meshing.FiniteElementMesh;
 using Xunit;
 
 namespace Utility.Tests
@@ -31,6 +32,47 @@ namespace Utility.Tests
         {
             // Arrange a tiny LBMMesh with 4 electrodes and deterministic coordinates,
             /// TODO: validate W2
+        }
+
+        [Fact]
+        public void Wasserstein2_FEM_Evaluate_Produces_Finite_Value()
+        {
+            var mesh = TinyFEM();
+
+            // Simple distributions over 4 electrodes
+            double[] meas = { 0.0, 1.0, 0.0, 0.0 };
+            double[] sim = { 1.0, 0.0, 0.0, 0.0 };
+
+            IErrorMetric w2 = new Wasserstein2ErrorMetric();
+            double val = w2.Evaluate(mesh, meas, sim);
+            Assert.True(val >= 0.0);
+
+            var phi = w2.EvaluateAdjointSource(mesh, meas, sim);
+            Assert.Equal(meas.Length, phi.Length);
+        }
+
+        private static FEMMesh TinyFEM()
+        {
+            var v1 = new FEMVertex { GlobalId = 0, X = 0, Y = 0, IsElectrode = true };
+            var v2 = new FEMVertex { GlobalId = 1, X = 1, Y = 0, IsElectrode = true };
+            var v3 = new FEMVertex { GlobalId = 2, X = 1, Y = 1, IsElectrode = true };
+            var v4 = new FEMVertex { GlobalId = 3, X = 0, Y = 1, IsElectrode = true };
+
+            var elems = new List<FEMElement>
+            {
+                new FEMElement(0, v1, v2, v3),
+                new FEMElement(1, v1, v3, v4)
+            };
+
+            var electrodes = new List<FEMElectrode>
+            {
+                new FEMElectrode(0, 0, 0.0, 0.0, 0.0, isMeasuring: true),
+                new FEMElectrode(1, 1, 0.0, 0.0, 0.0, isMeasuring: true),
+                new FEMElectrode(2, 2, 0.0, 0.0, 0.0, isMeasuring: true),
+                new FEMElectrode(3, 3, 0.0, 0.0, 0.0, isMeasuring: true)
+            };
+
+            return new FEMMesh(new[] { v1, v2, v3, v4 }, elems, electrodes);
         }
 
         private sealed class DoubleArrayComparer : IEqualityComparer<double[]>


### PR DESCRIPTION
## Summary
- Extend Wasserstein-2 error metric to support FEM meshes alongside LBM meshes
- Add integration test scaffolding for W2 on FEM meshes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68becc797cf48333b6ede2ddf84f5799