### PR TITLE
Add reconstruction metrics panel

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -1,10 +1,13 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Maui.ApplicationModel;
 using ServiceLayer;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Timers;
 using Utility.Classes;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
-using System.Collections.ObjectModel;
 
 using Workspace = Utility.Classes.Application.Workspace;
 
@@ -14,6 +17,9 @@ namespace ElectricalImpedanceTomography.ViewModels
     {
         private readonly IReconstructionService _reconstructionService;
 
+        private readonly Stopwatch _reconstructionStopwatch = new();
+        private readonly Timer _elapsedTimer;
+
         private IDiscretization? _discretization = Workspace.GetDiscretization();
         private IDiscretization? _initializedDiscretization;
 
@@ -22,6 +28,12 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         [ObservableProperty]
         private double residual = 1.0;
+
+        [ObservableProperty]
+        private TimeSpan elapsedTime = TimeSpan.Zero;
+
+        [ObservableProperty]
+        private double correlation = 0.0;
 
         [ObservableProperty]
         private bool adjecentDrivePattern = true;
@@ -37,6 +49,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public ObservableCollection<ReconstructionInfo> AvailableReconstructions { get; } = [];
         public ObservableCollection<ReconstructionInfo> FilteredReconstructions { get; } = [];
+        public ObservableCollection<double> ResidualHistory { get; } = [];
 
         public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
         public event EventHandler<ReconstructionFrame>? ReconstructionFrameUpdated;
@@ -45,11 +58,74 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             _reconstructionService = reconstructionService;
 
+            _elapsedTimer = new Timer(200)
+            {
+                AutoReset = true,
+                Enabled = false
+            };
+
+            _elapsedTimer.Elapsed += (_, _) =>
+            {
+                if (!_reconstructionStopwatch.IsRunning)
+                    return;
+
+                MainThread.BeginInvokeOnMainThread(() => ElapsedTime = _reconstructionStopwatch.Elapsed);
+            };
+
             // Use global reconstruction parameters stored in the workspace
             ReconstructionParameters = Workspace.GetReconstructionParameters();
 
             _reconstructionService.ReconstructionUpdated += OnServiceReconstructionUpdated;
             _reconstructionService.ReconstructionFrameUpdated += OnServiceFrameUpdated;
+        }
+
+        public void PrepareForNewReconstruction()
+        {
+            InitializeReconstruction(force: true);
+            ResetReconstructionMetrics();
+        }
+
+        public void ResetReconstructionMetrics()
+        {
+            ResidualHistory.Clear();
+            Residual = 0.0;
+            Correlation = 0.0;
+            ElapsedTime = TimeSpan.Zero;
+            _reconstructionStopwatch.Reset();
+            StopElapsedTimer();
+        }
+
+        public void BeginReconstructionMetrics()
+        {
+            if (!_reconstructionStopwatch.IsRunning)
+                _reconstructionStopwatch.Start();
+
+            StartElapsedTimer();
+        }
+
+        public void PauseReconstructionMetrics()
+        {
+            if (_reconstructionStopwatch.IsRunning)
+            {
+                _reconstructionStopwatch.Stop();
+                ElapsedTime = _reconstructionStopwatch.Elapsed;
+            }
+
+            StopElapsedTimer();
+        }
+
+        public void StopReconstructionMetrics() => PauseReconstructionMetrics();
+
+        private void StartElapsedTimer()
+        {
+            if (!_elapsedTimer.Enabled)
+                _elapsedTimer.Start();
+        }
+
+        private void StopElapsedTimer()
+        {
+            if (_elapsedTimer.Enabled)
+                _elapsedTimer.Stop();
         }
 
         partial void OnReconstructionSearchTextChanged(string value) => ApplyReconstructionFilter();
