### PR TITLE
Align main UI pages with reconstruction styling

### DIFF
--- a/ElectricalImpedanceTomography/App.xaml
+++ b/ElectricalImpedanceTomography/App.xaml
@@ -8,6 +8,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+                <ResourceDictionary Source="Resources/Styles/PanelStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/ElectricalImpedanceTomography/Resources/Styles/PanelStyles.xaml
+++ b/ElectricalImpedanceTomography/Resources/Styles/PanelStyles.xaml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xaml-comp compile="true" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+
+    <Color x:Key="PageBackgroundColor">GhostWhite</Color>
+
+    <LinearGradientBrush x:Key="ConfigurationPanelBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="#232E45" Offset="0" />
+        <GradientStop Color="#161D2C" Offset="1" />
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="ControlPanelBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="#1E273B" Offset="0" />
+        <GradientStop Color="#101624" Offset="1" />
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="PartialResultsBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="#202A3F" Offset="0" />
+        <GradientStop Color="#121923" Offset="1" />
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="FullResultsBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="#1C2638" Offset="0" />
+        <GradientStop Color="#0F151F" Offset="1" />
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="HistoryPanelBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="#222E45" Offset="0" />
+        <GradientStop Color="#141B28" Offset="1" />
+    </LinearGradientBrush>
+    <LinearGradientBrush x:Key="StatisticsPanelBrush" StartPoint="0,0" EndPoint="0,1">
+        <GradientStop Color="#1E2435" Offset="0" />
+        <GradientStop Color="#111723" Offset="1" />
+    </LinearGradientBrush>
+
+    <Style x:Key="PanelBorderStyle" TargetType="Border">
+        <Setter Property="StrokeShape" Value="RoundRectangle 12" />
+        <Setter Property="StrokeThickness" Value="1.5" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="Stroke">
+            <Setter.Value>
+                <SolidColorBrush Color="#3A7CA5" />
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Shadow">
+            <Setter.Value>
+                <Shadow Brush="#883A7CA5" Offset="0,4" Radius="12" Opacity="0.45" />
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="PanelSectionBorderStyle" TargetType="Border">
+        <Setter Property="StrokeShape" Value="RoundRectangle 10" />
+        <Setter Property="StrokeThickness" Value="0" />
+        <Setter Property="Padding" Value="12" />
+        <Setter Property="BackgroundColor" Value="#242F47" />
+    </Style>
+
+    <Style x:Key="CanvasBorderStyle" TargetType="Border">
+        <Setter Property="StrokeShape" Value="RoundRectangle 12" />
+        <Setter Property="StrokeThickness" Value="1" />
+        <Setter Property="Stroke" Value="Transparent" />
+        <Setter Property="Padding" Value="10" />
+        <Setter Property="BackgroundColor" Value="#1A2436" />
+        <Setter Property="Shadow">
+            <Setter.Value>
+                <Shadow Brush="#663A7CA5" Offset="0,6" Radius="14" Opacity="0.5" />
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/ElectricalImpedanceTomography/Views/DAQPage.xaml
+++ b/ElectricalImpedanceTomography/Views/DAQPage.xaml
@@ -9,94 +9,96 @@
              xmlns:controls="clr-namespace:ElectricalImpedanceTomography.Controls"
              x:DataType="viewmodels:DAQPageViewModel"
              Shell.NavBarIsVisible="False"
-             Title="DAQPage">
+             Title="DAQPage"
+             BackgroundColor="{StaticResource PageBackgroundColor}">
     <ContentPage.Resources>
-        <Style x:Key="CardFrameStyle" TargetType="Border">
-            <Setter Property="Padding" Value="10"/>
-            <Setter Property="BackgroundColor" Value="White"/>
-            <Setter Property="Margin" Value="5"/>
-        </Style>
-
-        <Style x:Key="CardTitleStyle" TargetType="Label">
-            <Setter Property="FontSize" Value="Medium"/>
+        <Style TargetType="Label">
             <Setter Property="FontFamily" Value="SF Pro Text"/>
             <Setter Property="FontAttributes" Value="Bold"/>
-            <Setter Property="HorizontalOptions" Value="Center"/>
-            <Setter Property="TextColor" Value="Black"/>
+            <Setter Property="TextColor" Value="#F0F4FF"/>
         </Style>
-
-        <Style x:Key="ControlButtonStyle" TargetType="Button">
-            <Setter Property="FontSize" Value="20"/>
+        <Style TargetType="Button">
+            <Setter Property="FontSize" Value="18"/>
             <Setter Property="FontFamily" Value="SF Pro Text"/>
             <Setter Property="FontAttributes" Value="Bold"/>
-            <Setter Property="HorizontalOptions" Value="Center"/>
-            <Setter Property="VerticalOptions" Value="Center"/>
-            <Setter Property="CornerRadius" Value="5"/>
-            <Setter Property="IsEnabled" Value="True"/>
-            <Setter Property="MinimumWidthRequest" Value="100"/>
+            <Setter Property="TextColor" Value="#F7FBFF"/>
+            <Setter Property="CornerRadius" Value="12"/>
+            <Setter Property="Padding" Value="18,12"/>
+            <Setter Property="BackgroundColor" Value="#3A7CA5"/>
         </Style>
-
     </ContentPage.Resources>
-    <Grid RowDefinitions="Auto, *, Auto">
-        <controls:NavBarControl x:Name="NavBar" Grid.Row="0" CurrentPageName="DAQPage"/>
 
-        <CollectionView Grid.Row="1" ItemsSource="{Binding PlotModels}" SelectionMode="None">
-            <CollectionView.ItemsLayout>
-                <GridItemsLayout Orientation="Vertical" Span="4"
-                              VerticalItemSpacing="10"
-                              HorizontalItemSpacing="10"/>
-            </CollectionView.ItemsLayout>
-            <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="oxyplot:PlotModel">
-                    <VerticalStackLayout Spacing="2" Padding="5" BackgroundColor="Transparent">
-                        <Border Style="{StaticResource CardFrameStyle}">
+    <Grid RowDefinitions="Auto, *, Auto">
+        <controls:NavBarControl x:Name="NavBar"
+                                Grid.Row="0"
+                                CurrentPageName="DAQPage"/>
+
+        <Border Grid.Row="1"
+                Style="{StaticResource PanelBorderStyle}"
+                Margin="24,12,24,12"
+                Background="{StaticResource PartialResultsBrush}">
+            <CollectionView ItemsSource="{Binding PlotModels}" SelectionMode="None"
+                            Margin="16">
+                <CollectionView.Header>
+                    <Label Text="Channel Monitoring"
+                           FontSize="Large"
+                           HorizontalOptions="Center"
+                           Margin="0,0,0,16"
+                           TextColor="#F7FBFF"/>
+                </CollectionView.Header>
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout Orientation="Vertical"
+                                  Span="4"
+                                  VerticalItemSpacing="14"
+                                  HorizontalItemSpacing="14"/>
+                </CollectionView.ItemsLayout>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="oxyplot:PlotModel">
+                        <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                Padding="16"
+                                BackgroundColor="#1F2B44">
                             <oxy:PlotView Model="{Binding .}"
-                                          HeightRequest="150"
-                                          MinimumWidthRequest="100">
+                                          HeightRequest="160"
+                                          MinimumWidthRequest="120">
                                 <oxy:PlotView.GestureRecognizers>
-                                    <TapGestureRecognizer
-                                        NumberOfTapsRequired="1"
-                                        Buttons="Secondary"
-                                        Command="{Binding Source={x:Reference Page}, Path=BindingContext.ConfigureChannelCommand}"
-                                        CommandParameter="{Binding .}" />
+                                    <TapGestureRecognizer NumberOfTapsRequired="1"
+                                                          Buttons="Secondary"
+                                                          Command="{Binding Source={x:Reference Page}, Path=BindingContext.ConfigureChannelCommand}"
+                                                          CommandParameter="{Binding .}" />
                                 </oxy:PlotView.GestureRecognizers>
                             </oxy:PlotView>
-                            <Border.Shadow>
-                                <Shadow Brush="Gray" Opacity="1.0" Radius="1.0" Offset="1.0, 1.0"/>
-                            </Border.Shadow>
                         </Border>
-                    </VerticalStackLayout>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
-            <CollectionView.Margin>10</CollectionView.Margin>
-        </CollectionView>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </Border>
 
