### PR TITLE
Accumulate gradient after full reconstruction cycle

### DIFF
--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -433,7 +433,23 @@ namespace ServiceLayer
                         ReconstructionFrameUpdated?.Invoke(this, frame);
                     }
 
-                    var result = new ReconstructionResult(_mesh!.GetMesh(), _originalSigma!, _initialSigma!, _mesh!.GetConductivityDistribution(), _currentCycleFrames.ToList());
+                    // accumulate gradient and update conductivity distribution
+                    var frameCount = _currentCycleFrames.Count;
+                    var prevSigma = _mesh!.GetConductivityDistribution();
+                    var accumGrad = new Dictionary<int, double>();
+                    foreach (var frame in _currentCycleFrames)
+                        foreach (var kvp in frame.ConductivityGradient.Conductivities)
+                            accumGrad[kvp.Key] = accumGrad.TryGetValue(kvp.Key, out var g) ? g + kvp.Value : kvp.Value;
+
+                    var newSigmaDict = prevSigma.Conductivities.ToDictionary(
+                        kvp => kvp.Key,
+                        kvp => kvp.Value + (accumGrad.TryGetValue(kvp.Key, out var g) ? g / frameCount : 0.0));
+                    var newSigma = new ConductivityDistribution(newSigmaDict);
+                    _mesh.SetConductivityDistribution(newSigma);
+                    _initialSigma = newSigma;
+                    _reconstructionPersistence.SetConductivityDistributions(_originalSigma!, _initialSigma!);
+
+                    var result = new ReconstructionResult(_mesh!.GetMesh(), _originalSigma!, prevSigma, newSigma, _currentCycleFrames.ToList());
                     Workspace.AddReconstructionResultToWorkspace(result);
                     ReconstructionUpdated?.Invoke(this, result);
                     _currentCycleFrames.Clear();
@@ -457,7 +473,22 @@ namespace ServiceLayer
                         lbmMesh.ShiftExcitationElectrodes(DrivePattern.Adjecent);
                     }
 
-                    var result = new ReconstructionResult(_mesh!.GetMesh(), _originalSigma!, _initialSigma!, _mesh!.GetConductivityDistribution(), _currentCycleFrames.ToList());
+                    var frameCount = _currentCycleFrames.Count;
+                    var prevSigma = _mesh!.GetConductivityDistribution();
+                    var accumGrad = new Dictionary<int, double>();
+                    foreach (var frame in _currentCycleFrames)
+                        foreach (var kvp in frame.ConductivityGradient.Conductivities)
+                            accumGrad[kvp.Key] = accumGrad.TryGetValue(kvp.Key, out var g) ? g + kvp.Value : kvp.Value;
+
+                    var newSigmaDict = prevSigma.Conductivities.ToDictionary(
+                        kvp => kvp.Key,
+                        kvp => kvp.Value + (accumGrad.TryGetValue(kvp.Key, out var g) ? g / frameCount : 0.0));
+                    var newSigma = new ConductivityDistribution(newSigmaDict);
+                    _mesh.SetConductivityDistribution(newSigma);
+                    _initialSigma = newSigma;
+                    _reconstructionPersistence.SetConductivityDistributions(_originalSigma!, _initialSigma!);
+
+                    var result = new ReconstructionResult(_mesh!.GetMesh(), _originalSigma!, prevSigma, newSigma, _currentCycleFrames.ToList());
                     Workspace.AddReconstructionResultToWorkspace(result);
                     ReconstructionUpdated?.Invoke(this, result);
                     _currentCycleFrames.Clear();


### PR DESCRIPTION
## Summary
- Aggregate frame gradients in `RunFullReconstructionCycleAsync` and apply normalized update to mesh conductivity
- Persist updated conductivity as new initial distribution for subsequent cycles

## Testing
- ⚠️ `dotnet build ElectricalImpedanceTomography.sln` *(dotnet not installed; apt repositories 403 during attempted install)*

------
https://chatgpt.com/codex/tasks/task_e_68bece85014483339e35e0f80cedfe5f