@@ -101,11 +177,20 @@ namespace ElectricalImpedanceTomography.ViewModels
         public async void OnSolveInverseClicked(object sender, EventArgs e)
         {
             InitializeReconstruction(force: true);
+            ResetReconstructionMetrics();
+            BeginReconstructionMetrics();
 
-            if (_discretization is FEMMesh)
-                await Task.Run(() => _reconstructionService.InverseSolveFem(MaxIterationCount, StepSize, RegularizationWeight, ExcitationCurrentAmplitude));
-            else if (_discretization is LBMGrid)
-                await Task.Run(() => _reconstructionService.InverseSolveLbm(MaxIterationCount, StepSize, RegularizationWeight, ExcitationCurrentAmplitude));
+            try
+            {
+                if (_discretization is FEMMesh)
+                    await Task.Run(() => _reconstructionService.InverseSolveFem(MaxIterationCount, StepSize, RegularizationWeight, ExcitationCurrentAmplitude));
+                else if (_discretization is LBMGrid)
+                    await Task.Run(() => _reconstructionService.InverseSolveLbm(MaxIterationCount, StepSize, RegularizationWeight, ExcitationCurrentAmplitude));
+            }
+            finally
+            {
+                PauseReconstructionMetrics();
+            }
         }
 
         private double CalculateResidual(ConductivityDistribution reconstructed, ConductivityDistribution original)
@@ -120,41 +205,109 @@ namespace ElectricalImpedanceTomography.ViewModels
             return Math.Sqrt(sum);
         }
 
+        private double CalculateCorrelation(ConductivityDistribution reconstructed, ConductivityDistribution original)
+        {
+            if (reconstructed.Conductivities.Count == 0)
+                return 0.0;
+
+            double sumReconstructed = 0.0;
+            double sumOriginal = 0.0;
+            foreach (var kv in reconstructed.Conductivities)
+            {
+                sumReconstructed += kv.Value;
+                original.Conductivities.TryGetValue(kv.Key, out double origVal);
+                sumOriginal += origVal;
+            }
+
+            int count = reconstructed.Conductivities.Count;
+            double meanReconstructed = sumReconstructed / count;
+            double meanOriginal = sumOriginal / count;
+
+            double numerator = 0.0;
+            double sumSqReconstructed = 0.0;
+            double sumSqOriginal = 0.0;
+            foreach (var kv in reconstructed.Conductivities)
+            {
+                original.Conductivities.TryGetValue(kv.Key, out double origVal);
+                double centeredReconstructed = kv.Value - meanReconstructed;
+                double centeredOriginal = origVal - meanOriginal;
+                numerator += centeredReconstructed * centeredOriginal;
+                sumSqReconstructed += centeredReconstructed * centeredReconstructed;
+                sumSqOriginal += centeredOriginal * centeredOriginal;
+            }
+
+            double denominator = Math.Sqrt(sumSqReconstructed * sumSqOriginal);
+            if (denominator < 1e-12)
+                return 0.0;
+
+            return numerator / denominator;
+        }
+
         public void StartBackgroundReconstruction()
         {
             InitializeReconstruction(force: true);
+            ResetReconstructionMetrics();
+            BeginReconstructionMetrics();
             _reconstructionService.StartBackgroundReconstruction(MaxIterationCount, StepSize, RegularizationWeight, ExcitationCurrentAmplitude);
         }
 
-        public void PauseReconstruction() => _reconstructionService.PauseBackgroundReconstruction();
-        public void ResumeReconstruction() => _reconstructionService.ResumeBackgroundReconstruction();
+        public void PauseReconstruction()
+        {
+            _reconstructionService.PauseBackgroundReconstruction();
+            PauseReconstructionMetrics();
+        }
+
+        public void ResumeReconstruction()
+        {
+            _reconstructionService.ResumeBackgroundReconstruction();
+            BeginReconstructionMetrics();
+        }
 
         public void StopReconstruction()
         {
             _reconstructionService.StopBackgroundReconstruction();
+            StopReconstructionMetrics();
             _initializedDiscretization = null;
         }
 
