### PR TITLE
Improve navigation visuals and mesh validation

### DIFF
--- a/ElectricalImpedanceTomography/AppShell.xaml
+++ b/ElectricalImpedanceTomography/AppShell.xaml
@@ -7,21 +7,17 @@
     xmlns:views="clr-namespace:ElectricalImpedanceTomography.Views"
     Title="ElectricalImpedanceTomography">
 
-    <ShellContent
-        Title="Home"
-        ContentTemplate="{DataTemplate views:MainPage}"
-        Route="MainPage" />
-    <ShellContent
-        Title="DAQ"
-        ContentTemplate="{DataTemplate views:DAQPage}"
-        Route="DAQPage"/>
-    <ShellContent 
-        Title="Meshgin"
-        ContentTemplate="{DataTemplate views:MeshingPage}"
-        Route="MeshingPage"/>
-    <ShellContent 
-        Title="Reconstruction"
-        ContentTemplate="{DataTemplate views:ReconstructionPage}"
-        Route="ReconstructionPage"/>
+    <ShellContent Title="Home" Route="MainPage">
+        <views:MainPage />
+    </ShellContent>
+    <ShellContent Title="DAQ" Route="DAQPage">
+        <views:DAQPage />
+    </ShellContent>
+    <ShellContent Title="Meshgin" Route="MeshingPage">
+        <views:MeshingPage />
+    </ShellContent>
+    <ShellContent Title="Reconstruction" Route="ReconstructionPage">
+        <views:ReconstructionPage />
+    </ShellContent>
     
 </Shell>

--- a/ElectricalImpedanceTomography/AppShell.xaml.cs
+++ b/ElectricalImpedanceTomography/AppShell.xaml.cs
@@ -1,16 +1,31 @@
+using ElectricalImpedanceTomography.Controls;
 ﻿namespace ElectricalImpedanceTomography
 {
     public partial class AppShell : Shell
     {
         public AppShell()
         {
-            InitializeComponent();      
+            InitializeComponent();
             
             // Registering routes for the shell routing. It is a must to register pages, so navigation knows where to go.
             Routing.RegisterRoute(nameof(Views.MainPage), typeof(Views.MainPage));
             Routing.RegisterRoute(nameof(Views.DAQPage), typeof(Views.DAQPage));    
             Routing.RegisterRoute(nameof(Views.MeshingPage), typeof(Views.MeshingPage));
             Routing.RegisterRoute(nameof(Views.ReconstructionPage), typeof(Views.ReconstructionPage));
+
+            Navigated += OnNavigated;
+
+            if (CurrentPage is ContentPage page)
+                page.FindByName<NavBarControl>("NavBar")?.RefreshCurrentPage();
+        }
+
+        private void OnNavigated(object? sender, ShellNavigatedEventArgs e)
+        {
+            if (CurrentPage is ContentPage page)
+            {
+                var navBar = page.FindByName<NavBarControl>("NavBar");
+                navBar?.RefreshCurrentPage();
+            }
         }
     }
 }

--- a/ElectricalImpedanceTomography/Controls/NavBarControl.xaml.cs
+++ b/ElectricalImpedanceTomography/Controls/NavBarControl.xaml.cs
@@ -1,5 +1,6 @@
 namespace ElectricalImpedanceTomography.Controls;
 
+using Color = Microsoft.Maui.Graphics.Color;
 using Workspace = Utility.Classes.Application.Workspace;
 
 public partial class NavBarControl : ContentView
@@ -23,37 +24,48 @@ public partial class NavBarControl : ContentView
     {
         InitializeComponent();
 
-        // Initial visibility setup based on default value (can be omitted if default is empty)
-        UpdateButtonVisibility(CurrentPageName);
+        // Initialize button states so that the bound page appears pressed
+        SetButtonStates(CurrentPageName);
     }
 
     // Called when the CurrentPageName property changes
     private static void OnCurrentPageNameChanged(BindableObject bindable, object oldValue, object newValue)
     {
-        if (bindable is NavBarControl control && newValue is string pageName)
-            control.UpdateButtonVisibility(pageName);
+        if (bindable is NavBarControl control)
+            control.SetButtonStates(newValue as string);
     }
 