-        <Grid Grid.Row="2"
-              ColumnDefinitions="Auto, Auto"
-              HorizontalOptions="Center"
-              VerticalOptions="Center"
-              ColumnSpacing="10"
-              Padding="10">
-            <Button Grid.Column="0" 
-                    Style="{StaticResource ControlButtonStyle}"
-                    Text="Stop" 
-                    Clicked="OnStopButtonPressed" 
-                    BackgroundColor="PaleVioletRed"
-                    BorderColor="Transparent">
-                <Button.Shadow>
-                    <Shadow Brush="PaleVioletRed" Opacity="1.0" Radius="2.0" />
-                </Button.Shadow>
-            </Button>
-            <Button Grid.Column="1" 
-                    Style="{StaticResource ControlButtonStyle}"
-                    Text="Start" 
-                    Clicked="OnStartButtonPressed" 
-                    Background="LightGreen"
-                    BorderColor="Transparent">
-                <Button.Shadow>
-                    <Shadow Brush="LightGreen" Opacity="1.0" Radius="2.0"/>
-                </Button.Shadow>
-            </Button>
-        </Grid>
+        <Border Grid.Row="2"
+                Style="{StaticResource PanelBorderStyle}"
+                Margin="24,0,24,24"
+                Background="{StaticResource ControlPanelBrush}">
+            <Grid ColumnDefinitions="Auto, Auto"
+                  HorizontalOptions="Center"
+                  VerticalOptions="Center"
+                  ColumnSpacing="20"
+                  Padding="20">
+                <Button Grid.Column="0"
+                        Text="Stop"
+                        Clicked="OnStopButtonPressed"
+                        BackgroundColor="#C23C3C">
+                    <Button.Shadow>
+                        <Shadow Brush="#C23C3C" Opacity="0.75" Radius="12" />
+                    </Button.Shadow>
+                </Button>
+                <Button Grid.Column="1"
+                        Text="Start"
+                        Clicked="OnStartButtonPressed"
+                        BackgroundColor="#2F9E9C">
+                    <Button.Shadow>
+                        <Shadow Brush="#2F9E9C" Opacity="0.75" Radius="12"/>
+                    </Button.Shadow>
+                </Button>
+            </Grid>
+        </Border>
     </Grid>
 </ContentPage>

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml
@@ -9,37 +9,82 @@
              xmlns:skia="clr-namespace:SkiaSharp.Views.Maui.Controls;assembly=SkiaSharp.Views.Maui.Controls"
              x:DataType="viewmodels:MainPageViewModel"
              Shell.NavBarIsVisible="False"
-             Title="MainPage">
+             Title="MainPage"
+             BackgroundColor="{StaticResource PageBackgroundColor}">
     <ContentPage.Resources>
         <Style TargetType="Label">
             <Setter Property="FontFamily" Value="SF Pro Text"/>
+            <Setter Property="FontAttributes" Value="Bold"/>
+            <Setter Property="TextColor" Value="#F0F4FF"/>
         </Style>
         <Style TargetType="Picker">
             <Setter Property="FontFamily" Value="SF Pro Text"/>
+            <Setter Property="TextColor" Value="#F0F4FF"/>
+            <Setter Property="TitleColor" Value="#9DAAD3"/>
+            <Setter Property="BackgroundColor" Value="Transparent"/>
         </Style>
         <Style TargetType="Button">
             <Setter Property="FontFamily" Value="SF Pro Text"/>
+            <Setter Property="FontAttributes" Value="Bold"/>
+            <Setter Property="TextColor" Value="#F7FBFF"/>
+            <Setter Property="BackgroundColor" Value="#3A7CA5"/>
+            <Setter Property="CornerRadius" Value="10"/>
+            <Setter Property="Padding" Value="14,8"/>
+        </Style>
+        <Style TargetType="Entry">
+            <Setter Property="FontFamily" Value="SF Pro Text"/>
+            <Setter Property="TextColor" Value="#F0F4FF"/>
+            <Setter Property="PlaceholderColor" Value="#6F84AE"/>
+            <Setter Property="BackgroundColor" Value="Transparent"/>
+        </Style>
+        <Style TargetType="ImageButton">
+            <Setter Property="BackgroundColor" Value="Transparent"/>
+            <Setter Property="BorderColor" Value="Transparent"/>
         </Style>
         <converters:MessageTypeToColorConverter x:Key="MessageTypeToColorConverter"/>
     </ContentPage.Resources>
 
-    <Grid RowDefinitions="Auto, Auto">
-        <controls:NavBarControl x:Name="NavBar" Grid.Row="0" CurrentPageName="MainPage"/>
+    <Grid RowDefinitions="Auto, *">
+        <controls:NavBarControl x:Name="NavBar"
+                                Grid.Row="0"
+                                CurrentPageName="MainPage"/>
 
-        <Grid Grid.Row="1" ColumnDefinitions="400, *, *" RowSpacing="5" ColumnSpacing="5">
+        <Grid Grid.Row="1"
+              Margin="24,12,24,24"
+              ColumnDefinitions="360, *, 420"
+              ColumnSpacing="24"
+              RowSpacing="0">
 
-            <VerticalStackLayout Grid.Column="0" Spacing="10" Padding="10">
-                <Border StrokeShape="RoundRectangle 3">
-                    <VerticalStackLayout Spacing="3">
-                        <Grid ColumnDefinitions="Auto, *" ColumnSpacing="5" Margin="5">
-                            <Image Grid.Column="0" Source="icon_hardware4.png" HeightRequest="20"/>
-                            <Label Grid.Column="1" Text="Hardware Info" FontAttributes="Italic" FontSize="Medium" />
+            <!-- Left column with hardware, navigation and quick actions -->
+            <VerticalStackLayout Grid.Column="0"
+                                  Spacing="20">
+                <Border Style="{StaticResource PanelBorderStyle}"
+                        Background="{StaticResource ConfigurationPanelBrush}">
+                    <VerticalStackLayout Margin="20"
+                                          Spacing="12">
+                        <Grid ColumnDefinitions="Auto, *"
+                              ColumnSpacing="12">
+                            <Image Grid.Column="0"
+                                   Source="icon_hardware4.png"
+                                   HeightRequest="30"/>
+                            <Label Grid.Column="1"
+                                   Text="Hardware Info"
+                                   FontAttributes="Italic"
+                                   FontSize="Medium"
+                                   TextColor="#F7FBFF"/>
                         </Grid>
-                        <Label Margin="5" Text="{Binding CurrentAmplitude, StringFormat='Current amplitude: {0:F2} mA'}"/>
-                        <Label Margin="5" Text="{Binding ExcitationFrequency, StringFormat='Excitation frequency: {0:F0} kHz'}"/>
-                        <Grid ColumnDefinitions="Auto, Auto, Auto" ColumnSpacing="5" Margin="5">
-                            <Label Text="Connection Status: "/>
-                            <Image Grid.Column="1" HeightRequest="15">
+                        <Label Text="{Binding CurrentAmplitude, StringFormat='Current amplitude: {0:F2} mA'}"
+                               TextColor="#C9D7F2"/>
+                        <Label Text="{Binding ExcitationFrequency, StringFormat='Excitation frequency: {0:F0} kHz'}"
+                               TextColor="#C9D7F2"/>
+                        <Grid ColumnDefinitions="Auto, Auto, *"
+                              ColumnSpacing="8"
+                              VerticalOptions="Center">
+                            <Label Text="Connection Status: "
+                                   TextColor="#9DAAD3"
+                                   FontAttributes="None"/>
+                            <Image Grid.Column="1"
+                                   HeightRequest="16">
                                 <Image.Triggers>
                                     <DataTrigger TargetType="Image"
                                                  Binding="{Binding HardwareStatusColor}"
@@ -53,184 +98,308 @@
                                     </DataTrigger>
                                 </Image.Triggers>
                             </Image>
-                            <Label Grid.Column="2" Text="{Binding HardwareConnectionText}" TextColor="{Binding HardwareStatusColor}"/>
+                            <Label Grid.Column="2"
+                                   Text="{Binding HardwareConnectionText}"
+                                   TextColor="{Binding HardwareStatusColor}"
+                                   FontAttributes="None"/>
                         </Grid>
-                        <Button Clicked="OnConnectButtonClicked" Margin="10" BorderColor="Transparent">
+                        <Button Clicked="OnConnectButtonClicked"
+                                Margin="0,6,0,0"
+                                BorderColor="Transparent">
                             <Button.Triggers>
                                 <DataTrigger TargetType="Button"
                                              Binding="{Binding HardwareConnected}"
                                              Value="True">
                                     <Setter Property="Text" Value="Disconnect"/>
-                                    <Setter Property="BackgroundColor" Value="Red"/>
+                                    <Setter Property="BackgroundColor" Value="#C23C3C"/>
                                 </DataTrigger>
                                 <DataTrigger TargetType="Button"
                                              Binding="{Binding HardwareConnected}"
                                              Value="False">
                                     <Setter Property="Text" Value="Connect"/>
-                                    <Setter Property="BackgroundColor" Value="#00A000"/>
+                                    <Setter Property="BackgroundColor" Value="#2F9E9C"/>
                                 </DataTrigger>
                             </Button.Triggers>
                         </Button>
                     </VerticalStackLayout>
                 </Border>
 