-        public Task<ReconstructionFrame?> StepReconstructionAsync()
+        public async Task<ReconstructionFrame?> StepReconstructionAsync()
         {
             InitializeReconstruction();
-            return _reconstructionService.StepReconstructionAsync();
+            BeginReconstructionMetrics();
+            try
+            {
+                return await _reconstructionService.StepReconstructionAsync();
+            }
+            finally
+            {
+                PauseReconstructionMetrics();
+            }
         }
 
         public Task<ReconstructionResult?> RunFullReconstructionCycleAsync()
         {
             InitializeReconstruction();
+            BeginReconstructionMetrics();
             return _reconstructionService.RunFullReconstructionCycleAsync(StepSize,
-                                                                          RegularizationWeight,
-                                                                          ExcitationCurrentAmplitude);
+                                                                         RegularizationWeight,
+                                                                         ExcitationCurrentAmplitude);
         }
 
         private void OnServiceReconstructionUpdated(object? sender, ReconstructionResult result)
         {
-            IterationCount++;
-            Residual = CalculateResidual(result.ReconstructedConductivityDistribution,
-                                         result.OriginalConductivityDistribution);
-            ReconstructionUpdated?.Invoke(this, result);
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                IterationCount++;
+                Residual = CalculateResidual(result.ReconstructedConductivityDistribution,
+                                             result.OriginalConductivityDistribution);
+                Correlation = CalculateCorrelation(result.ReconstructedConductivityDistribution,
+                                                    result.OriginalConductivityDistribution);
+
+                ResidualHistory.Add(Residual);
+                ElapsedTime = _reconstructionStopwatch.Elapsed;
+
+                ReconstructionUpdated?.Invoke(this, result);
+            });
         }
 
         private void OnServiceFrameUpdated(object? sender, ReconstructionFrame frame)

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -321,32 +321,49 @@
                     </Grid>
                 </Grid>
             </Grid>
-            <Border Grid.Column="2" StrokeShape="RoundRectangle 5" Margin="5" WidthRequest="250" HorizontalOptions="End">
-                <VerticalStackLayout Margin="2" Spacing="10">
-                    <Label Text="Past Reconstructions" HorizontalOptions="Center"/>
-                    <SearchBar Placeholder="Search" Text="{Binding ReconstructionSearchText}" Margin="5"/>
-                    <Border StrokeShape="RoundRectangle 10">
-                        <ScrollView>
-                            <VerticalStackLayout Spacing="2" BindableLayout.ItemsSource="{Binding FilteredReconstructions}">
-                                <BindableLayout.ItemTemplate>
-                                    <DataTemplate x:DataType="models:ReconstructionInfo">
-                                        <Border StrokeShape="RoundRectangle 5" Padding="4" Stroke="Transparent">
-                                            <Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto, Auto, Auto" ColumnSpacing="5">
-                                                <Label Grid.Column="0" Grid.Row="0" Text="{Binding Name}" FontAttributes="Bold" FontSize="Small"/>
-                                                <Label Grid.Column="0" Grid.Row="1" Text="{Binding Metadata.CreatedOn, StringFormat='Saved: {0:G}'}" FontSize="10"/>
-                                                <Label Grid.Column="0" Grid.Row="2" Text="{Binding ParameterSummary}" FontSize="10"/>
-                                            </Grid>
-                                            <Border.GestureRecognizers>
-                                                <TapGestureRecognizer Tapped="OnReconstructionSelected"/>
-                                            </Border.GestureRecognizers>
-                                        </Border>
-                                    </DataTemplate>
-                                </BindableLayout.ItemTemplate>
-                            </VerticalStackLayout>
-                        </ScrollView>
-                    </Border>
-                </VerticalStackLayout>
-            </Border>
+            <Grid Grid.Column="2" RowDefinitions="*, Auto" RowSpacing="10" Margin="5" WidthRequest="250" HorizontalOptions="End">
+                <Border Grid.Row="0" StrokeShape="RoundRectangle 5">
+                    <VerticalStackLayout Margin="2" Spacing="10">
+                        <Label Text="Past Reconstructions" HorizontalOptions="Center"/>
+                        <SearchBar Placeholder="Search" Text="{Binding ReconstructionSearchText}" Margin="5"/>
+                        <Border StrokeShape="RoundRectangle 10">
+                            <ScrollView>
+                                <VerticalStackLayout Spacing="2" BindableLayout.ItemsSource="{Binding FilteredReconstructions}">
+                                    <BindableLayout.ItemTemplate>
+                                        <DataTemplate x:DataType="models:ReconstructionInfo">
+                                            <Border StrokeShape="RoundRectangle 5" Padding="4" Stroke="Transparent">
+                                                <Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto, Auto, Auto" ColumnSpacing="5">
+                                                    <Label Grid.Column="0" Grid.Row="0" Text="{Binding Name}" FontAttributes="Bold" FontSize="Small"/>
+                                                    <Label Grid.Column="0" Grid.Row="1" Text="{Binding Metadata.CreatedOn, StringFormat='Saved: {0:G}'}" FontSize="10"/>
+                                                    <Label Grid.Column="0" Grid.Row="2" Text="{Binding ParameterSummary}" FontSize="10"/>
+                                                </Grid>
+                                                <Border.GestureRecognizers>
+                                                    <TapGestureRecognizer Tapped="OnReconstructionSelected"/>
+                                                </Border.GestureRecognizers>
+                                            </Border>
+                                        </DataTemplate>
+                                    </BindableLayout.ItemTemplate>
+                                </VerticalStackLayout>
+                            </ScrollView>
+                        </Border>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border Grid.Row="1" StrokeShape="RoundRectangle 5">
+                    <VerticalStackLayout Margin="10" Spacing="6">
+                        <Label Text="Reconstruction Statistics" HorizontalOptions="Center" FontAttributes="Italic"/>
+                        <Label Text="{Binding ElapsedTime, StringFormat='Elapsed Time: {0:hh\\:mm\\:ss}'}" FontSize="12"/>
+                        <Label Text="{Binding Residual, StringFormat='Current Residual: {0:F3}'}" FontSize="12"/>
+                        <Label Text="{Binding Correlation, StringFormat='Correlation: {0:F3}'}" FontSize="12"/>
+                        <Label Text="Residual vs. Iteration" HorizontalOptions="Center" FontSize="12"/>
+                        <Border StrokeShape="RoundRectangle 5" Padding="4" BackgroundColor="#1E1E1E">
+                            <skia:SKCanvasView x:Name="ResidualTrendCanvas"
+                                              HeightRequest="120"
+                                              PaintSurface="OnResidualTrendCanvasPaintSurface"/>
+                        </Border>
+                    </VerticalStackLayout>
+                </Border>
+            </Grid>
         </Grid>
     </Grid>
 </ContentPage>

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -1,8 +1,10 @@
 using CommunityToolkit.Maui.Views;
 using ElectricalImpedanceTomography.ViewModels;
