### PR TITLE
Preserve original LBM grid for reconstruction

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -142,7 +142,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             _currentDiscretization = _undoStack.Pop();
 
             Workspace.SetDiscretization(_currentDiscretization);
-            Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
 
             MeshChanged?.Invoke();
         }
@@ -157,7 +156,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             _currentDiscretization = _redoStack.Pop();
 
             Workspace.SetDiscretization(_currentDiscretization);
-            Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
 
             MeshChanged?.Invoke();
         }
@@ -195,7 +193,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             MeshFactory.AddGaussianNoise(_currentDiscretization);
 
             Workspace.SetDiscretization(_currentDiscretization);
-            Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
         }
 
         private FEMMesh GenerateFEMMesh()
@@ -253,7 +250,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             _currentDiscretization.SetConductivityDistribution(new ConductivityDistribution(dict));
 
             Workspace.SetDiscretization(_currentDiscretization);
-            Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
         }
 
         public void RefreshLbmElectrodes()
@@ -267,7 +263,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             mesh.SetElectrodes(electrodes);
 
             Workspace.SetDiscretization(_currentDiscretization);
-            Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
         }
 
         public void RefreshFemElectrodes()
@@ -286,7 +281,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             mesh.SetElectrodes(electrodes);
 
             Workspace.SetDiscretization(_currentDiscretization);
-            Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
         }
 
         public void Clear()
@@ -362,7 +356,6 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             _currentDiscretization.Metadata.Parameters["electrodeCount"] = value.ToString();
             Workspace.SetDiscretization(_currentDiscretization);
-            Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
             MeshChanged?.Invoke();
         }
 

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -14,7 +14,7 @@ namespace ElectricalImpedanceTomography.ViewModels
     {
         private readonly IReconstructionService _reconstructionService;
 
-        private IDiscretization? _discretization = Workspace.GetDiscretization();
+        private IDiscretization? _discretization = Workspace.GetOriginalDiscretization();
         private IDiscretization? _initializedDiscretization;
 
         [ObservableProperty]
@@ -53,7 +53,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         }
 
         partial void OnReconstructionSearchTextChanged(string value) => ApplyReconstructionFilter();
-        private void UpdateMesh() => _discretization = Workspace.GetDiscretization();
+        private void UpdateMesh() => _discretization = Workspace.GetOriginalDiscretization();
         private void UpdateReconstructionParameters() => ReconstructionParameters = Workspace.GetReconstructionParameters();
 
         private void InitializeReconstruction(bool force = false)

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -110,7 +110,7 @@ namespace ServiceLayer
             try
             {
                 Workspace.AddLogMessage("Reconstruction Service", "Reconstruction initialization started with the specified EITReconstructionParameters object.");
-                Workspace.SetDiscretization(discretization);
+                Workspace.SetInitialDiscretization(discretization);
                 _discretization = discretization;
                 _simulatedMeasurements.Clear();
                 _simMeasurementIndex = 0;
@@ -120,7 +120,7 @@ namespace ServiceLayer
 
                 Workspace.SetReconstructionResults(new List<ReconstructionResult>());
 
-                _originalSigma = Workspace.GetOriginalDiscretization()?.GetConductivityDistribution()
+                _originalSigma = Workspace.GetDiscretization()?.GetConductivityDistribution()
                                  ?? discretization.DeepCopy().GetConductivityDistribution();
                 _initialSigma = Workspace.GetInitialDiscretization()?.GetConductivityDistribution() ?? ConductivityDistributionFactory.CreateInitialDistribution(discretization, parameters.InitialDistributionType);
                 discretization.SetConductivityDistribution(_initialSigma);


### PR DESCRIPTION
## Summary
- keep a deep copy of the generated or loaded LBM grid as the reconstruction starting point
- avoid overwriting the original grid when editing walls, conductivity, or electrodes
- initialize reconstruction using the preserved grid while using the edited grid as the target

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c82940d8088333a0669937e9bf521c