### PR TITLE
Ensure optimizers keep conductivity positive

### DIFF
--- a/Utility/Classes/ReconstructionParameters/NumericOptimizer.cs
+++ b/Utility/Classes/ReconstructionParameters/NumericOptimizer.cs
@@ -59,6 +59,8 @@
     public sealed class PolyakHeavyBallOptimizer : INumericOptimizer
     {
         private readonly double _beta;
+        private readonly double _min = 1e-6;
+        private readonly double _max = 10.0;
         // store velocity per element
         private Dictionary<int, double>? _velocity;
 
@@ -88,6 +90,7 @@
                 double v_new = _beta * v_prev - stepSize * gradient;
                 // σ_new = σ + v_new
                 double nextValue = conductivity + v_new;
+                nextValue = Math.Max(_min, Math.Min(_max, nextValue));
 
                 nextVel[id] = v_new;
                 nextSigma[id] = nextValue;
@@ -108,6 +111,8 @@
         private readonly double _eps;
         private readonly double _weightDecay;
         private readonly double? _maxGradNorm;
+        private readonly double _min = 1e-6;
+        private readonly double _max = 10.0;
 
         private int _t = 0;
         private Dictionary<int, double>? _m;  // 1st moment
@@ -193,6 +198,7 @@
 
                 // update σ
                 double σn = conductivity - stepSize * m_hat / denom;
+                σn = Math.Max(_min, Math.Min(_max, σn));
                 newSigma[id] = σn;
             }
             return new ConductivityDistribution(newSigma);
@@ -206,6 +212,8 @@
     public sealed class NesterovAcceleratedGradientOptimizer : INumericOptimizer
     {
         private readonly double _gamma;
+        private readonly double _min = 1e-6;
+        private readonly double _max = 10.0;
         private Dictionary<int, double>? _prevSigma;
 
         public NesterovAcceleratedGradientOptimizer(double gamma = 0.9)
@@ -238,6 +246,7 @@
                 double yv = kv.Value;
                 double gradient = totalGradient.GetConductivity(id);
                 double nextValue = yv - stepSize * gradient;
+                nextValue = Math.Max(_min, Math.Min(_max, nextValue));
                 nextSigma[id] = nextValue;
             }
 
@@ -373,14 +382,25 @@
     {
         private double _temperature = 1.0;
         private readonly double _cooling = 0.95;
-        private readonly Random _rnd = new Random();
+        private readonly Random _rnd;
+        private readonly double _min = 1e-6;
+        private readonly double _max = 10.0;
+
+        public SimulatedAnnealingOptimizer(Random? random = null)
+        {
+            _rnd = random ?? new Random();
+        }
 
         public ConductivityDistribution OptimizationStep(ConductivityDistribution sigmaK, ConductivityDistribution totalGradient, double stepSize)
         {
             // propose Δσ uniform in [-stepSize,stepSize]
             var σp = new Dictionary<int, double>();
             foreach (var kv in sigmaK.Conductivities)
-                σp[kv.Key] = kv.Value + (2 * _rnd.NextDouble() - 1) * stepSize;
+            {
+                double proposal = kv.Value + (2 * _rnd.NextDouble() - 1) * stepSize;
+                proposal = Math.Max(_min, Math.Min(_max, proposal));
+                σp[kv.Key] = proposal;
+            }
 
             // approximate ΔJ = ∑g_i Δσ_i
             double dJ = 0;

--- a/Utility/Tests/NumericOptimizerTests.cs
+++ b/Utility/Tests/NumericOptimizerTests.cs
@@ -4,6 +4,11 @@ using Xunit;
 
 namespace Utility.Tests
 {
+    internal sealed class ZeroRandom : Random
+    {
+        protected override double Sample() => 0.0;
+    }
+
     public class NumericOptimizerTests
     {
         [Fact]
@@ -34,6 +39,17 @@ namespace Utility.Tests
 
             var σ2 = opt.OptimizationStep(σ1, g, 0.1); // v2 = 0.5*(-0.1) - 0.1*1 = -0.15, σ2=0.75
             Assert.Equal(0.75, σ2.GetConductivity(0), 12);
+        }
+
+        [Fact]
+        public void PolyakHeavyBall_Clamps_Negative()
+        {
+            var opt = new PolyakHeavyBallOptimizer();
+            var σ = TestData.Sigma((0, 1.0));
+            var g = TestData.Grad((0, 5.0));
+
+            var σ1 = opt.OptimizationStep(σ, g, 1.0);
+            Assert.Equal(1e-6, σ1.GetConductivity(0), 12);
         }
 
         [Fact]
@@ -71,6 +87,17 @@ namespace Utility.Tests
         }
 
         [Fact]
+        public void Adam_Clamps_Negative()
+        {
+            var opt = new AdamGradientOptimizer();
+            var σ = TestData.Sigma((0, 1.0));
+            var g = TestData.Grad((0, 2.0));
+
+            var σ1 = opt.OptimizationStep(σ, g, 2.0);
+            Assert.Equal(1e-6, σ1.GetConductivity(0), 12);
+        }
+
+        [Fact]
         public void Nesterov_Uses_PrevSigma()
         {
             var opt = new NesterovAcceleratedGradientOptimizer(gamma: 0.9);
@@ -83,6 +110,17 @@ namespace Utility.Tests
         }
 
         [Fact]
+        public void Nesterov_Clamps_Negative()
+        {
+            var opt = new NesterovAcceleratedGradientOptimizer();
+            var σ = TestData.Sigma((0, 1.0));
+            var g = TestData.Grad((0, 5.0));
+
+            var σ1 = opt.OptimizationStep(σ, g, 1.0);
+            Assert.Equal(1e-6, σ1.GetConductivity(0), 12);
+        }
+
+        [Fact]
         public void SimulatedAnnealing_Is_Idempotent_When_Step_Is_Zero()
         {
             var opt = new SimulatedAnnealingOptimizer();
@@ -92,6 +130,17 @@ namespace Utility.Tests
             var σ1 = opt.OptimizationStep(σ0, g, 0.0);
             Assert.Equal(1.0, σ1.GetConductivity(0), 12);
             Assert.Equal(2.0, σ1.GetConductivity(1), 12);
+        }
+
+        [Fact]
+        public void SimulatedAnnealing_Clamps_Negative()
+        {
+            var opt = new SimulatedAnnealingOptimizer(new ZeroRandom());
+            var σ0 = TestData.Sigma((0, 1.0));
+            var g = TestData.Grad((0, 0.0));
+
+            var σ1 = opt.OptimizationStep(σ0, g, 2.0);
+            Assert.Equal(1e-6, σ1.GetConductivity(0), 12);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Clamp conductivity updates in Polyak Heavy Ball, Adam, Nesterov, and Simulated Annealing optimizers to physical bounds
- Allow Simulated Annealing optimizer to accept a seeded random instance
- Extend numeric optimizer tests to verify clamping behavior across optimizers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c815bf03548333bf1b9dee1961c093