-    // Logic to hide the button corresponding to the current page
-    private void UpdateButtonVisibility(string currentPageName)
+    // Applies the visual state to all buttons and marks the given page as active
+    private void SetButtonStates(string? currentPageName)
     {
-        // Reset all buttons to visible first
-        MainPageButton.IsVisible = true;
-        DAQPageButton.IsVisible = true;
-        MeshingPageButton.IsVisible = true;
-        ReconstructionPageButton.IsVisible = true;
+        ResetButton(MainPageButton);
+        ResetButton(DAQPageButton);
+        ResetButton(MeshingPageButton);
+        ResetButton(ReconstructionPageButton);
 
-        // Hide the button matching the current page name (case-insensitive)
-        if (string.Equals(currentPageName, "MainPage"))
-            MainPageButton.IsVisible = false;
-        else if (string.Equals(currentPageName, "DAQPage"))
-            DAQPageButton.IsVisible = false;
-        else if (string.Equals(currentPageName, "MeshingPage"))
-            MeshingPageButton.IsVisible = false;
-        else if(string.Equals(currentPageName, "ReconstructionPage"))
-            ReconstructionPageButton.IsVisible = false;
-
+        var active = GetButtonForPage(currentPageName);
+        if (active != null)
+        {
+            active.BackgroundColor = Color.FromRgb(0x44, 0x44, 0x44);
+            active.Scale = 0.95;
+        }
     }
+
+    private static void ResetButton(Border btn)
+    {
+        btn.BackgroundColor = Color.FromRgb(0x55, 0x55, 0x55);
+        btn.Scale = 1.0;
+    }
+
+    private Border? GetButtonForPage(string? pageName)
+        => pageName switch
+        {
+            "MainPage" => MainPageButton,
+            "DAQPage" => DAQPageButton,
+            "MeshingPage" => MeshingPageButton,
+            "ReconstructionPage" => ReconstructionPageButton,
+            _ => null
+        };
 
     private async void NavigateButton_Clicked(object sender, EventArgs e)
         => await HandleNavigationAsync(sender as VisualElement);
@@ -66,18 +78,28 @@ public partial class NavBarControl : ContentView
         if (element == null)
             return;
 
-        await element.ScaleTo(0.95, 50);
-        await element.ScaleTo(1.0, 50);
-
+        string targetPage = string.Empty;
         string route = string.Empty;
         if (element == MainPageButton)
+        {
+            targetPage = "MainPage";
             route = "///MainPage";
+        }
         else if (element == DAQPageButton)
+        {
+            targetPage = "DAQPage";
             route = "//DAQPage";
+        }
         else if (element == MeshingPageButton)
+        {
+            targetPage = "MeshingPage";
             route = "//MeshingPage";
+        }
         else if (element == ReconstructionPageButton)
+        {
+            targetPage = "ReconstructionPage";
             route = "//ReconstructionPage";
+        }
 
         if (string.IsNullOrEmpty(route) || Shell.Current == null)
         {
@@ -88,15 +110,18 @@ public partial class NavBarControl : ContentView
             return;
         }
 
-        var currentRoute = Shell.Current.CurrentState?.Location?.OriginalString;
-        if (currentRoute != null && new Uri(currentRoute, UriKind.Absolute).AbsolutePath == new Uri(route.TrimStart('/'), UriKind.RelativeOrAbsolute).ToString())
+        if (targetPage == CurrentPageName)
         {
             string warningMessage = $"Already on page: {route}";
-
             System.Diagnostics.Debug.WriteLine(warningMessage);
             Workspace.AddWarningMessage(warningMessage);
             return;
         }
+
+        var current = CurrentPageName;
+
+        // Animate old/new button states
+        await AnimateButtonChangeAsync(current, targetPage);
 
         try
         {
@@ -113,5 +138,48 @@ public partial class NavBarControl : ContentView
             System.Diagnostics.Debug.WriteLine(errorMessage);
             Workspace.AddErrorMessage(errorMessage);
         }