+using Microsoft.Maui.ApplicationModel;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
 using SkiaSharp.Views.Maui.Controls;
+using System.Collections.Specialized;
 using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Discretizer;
@@ -55,6 +57,7 @@ public partial class ReconstructionPage : ContentPage
 
         _viewModel.ReconstructionUpdated += OnReconstructionUpdated;
         _viewModel.ReconstructionFrameUpdated += OnReconstructionFrameUpdated;
+        _viewModel.ResidualHistory.CollectionChanged += OnResidualHistoryChanged;
 
         StepButton.IsEnabled = false;
         PlayButton.IsVisible = true;
@@ -103,18 +106,26 @@ public partial class ReconstructionPage : ContentPage
         PlayButton.IsEnabled = false;
         _isPaused = false;
 
-        int iterations = _viewModel.MaxIterationCount;
-        for (int i = 0; i < iterations; i++)
-        {
-            await _viewModel.RunFullReconstructionCycleAsync();
-        }
-        //await _viewModel.RunFullReconstructionCycleAsync();
+        _viewModel.PrepareForNewReconstruction();
+        _viewModel.BeginReconstructionMetrics();
 
-        _isPaused = true;
-        StepButton.IsEnabled = true;
-        PlayerBackButton.IsEnabled = true;
-        PlayerForwardButton.IsEnabled = true;
-        PlayButton.IsEnabled = true;
+        int iterations = _viewModel.MaxIterationCount;
+        try
+        {
+            for (int i = 0; i < iterations; i++)
+            {
+                await _viewModel.RunFullReconstructionCycleAsync();
+            }
+        }
+        finally
+        {
+            _viewModel.PauseReconstructionMetrics();
+            _isPaused = true;
+            StepButton.IsEnabled = true;
+            PlayerBackButton.IsEnabled = true;
+            PlayerForwardButton.IsEnabled = true;
+            PlayButton.IsEnabled = true;
+        }
     }
 
     private async void OnPauseButtonClicked(object sender, EventArgs e)
@@ -218,6 +229,9 @@ public partial class ReconstructionPage : ContentPage
             UpdatePlaybackLabel();
         });
     }
+
+    private void OnResidualHistoryChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        => MainThread.BeginInvokeOnMainThread(() => ResidualTrendCanvas.InvalidateSurface());
 
     #region Drawing helpers
     private void ComputeFemTransform(FEMMesh mesh, SKImageInfo info)
@@ -424,6 +438,90 @@ public partial class ReconstructionPage : ContentPage
     #endregion
 
     #region Canvas paint