-                <!-- Navigation Menu-->
-                <Border Stroke="Gray" StrokeThickness="1" Padding="10" StrokeShape="RoundRectangle 3">
-                    <VerticalStackLayout Spacing="8">
-                        <Grid ColumnDefinitions="Auto, *" ColumnSpacing="5">
-                            <Image Grid.Column="0" Source="icon_navigation.png" HeightRequest="20"/>
-                            <Label Grid.Column="1" Text="Navigation" FontAttributes="Italic" FontSize="Medium"/>
+                <!-- Navigation Menu -->
+                <Border Style="{StaticResource PanelBorderStyle}"
+                        Background="{StaticResource ControlPanelBrush}">
+                    <VerticalStackLayout Spacing="16"
+                                          Margin="20">
+                        <Grid ColumnDefinitions="Auto, *"
+                              ColumnSpacing="12">
+                            <Image Grid.Column="0"
+                                   Source="icon_navigation.png"
+                                   HeightRequest="26"/>
+                            <Label Grid.Column="1"
+                                   Text="Navigation"
+                                   FontAttributes="Italic"
+                                   FontSize="Medium"
+                                   TextColor="#F7FBFF"/>
                         </Grid>
 
-                        <Border StrokeShape="RoundRectangle 5" Background="#1A1A1A" Padding="3">
-                            <Grid ColumnDefinitions="Auto, Auto" ColumnSpacing="5" HorizontalOptions="Center">
-                                <Image Grid.Column="0" Source="icon_hardware.png" BackgroundColor="Transparent" HeightRequest="30" WidthRequest="30"/>
-                                <Label Grid.Column="1" Text="Hardware" HorizontalOptions="Center" VerticalOptions="Center"/>
+                        <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                Padding="10"
+                                BackgroundColor="#293756">
+                            <Grid ColumnDefinitions="Auto, *"
+                                  ColumnSpacing="10"
+                                  HorizontalOptions="Center"
+                                  VerticalOptions="Center">
+                                <Image Grid.Column="0"
+                                       Source="icon_hardware.png"
+                                       HeightRequest="32"
+                                       WidthRequest="32"/>
+                                <Label Grid.Column="1"
+                                       Text="Hardware"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="Center"
+                                       FontAttributes="None"/>
                             </Grid>
                             <Border.GestureRecognizers>
-                                <TapGestureRecognizer Tapped="OnNavigationMenuTapped" CommandParameter="DAQPage"/>
+                                <TapGestureRecognizer Tapped="OnNavigationMenuTapped"
+                                                       CommandParameter="DAQPage"/>
                             </Border.GestureRecognizers>
                         </Border>
 
-                        <Border StrokeShape="RoundRectangle 5" Background="#1A1A1A" Padding="3">
-                            <Grid ColumnDefinitions="Auto, Auto" ColumnSpacing="5" HorizontalOptions="Center">
-                                <Image Grid.Column="0" Source="icon_mesh2.png" BackgroundColor="Transparent" HeightRequest="30" WidthRequest="30"/>
-                                <Label Grid.Column="1" Text="Meshing" HorizontalOptions="Center" VerticalOptions="Center"/>
+                        <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                Padding="10"
+                                BackgroundColor="#25324A">
+                            <Grid ColumnDefinitions="Auto, *"
+                                  ColumnSpacing="10"
+                                  HorizontalOptions="Center"
+                                  VerticalOptions="Center">
+                                <Image Grid.Column="0"
+                                       Source="icon_mesh2.png"
+                                       HeightRequest="32"
+                                       WidthRequest="32"/>
+                                <Label Grid.Column="1"
+                                       Text="Meshing"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="Center"
+                                       FontAttributes="None"/>
                             </Grid>
                             <Border.GestureRecognizers>
-                                <TapGestureRecognizer Tapped="OnNavigationMenuTapped" CommandParameter="MeshingPage"/>
+                                <TapGestureRecognizer Tapped="OnNavigationMenuTapped"
+                                                       CommandParameter="MeshingPage"/>
                             </Border.GestureRecognizers>
                         </Border>
 
-                        <Border StrokeShape="RoundRectangle 5" Background="#1A1A1A" Padding="3">
-                            <Grid ColumnDefinitions="Auto, Auto" ColumnSpacing="5" HorizontalOptions="Center">
-                                <Image Grid.Column="0" Source="icon_reconstruction3.png" BackgroundColor="Transparent" HeightRequest="28" WidthRequest="28"/>
-                                <Label Grid.Column="1" Text="Reconstruction" HorizontalOptions="Center" VerticalOptions="Center"/>
+                        <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                Padding="10"
+                                BackgroundColor="#22304A">
+                            <Grid ColumnDefinitions="Auto, *"
+                                  ColumnSpacing="10"
+                                  HorizontalOptions="Center"
+                                  VerticalOptions="Center">
+                                <Image Grid.Column="0"
+                                       Source="icon_reconstruction3.png"
+                                       HeightRequest="30"
+                                       WidthRequest="30"/>
+                                <Label Grid.Column="1"
+                                       Text="Reconstruction"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="Center"
+                                       FontAttributes="None"/>
                             </Grid>
                             <Border.GestureRecognizers>
-                                <TapGestureRecognizer Tapped="OnNavigationMenuTapped" CommandParameter="ReconstructionPage"/>
+                                <TapGestureRecognizer Tapped="OnNavigationMenuTapped"
+                                                       CommandParameter="ReconstructionPage"/>
                             </Border.GestureRecognizers>
                         </Border>
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Stroke="LightGray" StrokeThickness="1" Padding="10" StrokeShape="RoundRectangle 3">
-                    <VerticalStackLayout Spacing="6">
-                        <Grid ColumnDefinitions="Auto, *" ColumnSpacing="5">
-                            <Image Grid.Column="0" Source="icon_configuration.png" HeightRequest="20" />
-                            <Label Grid.Column="1" Text="Configuration" FontAttributes="Italic" FontSize="Medium"/>
+                <Border Style="{StaticResource PanelBorderStyle}"
+                        Background="{StaticResource PartialResultsBrush}">
+                    <VerticalStackLayout Margin="20"
+                                          Spacing="14">
+                        <Grid ColumnDefinitions="Auto, *"
+                              ColumnSpacing="12">
+                            <Image Grid.Column="0"
+                                   Source="icon_configuration.png"
+                                   HeightRequest="28"/>
+                            <Label Grid.Column="1"
+                                   Text="Configuration"
+                                   FontAttributes="Italic"
+                                   FontSize="Medium"
+                                   TextColor="#F7FBFF"/>
                         </Grid>
-                        <Picker Title="Solver" ItemsSource="{Binding Solvers}" SelectedItem="{Binding ReconstructionParameters.DifferentialEquationSolver}"/>
-                        <Picker Title="Regularization" ItemsSource="{Binding Regularizations}" SelectedItem="{Binding ReconstructionParameters.RegularizationTechnique}"/>
-                        <Picker Title="Error Metric" ItemsSource="{Binding ErrorMetrics}" SelectedItem="{Binding ReconstructionParameters.ErrorMetric}"/>
-                        <Picker Title="Numeric Optimizer" ItemsSource="{Binding NumericOptimizers}" SelectedItem="{Binding ReconstructionParameters.NumericOptimizer}"/>
-                        <Picker Title="Numeric Solver" ItemsSource="{Binding NumericSolvers}" SelectedItem="{Binding ReconstructionParameters.NumericSolver}"/>
+                        <Picker Title="Solver"
+                                ItemsSource="{Binding Solvers}"
+                                SelectedItem="{Binding ReconstructionParameters.DifferentialEquationSolver}"/>
+                        <Picker Title="Regularization"
+                                ItemsSource="{Binding Regularizations}"
+                                SelectedItem="{Binding ReconstructionParameters.RegularizationTechnique}"/>
+                        <Picker Title="Error Metric"
+                                ItemsSource="{Binding ErrorMetrics}"
+                                SelectedItem="{Binding ReconstructionParameters.ErrorMetric}"/>
+                        <Picker Title="Numeric Optimizer"
+                                ItemsSource="{Binding NumericOptimizers}"
+                                SelectedItem="{Binding ReconstructionParameters.NumericOptimizer}"/>
+                        <Picker Title="Numeric Solver"
+                                ItemsSource="{Binding NumericSolvers}"
+                                SelectedItem="{Binding ReconstructionParameters.NumericSolver}"/>
                     </VerticalStackLayout>
                 </Border>
-                <Border Stroke="LightGray" StrokeThickness="1" Padding="10" StrokeShape="RoundRectangle 3">
-                    <VerticalStackLayout Spacing="6">
-                        <Grid ColumnDefinitions="Auto, *" ColumnSpacing="5">
-                            <Image Grid.Column="0" Source="icon_loading.png" HeightRequest="20"/>
-                            <Label Grid.Column="1" Text="Toolbox" FontAttributes="Italic" FontSize="Medium"/>
+
+                <Border Style="{StaticResource PanelBorderStyle}"
+                        Background="{StaticResource HistoryPanelBrush}">
+                    <VerticalStackLayout Margin="20"
+                                          Spacing="14">
+                        <Grid ColumnDefinitions="Auto, *"
+                              ColumnSpacing="12">
+                            <Image Grid.Column="0"
+                                   Source="icon_loading.png"
+                                   HeightRequest="26"/>
+                            <Label Grid.Column="1"
+                                   Text="Toolbox"
+                                   FontAttributes="Italic"
+                                   FontSize="Medium"
+                                   TextColor="#F7FBFF"/>
                         </Grid>
