### PR TITLE
Adjust reconstruction controls and dark theme styling

### DIFF
--- a/ElectricalImpedanceTomography/Resources/Styles/PanelStyles.xaml
+++ b/ElectricalImpedanceTomography/Resources/Styles/PanelStyles.xaml
@@ -4,7 +4,7 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 
-    <Color x:Key="PageBackgroundColor">#CCCCCC</Color>
+    <AppThemeColor x:Key="PageBackgroundColor" Light="#CCCCCC" Dark="#1F1F1F" />
 
     <LinearGradientBrush x:Key="ConfigurationPanelBrush" StartPoint="0,0" EndPoint="0,1">
         <GradientStop Color="#232E45" Offset="0" />

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -51,12 +51,12 @@
             <Setter Property="Padding" Value="0"/>
             <Setter Property="Stroke">
                 <Setter.Value>
-                    <SolidColorBrush Color="#3A7CA5" />
+                    <SolidColorBrush Color="{AppThemeBinding Light=#3A7CA5, Dark=#EA580C}" />
                 </Setter.Value>
             </Setter>
             <Setter Property="Shadow">
                 <Setter.Value>
-                    <Shadow Brush="#883A7CA5" Offset="0,4" Radius="12" Opacity="0.45" />
+                    <Shadow Brush="{AppThemeBinding Light=#883A7CA5, Dark=#88EA580C}" Offset="0,4" Radius="12" Opacity="0.45" />
                 </Setter.Value>
             </Setter>
         </Style>
@@ -65,7 +65,7 @@
             <Setter Property="StrokeShape" Value="RoundRectangle 10"/>
             <Setter Property="StrokeThickness" Value="0"/>
             <Setter Property="Padding" Value="12"/>
-            <Setter Property="BackgroundColor" Value="#242F47"/>
+            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#242F47, Dark=#8B3D0A}"/>
         </Style>
 
         <Style x:Key="CanvasBorderStyle" TargetType="Border">
@@ -73,32 +73,37 @@
             <Setter Property="StrokeThickness" Value="1"/>
             <Setter Property="Stroke" Value="Transparent"/>
             <Setter Property="Padding" Value="10"/>
-            <Setter Property="BackgroundColor" Value="#1A2436"/>
+            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#1A2436, Dark=#2B1608}"/>
+            <Setter Property="Shadow">
+                <Setter.Value>
+                    <Shadow Brush="{AppThemeBinding Light=#663A7CA5, Dark=#66EA580C}" Offset="0,6" Radius="14" Opacity="0.5" />
+                </Setter.Value>
+            </Setter>
         </Style>
 
         <LinearGradientBrush x:Key="ConfigurationPanelBrush" StartPoint="0,0" EndPoint="0,1">
-            <GradientStop Color="#232E45" Offset="0" />
-            <GradientStop Color="#161D2C" Offset="1" />
+            <GradientStop Color="{AppThemeBinding Light=#232E45, Dark=#C2410C}" Offset="0" />
+            <GradientStop Color="{AppThemeBinding Light=#161D2C, Dark=#7C2D12}" Offset="1" />
         </LinearGradientBrush>
         <LinearGradientBrush x:Key="ControlPanelBrush" StartPoint="0,0" EndPoint="0,1">
-            <GradientStop Color="#1E273B" Offset="0" />
-            <GradientStop Color="#101624" Offset="1" />
+            <GradientStop Color="{AppThemeBinding Light=#1E273B, Dark=#EA580C}" Offset="0" />
+            <GradientStop Color="{AppThemeBinding Light=#101624, Dark=#9A3412}" Offset="1" />
         </LinearGradientBrush>
         <LinearGradientBrush x:Key="PartialResultsBrush" StartPoint="0,0" EndPoint="0,1">