+        finally
+        {
+            // Restore the button state for this page so it remains correct when revisited
+            SetButtonStates(current);
+        }
+    }
+
+    // Performs the unstuck and stuck animations between pages
+    private async Task AnimateButtonChangeAsync(string? oldPage, string? newPage)
+    {
+        var oldBtn = GetButtonForPage(oldPage);
+        var newBtn = GetButtonForPage(newPage);
+
+        if (oldBtn != null)
+        {
+            await oldBtn.ScaleTo(1.0, 50);
+            oldBtn.BackgroundColor = Color.FromRgb(0x55, 0x55, 0x55);
+        }
+
+        if (newBtn != null)
+        {
+            await newBtn.ScaleTo(0.95, 50);
+            newBtn.BackgroundColor = Color.FromRgb(0x44, 0x44, 0x44);
+        }
+    }
+
+    // Resets the CurrentPageName to the page this control is hosted in
+    public void RefreshCurrentPage()
+    {
+        var pageName = GetParentPage()?.GetType().Name;
+        if (!string.IsNullOrEmpty(pageName))
+        {
+            CurrentPageName = pageName;
+            SetButtonStates(pageName);
+        }
+    }
+
+    private Page? GetParentPage()
+    {
+        Element? parent = Parent;
+        while (parent != null && parent is not Page)
+            parent = parent.Parent;
+        return parent as Page;
     }
 }

--- a/ElectricalImpedanceTomography/Views/DAQPage.xaml
+++ b/ElectricalImpedanceTomography/Views/DAQPage.xaml
@@ -38,7 +38,7 @@
 
     </ContentPage.Resources>
     <Grid RowDefinitions="Auto, *, Auto">
-        <controls:NavBarControl Grid.Row="0" CurrentPageName="DAQPage"/>
+        <controls:NavBarControl x:Name="NavBar" Grid.Row="0" CurrentPageName="DAQPage"/>
 
         <CollectionView Grid.Row="1" ItemsSource="{Binding PlotModels}" SelectionMode="None">
             <CollectionView.ItemsLayout>

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml
@@ -24,7 +24,7 @@
     </ContentPage.Resources>
 
     <Grid RowDefinitions="Auto, Auto">
-        <controls:NavBarControl Grid.Row="0" CurrentPageName="MainPage"/>
+        <controls:NavBarControl x:Name="NavBar" Grid.Row="0" CurrentPageName="MainPage"/>
 
         <Grid Grid.Row="1" ColumnDefinitions="400, *, *" RowSpacing="5" ColumnSpacing="5">
 
@@ -88,7 +88,7 @@
                                 <Label Grid.Column="1" Text="Hardware" HorizontalOptions="Center" VerticalOptions="Center"/>
                             </Grid>
                             <Border.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding NavigateCommand}" CommandParameter="DAQPage"/>
+                                <TapGestureRecognizer Tapped="OnNavigationMenuTapped" CommandParameter="DAQPage"/>
                             </Border.GestureRecognizers>
                         </Border>
 
@@ -98,7 +98,7 @@
                                 <Label Grid.Column="1" Text="Meshing" HorizontalOptions="Center" VerticalOptions="Center"/>
                             </Grid>
                             <Border.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding NavigateCommand}" CommandParameter="MeshingPage"/>
+                                <TapGestureRecognizer Tapped="OnNavigationMenuTapped" CommandParameter="MeshingPage"/>
                             </Border.GestureRecognizers>
                         </Border>
 
@@ -108,7 +108,7 @@
                                 <Label Grid.Column="1" Text="Reconstruction" HorizontalOptions="Center" VerticalOptions="Center"/>
                             </Grid>
                             <Border.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding NavigateCommand}" CommandParameter="ReconstructionPage"/>
+                                <TapGestureRecognizer Tapped="OnNavigationMenuTapped" CommandParameter="ReconstructionPage"/>
                             </Border.GestureRecognizers>
                         </Border>
                     </VerticalStackLayout>

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
@@ -173,5 +173,19 @@ namespace ElectricalImpedanceTomography.Views
                 await ConsoleScroll.ScrollToAsync(0, ConsoleStack.Height, false);
             });
         }
+
+        private async void OnNavigationMenuTapped(object sender, TappedEventArgs e)
+        {
+            if (sender is VisualElement v)
+            {
+                await v.ScaleTo(0.95, 50);
+                await v.ScaleTo(1.0, 50);
+            }
+
+            if (e.Parameter is string page)
+            {
+                _viewModel.NavigateCommand.Execute(page);
+            }
+        }
     }
 }

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -50,7 +50,7 @@
         </Style>
     </ContentPage.Resources>
     <Grid RowDefinitions="Auto, *">
