### PR TITLE
Optimize reconstruction statistics updates

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -339,16 +339,20 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         private void OnServiceReconstructionUpdated(object? sender, ReconstructionResult result)
         {
+            double residual = CalculateResidual(result.ReconstructedConductivityDistribution,
+                                                result.OriginalConductivityDistribution);
+            double correlation = CalculateCorrelation(result.ReconstructedConductivityDistribution,
+                                                      result.OriginalConductivityDistribution);
+            var elapsed = _reconstructionStopwatch.Elapsed;
+
             MainThread.BeginInvokeOnMainThread(() =>
             {
                 IterationCount++;
-                Residual = CalculateResidual(result.ReconstructedConductivityDistribution,
-                                             result.OriginalConductivityDistribution);
-                Correlation = CalculateCorrelation(result.ReconstructedConductivityDistribution,
-                                                    result.OriginalConductivityDistribution);
+                Residual = residual;
+                Correlation = correlation;
 
-                ResidualHistory.Add(Residual);
-                ElapsedTime = _reconstructionStopwatch.Elapsed;
+                ResidualHistory.Add(residual);
+                ElapsedTime = elapsed;
 
                 ReconstructionUpdated?.Invoke(this, result);
             });


### PR DESCRIPTION
## Summary
- calculate reconstruction residual and correlation metrics on the background thread
- reuse the computed values when updating UI-bound properties to keep the interface responsive

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9737b09c48333847fc31a94624399