### PR TITLE
Handle zero-mass and excitation electrodes in W2 error metric

### DIFF
--- a/Utility/Classes/ReconstructionParameters/ErrorMetric.cs
+++ b/Utility/Classes/ReconstructionParameters/ErrorMetric.cs
@@ -127,7 +127,20 @@ namespace Utility.Classes.ReconstructionParameters
             double sumA = a.Sum();
             double sumB = b.Sum();
             if (sumA <= Tiny || sumB <= Tiny)
-                throw new ArgumentException("Mass vectors must have positive total mass.");
+            {
+                // Degenerate case: all masses are identical (or arrays are empty),
+                // so after shifting the total mass collapses to ~0.  In this
+                // situation the Wasserstein distance is zero and the gradient
+                // should vanish.  Returning a zero-cost result avoids propagating
+                // an exception to callers which is observed in LBM based
+                // reconstructions where electrodes may carry uniform potentials.
+                int m = a.Length, n = b.Length;
+                return new OTResult(0.0,
+                    new double[m],
+                    new double[m, n],
+                    new double[m],
+                    new double[n]);
+            }
 
             for (int i = 0; i < a.Length; i++) a[i] /= sumA;
             for (int j = 0; j < b.Length; j++) b[j] /= sumB;
@@ -218,8 +231,18 @@ namespace Utility.Classes.ReconstructionParameters
             else
                 throw new ArgumentException("Wasserstein-2 currently implemented for LBMGrid or FEMMesh because it needs electrode coordinates.");
 
-            var (aRaw, aLoc, aMap) = BuildDistribution(simulated, all, coord);
-            var (bRaw, bLoc, _) = BuildDistribution(measured, all, coord);
+            // Determine which electrodes carry valid measurements.  Include
+            // an electrode if the corresponding measured value is finite,
+            // regardless of whether it is flagged as an excitation.  This
+            // allows active-electrode LBM setups where excitation electrodes
+            // also provide measurements.
+            var include = new List<int>();
+            for (int i = 0; i < measured.Length; i++)
+                if (!double.IsNaN(measured[i]))
+                    include.Add(i);
+
+            var (aRaw, aLoc, aMap) = BuildDistribution(simulated, all, coord, include);
+            var (bRaw, bLoc, _) = BuildDistribution(measured, all, coord, include);
 
             if (aRaw.Length == 0 || bRaw.Length == 0)
                 return new OptimalTransportResult(measured, simulated, 0.0, new double[all.Count]);
@@ -233,29 +256,20 @@ namespace Utility.Classes.ReconstructionParameters
         }
 
         private static (double[] raw, (double x, double y)[] loc, List<(int srcIdx, int electrodeIdx)> indexMap)
-            BuildDistribution(double[] raw, List<Electrode> electrodes, Func<Electrode, (double x, double y)> getCoord)
+            BuildDistribution(double[] raw, List<Electrode> electrodes,
+                Func<Electrode, (double x, double y)> getCoord, List<int> include)
         {
-            var vals = new List<double>();
-            var coords = new List<(double, double)>();
-            var map = new List<(int, int)>();
+            var vals = new List<double>(include.Count);
+            var coords = new List<(double, double)>(include.Count);
+            var map = new List<(int, int)>(include.Count);
 
-            // Some calling code does not flag measuring electrodes.  If no
-            // electrode has IsMeasuring=true, treat every electrode as
-            // measuring to avoid returning an empty distribution, which would
-            // yield zero cost and gradient.
-            bool anyMeasuring = electrodes.Any(e => e.IsMeasuring);
-
-            for (int i = 0; i < raw.Length; i++)
+            foreach (int i in include)
             {
-                var e = electrodes[i];
-                
-                if (anyMeasuring && !e.IsMeasuring) 
+                double v = raw[i];
+                if (double.IsNaN(v))
                     continue;
 
-                double v = raw[i];
-                if (double.IsNaN(v)) 
-                    continue;
-                
+                var e = electrodes[i];
                 vals.Add(v);
                 coords.Add(getCoord(e));
                 map.Add((vals.Count - 1, i));

--- a/Utility/Tests/ErrorMetricTests.cs
+++ b/Utility/Tests/ErrorMetricTests.cs
@@ -1,5 +1,7 @@
-﻿using Utility.Classes.ReconstructionParameters;
+﻿using System.Linq;
+using Utility.Classes.ReconstructionParameters;
 using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Xunit;
 
 namespace Utility.Tests
@@ -27,11 +29,33 @@ namespace Utility.Tests
 
         // Optional: W2 is an integration test because it needs LBMGrid + OR-Tools.
         // You can enable this on CI runners that have the dependency available.
-        [Fact(Skip = "Enable when OR-Tools + LBMGrid are wired; this is an integration test.")]
-        public void Wasserstein2_Evaluate_Produces_Finite_Value()
+        [Fact]
+        public void Wasserstein2_LBM_Includes_Excitation_Electrodes()
         {
-            // Arrange a tiny LBMGrid with 4 electrodes and deterministic coordinates,
-            /// TODO: validate W2
+            // Create a small grid with two electrodes.  One electrode is
+            // flagged purely as an excitation (IsMeasuring=false) but still
+            // carries a measured potential.  The W₂ metric should include this
+            // electrode in the transport problem.
+            var grid = new LBMGrid(5, 5);
+            grid.PlaceEquidistantElectrodes(2);
+
+            var els = grid.GetElectrodes().Cast<LBMElectrode>().ToList();
+            els[0].IsExcitation = true;
+            els[0].IsMeasuring = false; // active electrode with measurement
+            els[1].IsMeasuring = true;
+            grid.SetElectrodes(els);
+
+            // Distributions differing on the excitation electrode
+            double[] meas = { 1.0, 0.0 };
+            double[] sim = { 0.0, 1.0 };
+
+            IErrorMetric w2 = new Wasserstein2ErrorMetric();
+            double val = w2.Evaluate(grid, meas, sim);
+            Assert.True(val > 0.0);
+
+            var grad = w2.EvaluateAdjointSource(grid, meas, sim);
+            Assert.Equal(2, grad.Length);
+            Assert.NotEqual(0.0, grad[0], 12); // excitation electrode included
         }
 
         [Fact]

--- a/Utility/Tests/Wasserstein2Tests.cs
+++ b/Utility/Tests/Wasserstein2Tests.cs
@@ -7,6 +7,20 @@ namespace Utility.Tests
     public class Wasserstein2Tests
     {
         [Fact]
+        public void T0_UniformMassesYieldZero()
+        {
+            // When both distributions are uniform the OT problem becomes
+            // degenerate.  The helper should simply return zero cost and
+            // gradient instead of throwing.
+            double[] m = { 5.0, 5.0, 5.0 };
+            double[] d = { 1.0, 1.0, 1.0 };
+            var coords = new (double, double)[] { (0, 0), (1, 0), (2, 0) };
+            var res = Wasserstein2ErrorMetric.w2_misfit_and_grad(m, d, coords, coords);
+            Assert.Equal(0.0, res.Cost, 12);
+            Assert.All(res.Grad, g => Assert.Equal(0.0, g, 9));
+        }
+
+        [Fact]
         public void T1_ExactMatch()
         {
             double[] m = { 1.0, 2.0, 3.0 };


### PR DESCRIPTION
## Summary
- prevent Wasserstein-2 misfit from throwing on zero-mass distributions
- include excitation electrodes that provide measurements when assembling Wasserstein distributions
- add regression tests for uniform masses and active-electrode LBM grids

## Testing
- `dotnet test -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c715f889c88333a0b691d7400787de