-        <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="1" CurrentPageName="MeshingPage"/>
+        <controls:NavBarControl x:Name="NavBar" Grid.Row="0" Grid.ColumnSpan="1" CurrentPageName="MeshingPage"/>
         <Grid Grid.Row="1" ColumnDefinitions="Auto, *, Auto" Margin="5">
 
             <!-- Left control Panel FEM -->

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -33,6 +33,7 @@ public partial class MeshingPage : ContentPage
     private readonly HashSet<int> _selectedCells = [];
     private bool _isDrawing;
     private bool _outlineClosed;
+    private const float PointEpsilon = 5f;
 
     // dragging state
     private LBMElement? _draggedLbmElectrode;
@@ -240,12 +241,12 @@ public partial class MeshingPage : ContentPage
         _viewModel.AddNoiseToMesh();
     }
 
-    private void OnMeshCanvasTouch(object sender, SKTouchEventArgs e)
+    private async void OnMeshCanvasTouch(object sender, SKTouchEventArgs e)
     {
         var mesh = _viewModel.GetCurrentMesh();
         if (mesh == null)
         {
-            HandlePolygonDrawing(e);
+            await HandlePolygonDrawingAsync(e);
             return;
         }
 
@@ -401,7 +402,7 @@ public partial class MeshingPage : ContentPage
     MeshCanvas.InvalidateSurface();
     }
 
-    private void HandlePolygonDrawing(SKTouchEventArgs e)
+    private async Task HandlePolygonDrawingAsync(SKTouchEventArgs e)
     {
         if (e.MouseButton == SKMouseButton.Left && e.ActionType == SKTouchAction.Pressed)
         {
@@ -423,7 +424,18 @@ public partial class MeshingPage : ContentPage
                 }
                 else
                 {
-                    _outlinePoints.Add(e.Location);
+                    bool tooClose = _outlinePoints.Any(p =>
+                        (p.X - e.Location.X) * (p.X - e.Location.X) +
+                        (p.Y - e.Location.Y) * (p.Y - e.Location.Y) <= PointEpsilon * PointEpsilon);
+
+                    if (tooClose)
+                    {
+                        await DisplayAlert("Point Too Close", "Point is too close to another point.", "OK");
+                    }
+                    else
+                    {
+                        _outlinePoints.Add(e.Location);
+                    }
                 }
             }
         }
@@ -538,6 +550,12 @@ public partial class MeshingPage : ContentPage
     private async void OnGenerateClicked(object sender, EventArgs e)
     {
         if (sender is VisualElement v) await ShrinkViewAsync(v);
+        if (_outlinePoints.Count > 0 && !_outlineClosed)
+        {
+            await DisplayAlert("Perimeter Not Closed", "Close the perimeter before generating the mesh.", "OK");
+            return;
+        }
+
         if (_outlineClosed && _outlinePoints.Count > 2)
         {
             var outline = _outlinePoints.ToList();
@@ -562,6 +580,7 @@ public partial class MeshingPage : ContentPage
             _outlinePoints.Clear();
             _outlineClosed = false;
         }
+
         _viewModel.GenerateMesh();
         _viewModel.InvokeMeshChanged();
         MeshCanvas.InvalidateSurface();

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -49,7 +49,7 @@
         </Style>
     </ContentPage.Resources>
     <Grid RowDefinitions="Auto, Auto">
-        <controls:NavBarControl Grid.Row="0" Grid.ColumnSpan="1" CurrentPageName="ReconstructionPage"/>
+        <controls:NavBarControl x:Name="NavBar" Grid.Row="0" Grid.ColumnSpan="1" CurrentPageName="ReconstructionPage"/>
 
         <!-- Main Grid For Page display -->
         <Grid Grid.Row="1" ColumnDefinitions="Auto, *, Auto" ColumnSpacing="10">


### PR DESCRIPTION
## Summary
- Keep all navbar buttons visible and animate switching between pages
- Add tap animations to main page navigation shortcuts
- Validate custom meshing polygons and alert on errors
- Reuse page instances when navigating to preserve state
- Reset navbar state after navigation to avoid incorrect stuck button
- Sync navbar `CurrentPageName` with Shell navigation to avoid stale page indicators

## Testing
- `dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.83 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68c07cf0fcb883339a20d236a9f6c20f