-            <GradientStop Color="#202A3F" Offset="0" />
-            <GradientStop Color="#121923" Offset="1" />
+            <GradientStop Color="{AppThemeBinding Light=#202A3F, Dark=#B45309}" Offset="0" />
+            <GradientStop Color="{AppThemeBinding Light=#121923, Dark=#7C2D12}" Offset="1" />
         </LinearGradientBrush>
         <LinearGradientBrush x:Key="FullResultsBrush" StartPoint="0,0" EndPoint="0,1">
-            <GradientStop Color="#1C2638" Offset="0" />
-            <GradientStop Color="#0F151F" Offset="1" />
+            <GradientStop Color="{AppThemeBinding Light=#1C2638, Dark=#9A3412}" Offset="0" />
+            <GradientStop Color="{AppThemeBinding Light=#0F151F, Dark=#7C2D12}" Offset="1" />
         </LinearGradientBrush>
         <LinearGradientBrush x:Key="HistoryPanelBrush" StartPoint="0,0" EndPoint="0,1">
-            <GradientStop Color="#222E45" Offset="0" />
-            <GradientStop Color="#141B28" Offset="1" />
+            <GradientStop Color="{AppThemeBinding Light=#222E45, Dark=#C2410C}" Offset="0" />
+            <GradientStop Color="{AppThemeBinding Light=#141B28, Dark=#8A2C0D}" Offset="1" />
         </LinearGradientBrush>
         <LinearGradientBrush x:Key="StatisticsPanelBrush" StartPoint="0,0" EndPoint="0,1">
-            <GradientStop Color="#1E2435" Offset="0" />
-            <GradientStop Color="#111723" Offset="1" />
+            <GradientStop Color="{AppThemeBinding Light=#1E2435, Dark=#EA580C}" Offset="0" />
+            <GradientStop Color="{AppThemeBinding Light=#111723, Dark=#9A3412}" Offset="1" />
         </LinearGradientBrush>
     </ContentPage.Resources>
     <Grid RowDefinitions="Auto, Auto">
@@ -111,7 +116,7 @@
                     Grid.Column="0"
                     Background="{StaticResource ConfigurationPanelBrush}">
                 <Border.Stroke>
-                    <SolidColorBrush Color="#4D6FA3" />
+                    <SolidColorBrush Color="{AppThemeBinding Light=#4D6FA3, Dark=#EA580C}" />
                 </Border.Stroke>
                 <VerticalStackLayout Margin="18" Spacing="16">
                     <Grid ColumnDefinitions="Auto, *" ColumnSpacing="8">
@@ -122,7 +127,7 @@
                         <!-- Method Selection -->
                         <Border Grid.Column="0"
                                 Style="{StaticResource PanelSectionBorderStyle}"
-                                BackgroundColor="#27344D">
+                                BackgroundColor="{AppThemeBinding Light=#27344D, Dark=#9A3412}">
                             <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
                                 <Label Grid.Row="0" Text="Methods" FontSize="Medium" FontAttributes="Bold" Margin="0,0,0,12"/>
                                 <Label Grid.Row="1" HorizontalOptions="Start" Text="DE Solver" FontFamily="SF Pro Text" FontAttributes="None"/>
@@ -140,7 +145,7 @@
                         <!-- Parameter Configuration -->
                         <Border Grid.Column="1"
                                 Style="{StaticResource PanelSectionBorderStyle}"
-                                BackgroundColor="#25324A">
+                                BackgroundColor="{AppThemeBinding Light=#25324A, Dark=#B45309}">
                             <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
                                 <Label Grid.Row="0" Text="Parameters" FontSize="Medium" FontAttributes="Bold" Margin="0,0,0,12"/>
                                 <Label Grid.Row="1" HorizontalOptions="Start" Text="Regularization Weight (θ)" FontFamily="SF Pro Text" FontAttributes="None"/>
@@ -156,7 +161,7 @@
                     </Grid>
 
                     <Border Style="{StaticResource PanelSectionBorderStyle}"
