### PR TITLE
Sync meshing edits with workspace mesh

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -193,6 +193,9 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             PushState();
             MeshFactory.AddGaussianNoise(_currentDiscretization);
+
+            Workspace.SetDiscretization(_currentDiscretization);
+            Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
         }
 
         private FEMMesh GenerateFEMMesh()
@@ -244,10 +247,13 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public void RefreshConductivity()
         {
-            if (_currentDiscretization == null) 
+            if (_currentDiscretization == null)
                 return;
             var dict = _currentDiscretization.GetElements().ToDictionary(e => e.Id, e => e.Conductivity);
             _currentDiscretization.SetConductivityDistribution(new ConductivityDistribution(dict));
+
+            Workspace.SetDiscretization(_currentDiscretization);
+            Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
         }
 
         public void RefreshLbmElectrodes()
@@ -259,6 +265,9 @@ namespace ElectricalImpedanceTomography.ViewModels
                 if (el.IsElectrode)
                     electrodes.Add(new LBMElectrode(id++, el.Id, 0.0, 0.0, ElectrodeContactImpedance));
             mesh.SetElectrodes(electrodes);
+
+            Workspace.SetDiscretization(_currentDiscretization);
+            Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
         }
 
         public void RefreshFemElectrodes()
@@ -275,6 +284,9 @@ namespace ElectricalImpedanceTomography.ViewModels
                 electrodes.Add(el);
             }
             mesh.SetElectrodes(electrodes);
+
+            Workspace.SetDiscretization(_currentDiscretization);
+            Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
         }
 
         public void Clear()


### PR DESCRIPTION
## Summary
- Update meshing view model to push edited discretizations to the shared workspace
- Ensure changes to conductivity or electrodes persist when switching to the reconstruction page

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5adf9e4d0833396170238a5310a68