### PR TITLE
feat: enhance Adam optimizer with weight decay and stability

### DIFF
--- a/Utility/Classes/ReconstructionParameters/NumericOptimizer.cs
+++ b/Utility/Classes/ReconstructionParameters/NumericOptimizer.cs
@@ -103,15 +103,29 @@
     /// </summary>
     public sealed class AdamGradientOptimizer : INumericOptimizer
     {
-        private readonly double _beta1 = 0.9;
-        private readonly double _beta2 = 0.999;
-        private readonly double _eps = 1e-8;
+        private readonly double _beta1;
+        private readonly double _beta2;
+        private readonly double _eps;
+        private readonly double _weightDecay;
+        private readonly double? _maxGradNorm;
+
         private int _t = 0;
         private Dictionary<int, double>? _m;  // 1st moment
         private Dictionary<int, double>? _v;  // 2nd moment
 
-        public AdamGradientOptimizer()
+        public AdamGradientOptimizer(
+            double beta1 = 0.9,
+            double beta2 = 0.999,
+            double epsilon = 1e-8,
+            double weightDecay = 0.0,
+            double? maxGradientNorm = null)
         {
+            _beta1 = beta1;
+            _beta2 = beta2;
+            _eps = epsilon;
+            _weightDecay = weightDecay;
+            _maxGradNorm = maxGradientNorm;
+
             _m = null;
             _v = null;
         }
@@ -126,12 +140,36 @@
             }
             _t++;
 
+            // optional gradient clipping by global norm
+            double scale = 1.0;
+            if (_maxGradNorm.HasValue)
+            {
+                double norm = Math.Sqrt(totalGradient.Conductivities.Sum(kv => kv.Value * kv.Value));
+                if (norm > _maxGradNorm.Value && norm > 0)
+                {
+                    scale = _maxGradNorm.Value / norm;
+                }
+            }
+
             var newSigma = new Dictionary<int, double>();
             foreach (var kv in currentSigma.Conductivities)
             {
                 int id = kv.Key;
                 double conductivity = kv.Value;
-                double gradient = totalGradient.GetConductivity(id);
+                double gradient = totalGradient.GetConductivity(id) * scale;
+
+                if (!double.IsFinite(gradient))
+                {
+                    // skip update on invalid gradient
+                    newSigma[id] = conductivity;
+                    continue;
+                }
+
+                // decoupled weight decay (AdamW)
+                if (_weightDecay != 0.0)
+                {
+                    conductivity -= stepSize * _weightDecay * conductivity;
+                }
 
                 // update biased moments
                 double m_prev = _m[id];
@@ -146,8 +184,15 @@
                 double m_hat = m_new / (1 - Math.Pow(_beta1, _t));
                 double v_hat = v_new / (1 - Math.Pow(_beta2, _t));
 
+                double denom = Math.Sqrt(v_hat) + _eps;
+                if (!double.IsFinite(denom) || denom == 0.0)
+                {
+                    newSigma[id] = conductivity;
+                    continue;
+                }
+
                 // update σ
-                double σn = conductivity - stepSize * m_hat / (Math.Sqrt(v_hat) + _eps);
+                double σn = conductivity - stepSize * m_hat / denom;
                 newSigma[id] = σn;
             }
             return new ConductivityDistribution(newSigma);

--- a/Utility/Tests/NumericOptimizerTests.cs
+++ b/Utility/Tests/NumericOptimizerTests.cs
@@ -39,12 +39,35 @@ namespace Utility.Tests
         [Fact]
         public void Adam_Moves_Against_Gradient()
         {
-            var opt = new AdamGradientOptimizer(); 
+            var opt = new AdamGradientOptimizer();
             var σ = TestData.Sigma((0, 1.0));
             var g = TestData.Grad((0, 1.0));
 
             var σ1 = opt.OptimizationStep(σ, g, 0.1);
             Assert.True(σ1.GetConductivity(0) < 1.0);
+        }
+
+        [Fact]
+        public void AdamW_Applies_Weight_Decay()
+        {
+            var opt = new AdamGradientOptimizer(weightDecay: 0.1);
+            var σ = TestData.Sigma((0, 1.0));
+            var g = TestData.Grad((0, 0.0));
+
+            var σ1 = opt.OptimizationStep(σ, g, 0.1); // only weight decay
+            Assert.Equal(0.99, σ1.GetConductivity(0), 12);
+        }
+
+        [Fact]
+        public void Adam_Clips_Gradient_By_Global_Norm()
+        {
+            var opt = new AdamGradientOptimizer(maxGradientNorm: 1.0);
+            var σ = TestData.Sigma((0, 1.0), (1, 1.0));
+            var g = TestData.Grad((0, 3.0), (1, 4.0)); // norm = 5
+
+            var σ1 = opt.OptimizationStep(σ, g, 0.1);
+            Assert.Equal(0.9, σ1.GetConductivity(0), 12);
+            Assert.Equal(0.9, σ1.GetConductivity(1), 12);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- add configurable Adam optimizer with optional weight decay and gradient clipping
- guard against invalid gradients and denominator issues
- expand unit tests for Adam weight decay and clipping

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e37f56188333b91e22d13ff73923