-                            BackgroundColor="#253049">
+                            BackgroundColor="{AppThemeBinding Light=#253049, Dark=#C2410C}">
                         <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
                             <Grid Grid.Row="0" ColumnDefinitions="Auto, *" ColumnSpacing="8">
                                 <Image Grid.Column="0" Source="icon_boundary.png" HeightRequest="25"/>
@@ -197,7 +202,7 @@
                         Grid.Row="0"
                         Background="{StaticResource ConfigurationPanelBrush}">
                     <Border.Stroke>
-                        <SolidColorBrush Color="#3A5F8A" />
+                        <SolidColorBrush Color="{AppThemeBinding Light=#3A5F8A, Dark=#EA580C}" />
                     </Border.Stroke>
                     <Grid ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto"
                           RowDefinitions="*, Auto"
@@ -310,7 +315,7 @@
 
                 <!-- Displays for reconstruction steps -->
                 <Grid Grid.Row="1" Margin="0,5,0,0" RowDefinitions="Auto, Auto" ColumnDefinitions="Auto" HorizontalOptions="Center" VerticalOptions="Center" RowSpacing="14">
-                    <Border Grid.Row="0" Margin="0, 0, 0, -20" Style="{StaticResource PanelBorderStyle}" Background="{StaticResource PartialResultsBrush}" Stroke="#2F4F77">
+                    <Border Grid.Row="0" Margin="0, 0, 0, -20" Style="{StaticResource PanelBorderStyle}" Background="{StaticResource PartialResultsBrush}" Stroke="{AppThemeBinding Light=#2F4F77, Dark=#EA580C}">
                         <Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto, Auto" HorizontalOptions="Center" Margin="18" ColumnSpacing="18">
                             <!-- Calculated Potential -->
                             <VerticalStackLayout Grid.Row="0" Grid.Column="0" HorizontalOptions="Center" Spacing="10">
@@ -383,17 +388,17 @@
                   HorizontalOptions="End">
                 <Border Grid.Row="0" Style="{StaticResource PanelBorderStyle}" Background="{StaticResource HistoryPanelBrush}">
                     <Border.Stroke>
-                        <SolidColorBrush Color="#3D5D8C" />
+                        <SolidColorBrush Color="{AppThemeBinding Light=#3D5D8C, Dark=#EA580C}" />
                     </Border.Stroke>
                     <VerticalStackLayout Margin="16" Spacing="12">
                         <Label Text="Past Reconstructions" HorizontalOptions="Center" FontSize="16"/>
                         <SearchBar Placeholder="Search" Text="{Binding ReconstructionSearchText}" Margin="0"/>
-                        <Border Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="#25334A">
+                        <Border Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="{AppThemeBinding Light=#25334A, Dark=#9A3412}">
                             <ScrollView>
                                 <VerticalStackLayout Spacing="6" Padding="4" BindableLayout.ItemsSource="{Binding FilteredReconstructions}">
                                     <BindableLayout.ItemTemplate>
                                         <DataTemplate x:DataType="models:ReconstructionInfo">
-                                            <Border Style="{StaticResource CanvasBorderStyle}" Padding="8" BackgroundColor="#1B2334" Margin="0,0,0,6">
+                                            <Border Style="{StaticResource CanvasBorderStyle}" Padding="8" BackgroundColor="{AppThemeBinding Light=#1B2334, Dark=#3B1C0A}" Margin="0,0,0,6">
                                                 <Grid RowDefinitions="Auto, Auto, Auto" ColumnSpacing="0">
                                                     <Label Grid.Row="0" Text="{Binding Name}" FontAttributes="Bold" FontSize="Small"/>
                                                     <Label Grid.Row="1" Text="{Binding Metadata.CreatedOn, StringFormat='Saved: {0:G}'}" FontSize="10" FontAttributes="None"/>
@@ -412,7 +417,7 @@
                 </Border>
                                 
                 <Border Style="{StaticResource PanelSectionBorderStyle}"