+    private void OnResidualTrendCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    {
+        var canvas = e.Surface.Canvas;
+        canvas.Clear(SKColor.Parse("#1E1E1E"));
+
+        var history = _viewModel.ResidualHistory;
+        if (history.Count == 0)
+        {
+            using var emptyPaint = new SKPaint { Color = SKColors.Gray, TextSize = 14, IsAntialias = true };
+            const string message = "No residual data";
+            float textWidth = emptyPaint.MeasureText(message);
+            canvas.DrawText(message,
+                            (e.Info.Width - textWidth) / 2f,
+                            e.Info.Height / 2f,
+                            emptyPaint);
+            return;
+        }
+
+        double minResidual = double.MaxValue;
+        double maxResidual = double.MinValue;
+        foreach (double value in history)
+        {
+            if (value < minResidual) minResidual = value;
+            if (value > maxResidual) maxResidual = value;
+        }
+
+        if (Math.Abs(maxResidual - minResidual) < 1e-12)
+            maxResidual = minResidual + 1e-12;
+
+        const float leftPadding = 40f;
+        const float rightPadding = 10f;
+        const float topPadding = 10f;
+        const float bottomPadding = 25f;
+
+        float chartWidth = e.Info.Width - leftPadding - rightPadding;
+        float chartHeight = e.Info.Height - topPadding - bottomPadding;
+        if (chartWidth <= 0 || chartHeight <= 0)
+            return;
+
+        using var axisPaint = new SKPaint { Color = SKColors.Gray, StrokeWidth = 1, IsAntialias = true };
+        using var textPaint = new SKPaint { Color = SKColors.White, TextSize = 12, IsAntialias = true, TextAlign = SKTextAlign.Right };
+        using var linePaint = new SKPaint { Color = SKColors.DeepSkyBlue, StrokeWidth = 2, IsAntialias = true, Style = SKPaintStyle.Stroke };
+        using var pointPaint = new SKPaint { Color = SKColors.CornflowerBlue, IsAntialias = true };
+
+        var origin = new SKPoint(leftPadding, topPadding + chartHeight);
+        var xAxisEnd = new SKPoint(leftPadding + chartWidth, origin.Y);
+        var yAxisEnd = new SKPoint(leftPadding, topPadding);
+        canvas.DrawLine(origin, xAxisEnd, axisPaint);
+        canvas.DrawLine(origin, yAxisEnd, axisPaint);
+
+        textPaint.TextAlign = SKTextAlign.Right;
+        canvas.DrawText(maxResidual.ToString("F3"), leftPadding - 4, topPadding + textPaint.TextSize / 2f, textPaint);
+        canvas.DrawText(minResidual.ToString("F3"), leftPadding - 4, origin.Y, textPaint);
+
+        int count = history.Count;
+        float step = count > 1 ? chartWidth / (count - 1) : 0f;
+        var path = new SKPath();
+        for (int i = 0; i < count; i++)
+        {
+            double residual = history[i];
+            float x = leftPadding + (count > 1 ? step * i : chartWidth / 2f);
+            double normalized = (residual - minResidual) / (maxResidual - minResidual);
+            float y = topPadding + chartHeight * (float)(1 - normalized);
+
+            if (i == 0)
+                path.MoveTo(x, y);
+            else
+                path.LineTo(x, y);
+
+            canvas.DrawCircle(x, y, 3f, pointPaint);
+        }
+
+        canvas.DrawPath(path, linePaint);
+
+        textPaint.TextAlign = SKTextAlign.Center;
+        float labelY = origin.Y + textPaint.TextSize + 4f;
+        canvas.DrawText("1", leftPadding, labelY, textPaint);
+        canvas.DrawText(count.ToString(), leftPadding + chartWidth, labelY, textPaint);
+        canvas.DrawText("Iteration", leftPadding + chartWidth / 2f, e.Info.Height - 4f, textPaint);
+
+        textPaint.TextAlign = SKTextAlign.Right;
+        canvas.DrawText("Residual", leftPadding - 6f, topPadding - 2f, textPaint);
+    }
+
     private void OnOriginalCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
         _currentResult ??= Workspace.GetReconstructionResults().LastOrDefault();


### PR DESCRIPTION
## Summary
- track elapsed time, residual history, and correlation in the reconstruction view-model and reset metrics on new runs
- add a right-side statistics panel with elapsed time, residual, correlation, and a residual history sparkline
- update UI logic to manage metric timing and redraw the residual history chart when data changes

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c87c168bc88333830e244dbadd8699