-                        <Button Text="Load Measurement" Clicked="OnLoadMeasurementClicked"/>
-                        <Button Text="Load Mesh" Clicked="OnLoadMeshClicked"/>
+                        <Button Text="Load Measurement"
+                                Clicked="OnLoadMeasurementClicked"
+                                BackgroundColor="#2F9E9C"/>
+                        <Button Text="Load Mesh"
+                                Clicked="OnLoadMeshClicked"
+                                BackgroundColor="#3A7CA5"/>
                     </VerticalStackLayout>
                 </Border>
             </VerticalStackLayout>
 
-            <!-- Middle Panel -->
-            <Grid Grid.Column="1" RowDefinitions="Auto,*,Auto" RowSpacing="10">
-                <Border Grid.Row="0" Margin="5" StrokeShape="RoundRectangle 5" Stroke="Transparent">
-                    <VerticalStackLayout Spacing="5">
-                        <Label Text="{Binding User.Name, StringFormat='Welcome {0}!'}" FontSize="Large" FontAttributes="Bold" FontFamily="SF Pro Display" VerticalOptions="Center" HorizontalOptions="Center"/>
+            <!-- Middle column with welcome, orb and console -->
+            <Grid Grid.Column="1"
+                  RowDefinitions="Auto, Auto, *"
+                  RowSpacing="20">
+                <Border Grid.Row="0"
+                        Style="{StaticResource PanelBorderStyle}"
+                        Background="{StaticResource ControlPanelBrush}">
+                    <VerticalStackLayout Margin="20"
+                                          Spacing="6"
+                                          HorizontalOptions="Center">
+                        <Label Text="{Binding User.Name, StringFormat='Welcome {0}!'}"
+                               FontSize="Large"
+                               TextColor="#F7FBFF"
+                               FontFamily="SF Pro Display"/>
+                        <Label Text="Manage your workflow from the panels below"
+                               FontSize="Small"
+                               FontAttributes="None"
+                               TextColor="#9DAAD3"/>
                     </VerticalStackLayout>
-                    <Border.Shadow>
-                        <Shadow Brush="Gray" Opacity="0.5" Radius="3.0"/>
-                    </Border.Shadow>
                 </Border>
 
-                <controls:ImpedanceOrbView Grid.Row="1"
-                                           Margin="10"
-                                           Model="{Binding CurrentImpedanceModel}"
-                                           HeightRequest="175"
-                                           WidthRequest="175"
-                                           HorizontalOptions="Center"
-                                           VerticalOptions="Center"/>
+                <Border Grid.Row="1"
+                        Style="{StaticResource PanelBorderStyle}"
+                        Background="{StaticResource HistoryPanelBrush}">
+                    <controls:ImpedanceOrbView Margin="30"
+                                               Model="{Binding CurrentImpedanceModel}"
+                                               HeightRequest="175"
+                                               WidthRequest="175"
+                                               HorizontalOptions="Center"
+                                               VerticalOptions="Center"/>
+                </Border>
 
-                <Border Grid.Row="2" Stroke="LightGray" StrokeThickness="1" Padding="10" StrokeShape="RoundRectangle 3" HeightRequest="400" VerticalOptions="Start" BackgroundColor="{AppThemeBinding Light=White, Dark=#1F1F1F}">
-                    <Grid RowDefinitions="Auto,*,Auto" RowSpacing="2">
-                        <Grid Grid.Row="0" ColumnDefinitions="Auto, Auto" ColumnSpacing="5">
-                            <Image Grid.Column="0" Source="icon_terminal2.png" HeightRequest="20" BackgroundColor="Transparent"/>
-                            <Label Grid.Column="1" Text="Console" FontAttributes="Italic" FontSize="Medium"/>
+                <Border Grid.Row="2"
+                        Style="{StaticResource PanelBorderStyle}"
+                        Background="{StaticResource FullResultsBrush}">
+                    <Grid RowDefinitions="Auto,*,Auto"
+                          RowSpacing="12"
+                          Margin="20">
+                        <Grid Grid.Row="0"
+                              ColumnDefinitions="Auto, Auto"
+                              ColumnSpacing="10">
+                            <Image Grid.Column="0"
+                                   Source="icon_terminal2.png"
+                                   HeightRequest="26"/>
+                            <Label Grid.Column="1"
+                                   Text="Console"
+                                   FontAttributes="Italic"
+                                   FontSize="Medium"
+                                   TextColor="#F7FBFF"/>
                         </Grid>
-                        <ScrollView x:Name="ConsoleScroll" Grid.Row="1">
-                            <VerticalStackLayout x:Name="ConsoleStack" Spacing="2"
+                        <ScrollView x:Name="ConsoleScroll"
+                                    Grid.Row="1"
+                                    Padding="0">
+                            <VerticalStackLayout x:Name="ConsoleStack"
+                                                 Spacing="8"
                                                  BindableLayout.ItemsSource="{Binding DebugLog}">
                                 <BindableLayout.ItemTemplate>
                                     <DataTemplate x:DataType="messages:WorkspaceMessage">
-                                        <Border StrokeShape="RoundRectangle 5" Padding="4" Stroke="Transparent">
-                                            <Grid ColumnDefinitions="Auto, *" ColumnSpacing="5">
-                                                <Label Grid.Column="0" 
+                                        <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                                BackgroundColor="#1E293D"
+                                                Padding="10">
+                                            <Grid ColumnDefinitions="Auto, *"
+                                                  ColumnSpacing="10">
+                                                <Label Grid.Column="0"
                                                        Text="{Binding Time, StringFormat='[{0:HH:mm:ss}] >>'}"
-                                                       FontFamily="Consolas" 
-                                                       TextColor="{AppThemeBinding Light=Black, Dark=White}"/>
-                                                <Label Grid.Column="1" 
+                                                       FontFamily="Consolas"
+                                                       FontAttributes="None"
+                                                       TextColor="#9DAAD3"/>
+                                                <Label Grid.Column="1"
                                                        Text="{Binding Message}"
                                                        FontFamily="Consolas"
                                                        LineBreakMode="WordWrap"