-                         BackgroundColor="#22304A"
+                         BackgroundColor="{AppThemeBinding Light=#22304A, Dark=#A3410A}"
                          Grid.Row="1">
                     <VerticalStackLayout Spacing="12">
                         <Entry Text="{Binding Name}" Placeholder="Name"/>
@@ -425,24 +430,24 @@
 
                 <Border Grid.Row="2" Style="{StaticResource PanelBorderStyle}" Background="{StaticResource StatisticsPanelBrush}">
                     <Border.Stroke>
-                        <SolidColorBrush Color="#3A7CA5" />
+                        <SolidColorBrush Color="{AppThemeBinding Light=#3A7CA5, Dark=#EA580C}" />
                     </Border.Stroke>
                     <VerticalStackLayout Margin="16" Spacing="16">
                         <Label Text="Reconstruction Statistics" HorizontalOptions="Center" FontSize="16" TextColor="#F0F4FF"/>
                         <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
-                            <Border Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="#252F44">
+                            <Border Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="{AppThemeBinding Light=#252F44, Dark=#9A3412}">
                                 <VerticalStackLayout Spacing="2">
                                     <Label Text="Elapsed Time" FontAttributes="None" FontSize="12" TextColor="#9DAAD3"/>
                                     <Label Text="{Binding ElapsedTime, StringFormat='{0:mm\\:ss}'}" FontSize="18" TextColor="#F0F4FF"/>
                                 </VerticalStackLayout>
                             </Border>
-                            <Border Grid.Column="1" Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="#252F44">
+                            <Border Grid.Column="1" Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="{AppThemeBinding Light=#252F44, Dark=#B45309}">
                                 <VerticalStackLayout Spacing="2">
                                     <Label Text="Residual" FontAttributes="None" FontSize="12" TextColor="#9DAAD3"/>
                                     <Label Text="{Binding Residual, StringFormat='{0:F3}'}" FontSize="18" TextColor="#F0F4FF"/>
                                 </VerticalStackLayout>
                             </Border>
-                            <Border Grid.Row="1" Grid.ColumnSpan="2" Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="#252F44">
+                            <Border Grid.Row="1" Grid.ColumnSpan="2" Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="{AppThemeBinding Light=#252F44, Dark=#9A3412}">
                                 <VerticalStackLayout Spacing="2">
                                     <Label Text="Correlation" FontAttributes="None" FontSize="12" TextColor="#9DAAD3"/>
                                     <Label Text="{Binding Correlation, StringFormat='{0:F3}'}" FontSize="18" TextColor="#F0F4FF"/>

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -117,6 +117,9 @@ public partial class ReconstructionPage : ContentPage
         PlayerBackButton.IsEnabled = false;
         PlayerForwardButton.IsEnabled = false;
         PlayButton.IsEnabled = false;
+        PlayButton.IsVisible = false;
+        PauseButton.IsVisible = true;
+        PauseButton.IsEnabled = true;
         _isPaused = false;
 
         _viewModel.PrepareForNewReconstruction();
@@ -138,6 +141,8 @@ public partial class ReconstructionPage : ContentPage
             PlayerBackButton.IsEnabled = true;
             PlayerForwardButton.IsEnabled = true;
             PlayButton.IsEnabled = true;
+            PlayButton.IsVisible = true;
+            PauseButton.IsVisible = false;
         }
     }
 
@@ -171,6 +176,8 @@ public partial class ReconstructionPage : ContentPage
         PlayerBackButton.IsEnabled = false;
         PlayerForwardButton.IsEnabled = false;
         PlayButton.IsEnabled = true;
+        PlayButton.IsVisible = true;
+        PauseButton.IsVisible = false;
     }
     #endregion
 


### PR DESCRIPTION
## Summary
- toggle the reconstruction play and pause buttons so only the relevant control is visible while a run is active
- add theme-aware colors and gradients to the reconstruction page to keep existing light styling while switching dark mode to a deep orange palette
- darken the shared page background color for dark mode to avoid the bright default background

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cab279f764833395a01e2d44e72ec0