-                                                       TextColor="{Binding Type,
-                                                       Converter={StaticResource MessageTypeToColorConverter},
-                                                       ConverterParameter={AppThemeBinding Light=White, Dark=#1A1A1A}}"/>
+                                                       TextColor="{Binding Type, Converter={StaticResource MessageTypeToColorConverter}}"/>
                                             </Grid>
                                         </Border>
                                     </DataTemplate>
                                 </BindableLayout.ItemTemplate>
                             </VerticalStackLayout>
                         </ScrollView>
-                        <Grid Grid.Row="2" ColumnDefinitions="*,Auto" ColumnSpacing="5" Margin="5">
+                        <Grid Grid.Row="2"
+                              ColumnDefinitions="*,Auto"
+                              ColumnSpacing="12">
                             <Entry Grid.Column="0"
                                    Text="{Binding ConsoleInput}"
                                    FontFamily="Consolas"
-                                   Completed="OnConsoleEntryCompleted"/>
-                            <ImageButton Grid.Column="1"                                         
-                                         HeightRequest="20"
+                                   Placeholder="Enter command"
+                                   Completed="OnConsoleEntryCompleted"
+                                   BackgroundColor="#1B2335"/>
+                            <ImageButton Grid.Column="1"
+                                         HeightRequest="28"
+                                         WidthRequest="28"
                                          Source="icon_next_blue.png"
-                                         BackgroundColor="Transparent"
                                          Command="{Binding SendConsoleMessageCommand}"/>
                         </Grid>
                     </Grid>
                 </Border>
             </Grid>
 
-            <!-- Mesh Visualizer -->
-            <Grid Grid.Column="2" RowDefinitions="Auto, Auto" HorizontalOptions="Center" VerticalOptions="Center" RowSpacing="5">
-                <Label Grid.Row="0" 
-                       Text="Mesh Preview" 
-                       HorizontalOptions="Center" 
-                       FontAttributes="Italic" 
-                       FontSize="Medium" 
-                       VerticalOptions="End"/>
-                <Border Grid.Row="1"
-                        Margin="10"
-                        HeightRequest="400"
-                        WidthRequest="400"
-                        StrokeThickness="2"
-                        StrokeShape="RoundRectangle 10"
-                        HorizontalOptions="Center"
-                        VerticalOptions="Center">
-
-                    <skia:SKCanvasView x:Name="MeshCanvasView"
-                                       BackgroundColor="Transparent"
-                                       Margin="10"
-                                       PaintSurface="OnCanvasViewPaintSurface"
-                                       HeightRequest="370"
-                                       WidthRequest="370"/>
-                    <Border.Shadow>
-                        <Shadow Brush="White" Opacity="0.5" Radius="3.0"/>
-                    </Border.Shadow>
-                </Border>
-            </Grid>
+            <!-- Right column with mesh preview -->
+            <Border Grid.Column="2"
+                    Style="{StaticResource PanelBorderStyle}"
+                    Background="{StaticResource StatisticsPanelBrush}">
+                <VerticalStackLayout Margin="20"
+                                      Spacing="16"
+                                      HorizontalOptions="Center">
+                    <Grid ColumnDefinitions="Auto, *"
+                          ColumnSpacing="12"
+                          HorizontalOptions="Center">
+                        <Image Grid.Column="0"
+                               Source="icon_mesh2.png"
+                               HeightRequest="28"/>
+                        <Label Grid.Column="1"
+                               Text="Mesh Preview"
+                               FontAttributes="Italic"
+                               FontSize="Medium"
+                               TextColor="#F7FBFF"/>
+                    </Grid>
+                    <Border Style="{StaticResource CanvasBorderStyle}"
+                            HeightRequest="400"
+                            WidthRequest="400"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                        <skia:SKCanvasView x:Name="MeshCanvasView"
+                                           BackgroundColor="Transparent"
+                                           PaintSurface="OnCanvasViewPaintSurface"
+                                           HeightRequest="360"
+                                           WidthRequest="360"/>
+                    </Border>
+                </VerticalStackLayout>
+            </Border>
         </Grid>
     </Grid>
 </ContentPage>

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -8,7 +8,8 @@
              xmlns:models="clr-namespace:Utility.Classes.Discretizer;assembly=Utility"
              Title="MeshingPage"
              Shell.NavBarIsVisible="False"
-             x:DataType="viewmodels:MeshingPageViewModel">
+             x:DataType="viewmodels:MeshingPageViewModel"
+             BackgroundColor="{StaticResource PageBackgroundColor}">
     <ContentPage.MenuBarItems>
         <MenuBarItem Text="Edit" IsEnabled="False">
             <MenuFlyoutItem Text="Undo"
@@ -34,80 +35,136 @@
             </MenuFlyoutItem>
         </MenuBarItem>
     </ContentPage.MenuBarItems>
-    
+
     <ContentPage.Resources>
         <Style TargetType="Label">
             <Setter Property="FontFamily" Value="SF Pro Text"/>
+            <Setter Property="FontAttributes" Value="Bold"/>
+            <Setter Property="TextColor" Value="#F0F4FF"/>
         </Style>
         <Style TargetType="Picker">
             <Setter Property="FontFamily" Value="SF Pro Text"/>
+            <Setter Property="TextColor" Value="#F0F4FF"/>
+            <Setter Property="TitleColor" Value="#9DAAD3"/>
+            <Setter Property="BackgroundColor" Value="Transparent"/>
         </Style>
         <Style TargetType="Button">
             <Setter Property="FontFamily" Value="SF Pro Display"/>
             <Setter Property="FontSize" Value="Medium" />
             <Setter Property="FontAttributes" Value="Bold" />
             <Setter Property="BorderColor" Value="Transparent"/>
+            <Setter Property="TextColor" Value="#F7FBFF"/>
+            <Setter Property="CornerRadius" Value="10"/>
+        </Style>
+        <Style TargetType="Entry">
+            <Setter Property="FontFamily" Value="SF Pro Text"/>
+            <Setter Property="TextColor" Value="#F0F4FF"/>
+            <Setter Property="PlaceholderColor" Value="#6F84AE"/>
+            <Setter Property="BackgroundColor" Value="Transparent"/>
+        </Style>
+        <Style TargetType="SearchBar">
+            <Setter Property="FontFamily" Value="SF Pro Text"/>
+            <Setter Property="TextColor" Value="#F0F4FF"/>
+            <Setter Property="PlaceholderColor" Value="#6F84AE"/>
+            <Setter Property="BackgroundColor" Value="#1B2335"/>
+            <Setter Property="CancelButtonColor" Value="#3A7CA5"/>
+        </Style>
+        <Style TargetType="CheckBox">
+            <Setter Property="Color" Value="#3A7CA5"/>
         </Style>
     </ContentPage.Resources>
-    <Grid RowDefinitions="Auto, *">
-        <controls:NavBarControl x:Name="NavBar" Grid.Row="0" Grid.ColumnSpan="1" CurrentPageName="MeshingPage"/>
-        <Grid Grid.Row="1" ColumnDefinitions="Auto, *, Auto" Margin="5">
 
-            <!-- Left control Panel FEM -->
-            <Border Grid.Column="0" StrokeShape="RoundRectangle 5" IsVisible="{Binding IsFEM}">
-                <VerticalStackLayout Spacing="5" Margin="5">
-                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10" Margin="10">
-                        <Label Grid.Column="0" Text="Mesh Type:" VerticalOptions="Center"/>
-                        <Picker Grid.Column="1" ItemsSource="{Binding MeshTypes}" SelectedItem="{Binding SelectedMeshType}" WidthRequest="100"/>
+    <Grid RowDefinitions="Auto, *">
+        <controls:NavBarControl x:Name="NavBar"
+                                Grid.Row="0"
+                                Grid.ColumnSpan="1"
+                                CurrentPageName="MeshingPage"/>
+
+        <Grid Grid.Row="1"
+              Margin="24,12,24,24"
+              ColumnDefinitions="320, *, 260"
+              ColumnSpacing="24">
+
+            <!-- Left control panels for FEM and LBM -->
+            <Border Grid.Column="0"
+                    Style="{StaticResource PanelBorderStyle}"
+                    Background="{StaticResource ConfigurationPanelBrush}"
+                    IsVisible="{Binding IsFEM}">
+                <VerticalStackLayout Spacing="16"
+                                      Margin="20">
+                    <Grid ColumnDefinitions="Auto, *"
+                          ColumnSpacing="12">
+                        <Label Grid.Column="0"
+                               Text="Mesh Type:"
+                               FontAttributes="None"
+                               TextColor="#9DAAD3"/>
+                        <Picker Grid.Column="1"
+                                ItemsSource="{Binding MeshTypes}"
+                                SelectedItem="{Binding SelectedMeshType}"/>
                     </Grid>
 
-                    <BoxView WidthRequest="200" HeightRequest="2" BackgroundColor="Gray"/>
+                    <BoxView HeightRequest="1"
+                             BackgroundColor="#3A7CA5"/>
 
-                    <!-- FEM parameters -->
-                    <controls:PlusMinusEntryControl Margin="10"
+                    <controls:PlusMinusEntryControl Margin="0"
                                                     LabelText="Layers"
                                                     PlusImageSource="icon_plus2.png"
                                                     MinusImageSource="icon_minus2.png"
                                                     Value="{Binding Layers}"
                                                     Max="20"/>
 
-                    <controls:PlusMinusEntryControl Margin="10"
+                    <controls:PlusMinusEntryControl Margin="0"
                                                     LabelText="Boundary Vertices"
                                                     PlusImageSource="icon_plus2.png"
                                                     MinusImageSource="icon_minus2.png"
                                                     Value="{Binding BoundaryFEMVertexCount}"
-                                                    Max="100"/>      
+                                                    Max="100"/>
 
-                    <BoxView WidthRequest="200" HeightRequest="2" BackgroundColor="Gray"/>
+                    <BoxView HeightRequest="1"
+                             BackgroundColor="#3A7CA5"/>
 
-                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10" Margin="10">
-                        <Label Grid.Column="0" Text="Geometry" VerticalOptions="Center"/>
-                        <Picker Grid.Column="1" ItemsSource="{Binding GeometryTypes}" SelectedItem="{Binding SelectedGeometry}" WidthRequest="120"/>
+                    <Grid ColumnDefinitions="Auto, *"
+                          ColumnSpacing="12">
+                        <Label Grid.Column="0"
+                               Text="Geometry"
+                               FontAttributes="None"
+                               TextColor="#9DAAD3"/>
+                        <Picker Grid.Column="1"
+                                ItemsSource="{Binding GeometryTypes}"
+                                SelectedItem="{Binding SelectedGeometry}"/>
                     </Grid>
 
-                    <BoxView WidthRequest="200" HeightRequest="2" BackgroundColor="Gray"/>
+                    <BoxView HeightRequest="1"
+                             BackgroundColor="#3A7CA5"/>
 
-                    <!-- Common parameters -->
-                    <controls:PlusMinusEntryControl Margin="10"
-                                                   LabelText="Electrodes"
-                                                   PlusImageSource="icon_plus2.png"
-                                                   MinusImageSource="icon_minus2.png"
-                                                   Value="{Binding ElectrodeCount}"
-                                                   Max="32"/>
+                    <controls:PlusMinusEntryControl Margin="0"
+                                                    LabelText="Electrodes"
+                                                    PlusImageSource="icon_plus2.png"
+                                                    MinusImageSource="icon_minus2.png"
+                                                    Value="{Binding ElectrodeCount}"
+                                                    Max="32"/>
 
-                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10" Margin="10" IsVisible="{Binding InhomogenityEditing}">
-                        <Label Grid.Column="0" Text="Inhomogenity Value" VerticalOptions="Center"/>
-                        <Entry Grid.Column="1" Text="{Binding InhomogenityValue}" WidthRequest="80" Keyboard="Numeric"/>
+                    <Grid ColumnDefinitions="Auto, *"
+                          ColumnSpacing="12"
+                          IsVisible="{Binding InhomogenityEditing}">
+                        <Label Grid.Column="0"
+                               Text="Inhomogenity Value"
+                               FontAttributes="None"
+                               TextColor="#9DAAD3"/>
+                        <Entry Grid.Column="1"
+                               Text="{Binding InhomogenityValue}"
+                               WidthRequest="100"
+                               Keyboard="Numeric"/>
                     </Grid>
 
-                    <controls:PlusMinusEntryControl Margin="10"
+                    <controls:PlusMinusEntryControl Margin="0"
                                                     LabelText="Contact Impedance"
                                                     PlusImageSource="icon_plus2.png"
                                                     MinusImageSource="icon_minus2.png"
                                                     Value="{Binding ElectrodeContactImpedance}"
-                                                    Max="10"/>       
+                                                    Max="10"/>
 
-                    <controls:PlusMinusEntryControl Margin="10"
+                    <controls:PlusMinusEntryControl Margin="0"
                                                     LabelText="Electrode Size [%]"
                                                     PlusImageSource="icon_plus2.png"
                                                     MinusImageSource="icon_minus2.png"
@@ -116,247 +173,339 @@
                 </VerticalStackLayout>
             </Border>
 
-            <!-- Left Control Panel LBM-->
-            <Border Grid.Column="0" StrokeShape="RoundRectangle 5" IsVisible="{Binding IsLBM}">
-                <VerticalStackLayout Spacing="5" Margin="5">
-                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10" Margin="10">
-                        <Label Grid.Column="0" Text="Mesh Type:" VerticalOptions="Center"/>
-                        <Picker Grid.Column="1" ItemsSource="{Binding MeshTypes}" SelectedItem="{Binding SelectedMeshType}" WidthRequest="100"/>
+            <Border Grid.Column="0"
+                    Style="{StaticResource PanelBorderStyle}"
+                    Background="{StaticResource ConfigurationPanelBrush}"
+                    IsVisible="{Binding IsLBM}">
+                <VerticalStackLayout Spacing="16"
+                                      Margin="20">
+                    <Grid ColumnDefinitions="Auto, *"
+                          ColumnSpacing="12">
+                        <Label Grid.Column="0"
+                               Text="Mesh Type:"
+                               FontAttributes="None"
+                               TextColor="#9DAAD3"/>
+                        <Picker Grid.Column="1"
+                                ItemsSource="{Binding MeshTypes}"
+                                SelectedItem="{Binding SelectedMeshType}"/>
                     </Grid>
-                    
-                    <BoxView WidthRequest="200" HeightRequest="2" BackgroundColor="Gray"/>
-                    
-                    <!-- LBM parameters -->
-                    <Grid RowDefinitions="Auto,Auto" ColumnSpacing="10" Margin="10">
+
+                    <BoxView HeightRequest="1"
+                             BackgroundColor="#3A7CA5"/>
+
+                    <Grid RowDefinitions="Auto,Auto"
+                          ColumnSpacing="12">
                         <controls:PlusMinusEntryControl Grid.Row="0"
                                                         LabelText="X"
                                                         PlusImageSource="icon_plus2.png"
                                                         MinusImageSource="icon_minus2.png"
                                                         Value="{Binding Nx}"
-                                                        Max="200"/>          
-                        <Slider  Grid.Row="1" Grid.ColumnSpan="2" Minimum="3" Maximum="200" Value="{Binding Nx}" IsVisible="{Binding IsLBM}"/>
+                                                        Max="200"/>
+                        <Slider Grid.Row="1"
+                                Minimum="3"
+                                Maximum="200"
+                                Value="{Binding Nx}"
+                                MinimumTrackColor="#3A7CA5"
+                                MaximumTrackColor="#1B2234"/>
                     </Grid>
 
-                    <Grid RowDefinitions="Auto,Auto" ColumnSpacing="10" Margin="10">
+                    <Grid RowDefinitions="Auto,Auto"
+                          ColumnSpacing="12">
                         <controls:PlusMinusEntryControl Grid.Row="0"
                                                         LabelText="Y"
                                                         PlusImageSource="icon_plus2.png"
                                                         MinusImageSource="icon_minus2.png"
                                                         Value="{Binding Ny}"
                                                         Max="200"/>
-                        <Slider Grid.Row="1" Grid.ColumnSpan="2" Minimum="3" Maximum="200" Value="{Binding Ny}" IsVisible="{Binding IsLBM}"/>
+                        <Slider Grid.Row="1"
+                                Minimum="3"
+                                Maximum="200"
+                                Value="{Binding Ny}"
+                                MinimumTrackColor="#3A7CA5"
+                                MaximumTrackColor="#1B2234"/>
                     </Grid>
 
-                    <BoxView WidthRequest="200" HeightRequest="2" BackgroundColor="Gray"/>
+                    <BoxView HeightRequest="1"
+                             BackgroundColor="#3A7CA5"/>
 
-                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10" Margin="10" >
-                        <Label Grid.Column="0" Text="Geometry" VerticalOptions="Center"/>
-                        <Picker Grid.Column="1" ItemsSource="{Binding GeometryTypes}" SelectedItem="{Binding SelectedGeometry}" WidthRequest="120"/>
+                    <Grid ColumnDefinitions="Auto, *"
+                          ColumnSpacing="12">
+                        <Label Grid.Column="0"
+                               Text="Geometry"
+                               FontAttributes="None"
+                               TextColor="#9DAAD3"/>
+                        <Picker Grid.Column="1"
+                                ItemsSource="{Binding GeometryTypes}"
+                                SelectedItem="{Binding SelectedGeometry}"/>
                     </Grid>
 
-                    <BoxView WidthRequest="200" HeightRequest="2" BackgroundColor="Gray"/>
-                                       
-                    <!-- Common parameters -->
-                    <controls:PlusMinusEntryControl Grid.Row="0"
-                                                    LabelText="Electrode Num"
+                    <BoxView HeightRequest="1"
+                             BackgroundColor="#3A7CA5"/>
+
+                    <controls:PlusMinusEntryControl LabelText="Electrode Num"
                                                     PlusImageSource="icon_plus2.png"
                                                     MinusImageSource="icon_minus2.png"
                                                     Value="{Binding ElectrodeCount}"
-                                                    Max="64"/>      
+                                                    Max="64"/>
 
-                    <controls:PlusMinusEntryControl Grid.Row="0"
-                                                    LabelText="Inhomogenity Value"
+                    <controls:PlusMinusEntryControl LabelText="Inhomogenity Value"
                                                     PlusImageSource="icon_plus2.png"
                                                     MinusImageSource="icon_minus2.png"
                                                     Value="{Binding InhomogenityValue}"
                                                     Max="10"/>
 
-                    <controls:PlusMinusEntryControl Grid.Row="0"
-                                                    LabelText="Contact Impedance"
+                    <controls:PlusMinusEntryControl LabelText="Contact Impedance"
                                                     PlusImageSource="icon_plus2.png"
                                                     MinusImageSource="icon_minus2.png"
                                                     Value="{Binding ElectrodeContactImpedance}"
-                                                    Max="10"/>     
+                                                    Max="10"/>
                 </VerticalStackLayout>
             </Border>
 
-            <!-- Middle Canvas display -->
-            <Grid Grid.Column="1" RowDefinitions="Auto,Auto,*" Margin="5">
-                <Border Grid.Row="0" StrokeShape="RoundRectangle 10">
-                    <Grid ColumnDefinitions="*, Auto, *" 
-                          RowDefinitions="Auto, Auto"
-                          ColumnSpacing="10"
-                          RowSpacing="0"
-                          Margin="0"
-                          Padding="0">
-                        
-                        <!-- Control buttons -->
-                        <Label Grid.Column="0" Grid.Row="0" Text="Controls" HorizontalOptions="Center" HeightRequest="20"/>
-                        <Border Grid.Column="0" Grid.Row="1" Stroke="Transparent">
-                            <HorizontalStackLayout Grid.Row="0" VerticalOptions="Center" HorizontalOptions="Center" Spacing="10">
-                                <Border Padding="5" StrokeShape="RoundRectangle 5" Stroke="Transparent">
-                                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10">
-                                        <Image Grid.Column="0" Source="icon_save.png" HeightRequest="30"/>
-                                        <Label Grid.Column="1" Text="Save" HorizontalOptions="Center" VerticalOptions="Center" FontSize="Medium" FontAttributes="Bold"/>
-                                    </Grid>
-                                    <Border.GestureRecognizers>
-                                        <TapGestureRecognizer Tapped="OnSaveClicked" />
-                                    </Border.GestureRecognizers>
-                                    <Border.Shadow>
-                                        <Shadow Brush="Black" Opacity="5.0" Radius="4.0"/>
-                                    </Border.Shadow>
-                                </Border>
+            <!-- Center content with controls and canvas -->
+            <Grid Grid.Column="1"
+                  RowDefinitions="Auto,Auto,*"
+                  RowSpacing="20">
+                <Border Grid.Row="0"
+                        Style="{StaticResource PanelBorderStyle}"
+                        Background="{StaticResource ControlPanelBrush}">
+                    <VerticalStackLayout Margin="20"
+                                          Spacing="16">
+                        <Label Text="Controls"
+                               HorizontalOptions="Center"
+                               FontSize="Medium"
+                               TextColor="#F7FBFF"/>
+                        <HorizontalStackLayout Spacing="14"
+                                                HorizontalOptions="Center">
+                            <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                    Padding="10"
+                                    BackgroundColor="#27344D">
+                                <Grid ColumnDefinitions="Auto, *"
+                                      ColumnSpacing="10"
+                                      VerticalOptions="Center">
+                                    <Image Grid.Column="0"
+                                           Source="icon_save.png"
+                                           HeightRequest="30"/>
+                                    <Label Grid.Column="1"
+                                           Text="Save"
+                                           FontAttributes="None"
+                                           FontSize="Medium"/>
+                                </Grid>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="OnSaveClicked" />
+                                </Border.GestureRecognizers>
+                            </Border>
 
-                                <Border Padding="5" StrokeShape="RoundRectangle 5" Stroke="Transparent">
-                                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10">
-                                        <Image Grid.Column="0" Source="icon_load2.png" HeightRequest="30"/>
-                                        <Label Grid.Column="1" Text="Load" HorizontalOptions="Center" VerticalOptions="Center" FontSize="Medium" FontAttributes="Bold"/>
-                                    </Grid>
-                                    <Border.GestureRecognizers>
-                                        <TapGestureRecognizer Tapped="OnLoadClicked" />
-                                    </Border.GestureRecognizers>
-                                    <Border.Shadow>
-                                        <Shadow Brush="Black" Opacity="5.0" Radius="4.0"/>
-                                    </Border.Shadow>
-                                </Border>
+                            <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                    Padding="10"
+                                    BackgroundColor="#233149">
+                                <Grid ColumnDefinitions="Auto, *"
+                                      ColumnSpacing="10"
+                                      VerticalOptions="Center">
+                                    <Image Grid.Column="0"
+                                           Source="icon_load2.png"
+                                           HeightRequest="30"/>
+                                    <Label Grid.Column="1"
+                                           Text="Load"
+                                           FontAttributes="None"
+                                           FontSize="Medium"/>
+                                </Grid>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="OnLoadClicked" />
+                                </Border.GestureRecognizers>
+                            </Border>
 
-                                <Border Padding="5" StrokeShape="RoundRectangle 5"  Stroke="Transparent">
-                                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10">
-                                        <Image Grid.Column="0" Source="icon_generate.png" HeightRequest="30"/>
-                                        <Label Grid.Column="1" Text="Generate" HorizontalOptions="Center" VerticalOptions="Center" FontSize="Medium" FontAttributes="Bold"/>
-                                    </Grid>
-                                    <Border.GestureRecognizers>
-                                        <TapGestureRecognizer Tapped="OnGenerateClicked" />
-                                    </Border.GestureRecognizers>
-                                    <Border.Shadow>
-                                        <Shadow Brush="Black" Opacity="5.0" Radius="4.0"/>
-                                    </Border.Shadow>
-                                </Border>
+                            <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                    Padding="10"
+                                    BackgroundColor="#22304A">
+                                <Grid ColumnDefinitions="Auto, *"
+                                      ColumnSpacing="10"
+                                      VerticalOptions="Center">
+                                    <Image Grid.Column="0"
+                                           Source="icon_generate.png"
+                                           HeightRequest="30"/>
+                                    <Label Grid.Column="1"
+                                           Text="Generate"
+                                           FontAttributes="None"
+                                           FontSize="Medium"/>
+                                </Grid>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="OnGenerateClicked" />
+                                </Border.GestureRecognizers>
+                            </Border>
 
-                                <Border Padding="5" StrokeShape="RoundRectangle 5"  Stroke="Transparent">
-                                    <Grid ColumnDefinitions="Auto, *" ColumnSpacing="10">
-                                        <Image Grid.Column="0" Source="icon_delete.png" HeightRequest="30"/>
-                                        <Label Grid.Column="1" Text="Clear" HorizontalOptions="Center" VerticalOptions="Center" FontSize="Medium" FontAttributes="Bold"/>
-                                    </Grid>
-                                    <Border.GestureRecognizers>
-                                        <TapGestureRecognizer Tapped="OnClearClicked" />
-                                    </Border.GestureRecognizers>
-                                    <Border.Shadow>
-                                        <Shadow Brush="Black" Opacity="5.0" Radius="4.0"/>
-                                    </Border.Shadow>
-                                </Border>
-
-
-                            </HorizontalStackLayout>
-                        </Border>
-
-                        <BoxView Grid.Column="1" Grid.RowSpan="2" WidthRequest="2" HeightRequest="50" BackgroundColor="Gray" />
-
-                        <Label Grid.Column="2" Grid.Row="0" Text="Editing" HorizontalOptions="Center" VerticalOptions="Center"/>
-                        <Border Grid.Column="2" Grid.Row="1" Stroke="Transparent">
-
-                            <HorizontalStackLayout Spacing="10" HorizontalOptions="Center">
-                                <Border Grid.Column="1" Padding="5" StrokeShape="RoundRectangle 5" Stroke="Transparent">
-                                    <Grid ColumnDefinitions="Auto, *, Auto" ColumnSpacing="10">
-                                        <Image Grid.Column="0" Source="icon_edit2.png" HeightRequest="25"/>
-                                        <Label Grid.Column="1" Text="Edit" HorizontalOptions="Center" VerticalOptions="Center" FontSize="Medium" FontAttributes="Bold"/>
-                                        <CheckBox x:Name="EditingCheckbox"
-                                                  Grid.Column="2"
-                                                  IsChecked="{Binding InhomogenityEditing}" 
-                                                  HeightRequest="25" 
-                                                  WidthRequest="25"/>
-                                    </Grid>
-                                    <Border.GestureRecognizers>
-                                        <TapGestureRecognizer Tapped="OnEditClicked" />
-                                    </Border.GestureRecognizers>
-                                    <Border.Shadow>
-                                        <Shadow Brush="Black" Opacity="5.0" Radius="4.0"/>
-                                    </Border.Shadow>
-                                </Border>
-
-                                <Border Stroke="Transparent">
-                                    <Grid ColumnDefinitions="Auto, *" Margin="5" ColumnSpacing="5">
-                                        <Image Grid.Column="0" Source="icon_noise.png" HeightRequest="45"/>
-                                        <Label Grid.Column="1" Text="Add Noise" FontSize="Medium" HorizontalOptions="Center" VerticalOptions="Center" FontAttributes="Bold"/>
-                                    </Grid>
-                                    <Border.GestureRecognizers>
-                                        <TapGestureRecognizer Tapped="OnAddNoiseTapped"/>
-                                    </Border.GestureRecognizers>
-                                    <Border.Shadow>
-                                        <Shadow Brush="Black" Opacity="5.0" Radius="4.0"/>
-                                    </Border.Shadow>
-
-                                </Border>
-
-                                <Border Stroke="Transparent">
-                                    <Grid ColumnDefinitions="Auto, *" Margin="5" ColumnSpacing="10">
-                                        <Image Grid.Column="0" Source="icon_back2.png" HeightRequest="30"/>
-                                        <Label Grid.Column="1" Text="Undo" FontSize="Medium" HorizontalOptions="Center" VerticalOptions="Center" FontAttributes="Bold"/>
-                                    </Grid>
-                                    <Border.GestureRecognizers>
-                                        <TapGestureRecognizer Tapped="OnUndoClicked"/>
-                                    </Border.GestureRecognizers>
-                                    <Border.Shadow>
-                                        <Shadow Brush="Black" Opacity="5.0" Radius="4.0"/>
-                                    </Border.Shadow>
-                                </Border>
-
-                                <Border Stroke="Transparent">
-                                    <Grid ColumnDefinitions="Auto, *" Margin="5" ColumnSpacing="10">
-                                        <Image Grid.Column="0" Source="icon_redo2.png" HeightRequest="30"/>
-                                        <Label Grid.Column="1" Text="Redo" FontSize="Medium" HorizontalOptions="Center" VerticalOptions="Center" FontAttributes="Bold"/>
-                                    </Grid>
-                                    <Border.GestureRecognizers>
-                                        <TapGestureRecognizer Tapped="OnRedoClicked"/>
-                                    </Border.GestureRecognizers>
-                                    <Border.Shadow>
-                                        <Shadow Brush="Black" Opacity="5.0" Radius="4.0"/>
-                                    </Border.Shadow>
-                                </Border>
-
-                            </HorizontalStackLayout>
-                        </Border>
-                        
-                    </Grid>
+                            <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                    Padding="10"
+                                    BackgroundColor="#1F2B44">
+                                <Grid ColumnDefinitions="Auto, *"
+                                      ColumnSpacing="10"
+                                      VerticalOptions="Center">
+                                    <Image Grid.Column="0"
+                                           Source="icon_delete.png"
+                                           HeightRequest="30"/>
+                                    <Label Grid.Column="1"
+                                           Text="Clear"
+                                           FontAttributes="None"
+                                           FontSize="Medium"/>
+                                </Grid>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="OnClearClicked" />
+                                </Border.GestureRecognizers>
+                            </Border>
+                        </HorizontalStackLayout>
+                    </VerticalStackLayout>
                 </Border>
-                
-                <Label Grid.Row="1" 
-                       Text="{Binding HoveredElementInfo, StringFormat='Element Info: {0}'}"
-                       HorizontalOptions="Center"
-                       FontSize="Small"
-                       FontAttributes="Bold"
-                       Margin="10"/>
+
+                <Border Grid.Row="1"
+                        Style="{StaticResource PanelBorderStyle}"
+                        Background="{StaticResource PartialResultsBrush}">
+                    <VerticalStackLayout Margin="20"
+                                          Spacing="16">
+                        <Label Text="Editing"
+                               HorizontalOptions="Center"
+                               FontSize="Medium"
+                               TextColor="#F7FBFF"/>
+                        <HorizontalStackLayout HorizontalOptions="Center"
+                                                Spacing="14">
+                            <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                    Padding="10"
+                                    BackgroundColor="#27344D">
+                                <Grid ColumnDefinitions="Auto, *, Auto"
+                                      ColumnSpacing="10">
+                                    <Image Grid.Column="0"
+                                           Source="icon_edit2.png"
+                                           HeightRequest="25"/>
+                                    <Label Grid.Column="1"
+                                           Text="Edit"
+                                           FontAttributes="None"
+                                           FontSize="Medium"/>
+                                    <CheckBox Grid.Column="2"
+                                              IsChecked="{Binding InhomogenityEditing}"/>
+                                </Grid>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="OnEditClicked" />
+                                </Border.GestureRecognizers>
+                            </Border>
+
+                            <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                    Padding="10"
+                                    BackgroundColor="#233149">
+                                <Grid ColumnDefinitions="Auto, *"
+                                      ColumnSpacing="10">
+                                    <Image Grid.Column="0"
+                                           Source="icon_noise.png"
+                                           HeightRequest="40"/>
+                                    <Label Grid.Column="1"
+                                           Text="Add Noise"
+                                           FontAttributes="None"
+                                           FontSize="Medium"/>
+                                </Grid>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="OnAddNoiseTapped" />
+                                </Border.GestureRecognizers>
+                            </Border>
+
+                            <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                    Padding="10"
+                                    BackgroundColor="#22304A">
+                                <Grid ColumnDefinitions="Auto, *"
+                                      ColumnSpacing="10">
+                                    <Image Grid.Column="0"
+                                           Source="icon_back2.png"
+                                           HeightRequest="30"/>
+                                    <Label Grid.Column="1"
+                                           Text="Undo"
+                                           FontAttributes="None"
+                                           FontSize="Medium"/>
+                                </Grid>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="OnUndoClicked" />
+                                </Border.GestureRecognizers>
+                            </Border>
+
+                            <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                    Padding="10"
+                                    BackgroundColor="#1F2B44">
+                                <Grid ColumnDefinitions="Auto, *"
+                                      ColumnSpacing="10">
+                                    <Image Grid.Column="0"
+                                           Source="icon_redo2.png"
+                                           HeightRequest="30"/>
+                                    <Label Grid.Column="1"
+                                           Text="Redo"
+                                           FontAttributes="None"
+                                           FontSize="Medium"/>
+                                </Grid>
+                                <Border.GestureRecognizers>
+                                    <TapGestureRecognizer Tapped="OnRedoClicked" />
+                                </Border.GestureRecognizers>
+                            </Border>
+                        </HorizontalStackLayout>
+                        <Label Text="{Binding HoveredElementInfo, StringFormat='Element Info: {0}'}"
+                               HorizontalOptions="Center"
+                               FontSize="Small"
+                               FontAttributes="None"
+                               TextColor="#9DAAD3"/>
+                    </VerticalStackLayout>
+                </Border>
 
                 <Border Grid.Row="2"
-                        Stroke="Transparent"
-                        StrokeThickness="2"
-                        Margin="10"
-                        HorizontalOptions="Center"
-                        VerticalOptions="Center">
-                    <skia:SKCanvasView x:Name="MeshCanvas"
-                                       PaintSurface="OnMeshCanvasPaintSurface"
-                                       EnableTouchEvents="True"
-                                       Touch="OnMeshCanvasTouch"
-                                       HeightRequest="700"
-                                       WidthRequest="700"
-                                       Margin="10" />
+                        Style="{StaticResource PanelBorderStyle}"
+                        Background="{StaticResource FullResultsBrush}">
+                    <Border Style="{StaticResource CanvasBorderStyle}"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center">
+                        <skia:SKCanvasView x:Name="MeshCanvas"
+                                           PaintSurface="OnMeshCanvasPaintSurface"
+                                           EnableTouchEvents="True"
+                                           Touch="OnMeshCanvasTouch"
+                                           HeightRequest="700"
+                                           WidthRequest="700" />
+                    </Border>
                 </Border>
             </Grid>
 
-            <Border Grid.Column="2" StrokeShape="RoundRectangle 5" Margin="5" WidthRequest="250">
-                <VerticalStackLayout Margin="2" Spacing="10">
-                    <SearchBar Placeholder="Search" Text="{Binding MeshSearchText}" Margin="5"/>
-                    <Border StrokeShape="RoundRectangle 10" Stroke="Transparent">
-                        <ScrollView Grid.Row="1">
-                            <VerticalStackLayout Spacing="2"                                                  
+            <!-- Right panel with saved meshes -->
+            <Border Grid.Column="2"
+                    Style="{StaticResource PanelBorderStyle}"
+                    Background="{StaticResource StatisticsPanelBrush}">
+                <VerticalStackLayout Margin="20"
+                                      Spacing="16">
+                    <Label Text="Saved Meshes"
+                           FontSize="Medium"
+                           HorizontalOptions="Center"
+                           TextColor="#F7FBFF"/>
+                    <SearchBar Placeholder="Search"
+                               Text="{Binding MeshSearchText}"/>
+                    <Border Style="{StaticResource PanelSectionBorderStyle}"
+                            BackgroundColor="#1F2B44"
+                            Padding="0">
+                        <ScrollView>
+                            <VerticalStackLayout Spacing="8"
+                                                 Padding="12"
                                                  BindableLayout.ItemsSource="{Binding FilteredMeshes}">
                                 <BindableLayout.ItemTemplate>
                                     <DataTemplate x:DataType="models:DiscretizationInfo">
-                                        <Border StrokeShape="RoundRectangle 5" Padding="4" Stroke="Transparent">
-                                            <Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto, Auto, Auto" ColumnSpacing="5">
-                                                <Label Grid.Column="0" Grid.Row="0" Text="{Binding Name}" FontAttributes="Bold" FontSize="Small"/>
-                                                <Label Grid.Column="0" Grid.Row="1" Text="{Binding Metadata.CreatedOn, StringFormat='Created: {0:G}'}" FontSize="10"/>
-                                                <Label Grid.Column="0" Grid.Row="2" Text="{Binding Generator}" FontSize="10"/>
+                                        <Border Style="{StaticResource PanelSectionBorderStyle}"
+                                                BackgroundColor="#27344D"
+                                                Padding="12">
+                                            <Grid ColumnDefinitions="*"
+                                                  RowDefinitions="Auto, Auto, Auto"
+                                                  RowSpacing="4">
+                                                <Label Grid.Row="0"
+                                                       Text="{Binding Name}"
+                                                       FontSize="Small"
+                                                       TextColor="#F7FBFF"/>
+                                                <Label Grid.Row="1"
+                                                       Text="{Binding Metadata.CreatedOn, StringFormat='Created: {0:G}'}"
+                                                       FontSize="10"
+                                                       FontAttributes="None"
+                                                       TextColor="#9DAAD3"/>
+                                                <Label Grid.Row="2"
+                                                       Text="{Binding Generator}"
+                                                       FontSize="10"
+                                                       FontAttributes="None"
+                                                       TextColor="#9DAAD3"/>
                                             </Grid>
                                             <Border.GestureRecognizers>
                                                 <TapGestureRecognizer Tapped="OnMeshSelected"/>


### PR DESCRIPTION
## Summary
- add a shared panel style resource dictionary to provide the reconstruction gradients across the app
- restyle MainPage, MeshingPage, and DAQPage to use the shared gradients, ghostwhite background, and updated typography for consistency

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a46d3f8483338a16771e62b9677f