### PR TITLE
Refresh dark theme panel styling

### DIFF
--- a/ElectricalImpedanceTomography/Resources/Styles/PanelStyles.xaml
+++ b/ElectricalImpedanceTomography/Resources/Styles/PanelStyles.xaml
@@ -6,28 +6,28 @@
 
 
     <LinearGradientBrush x:Key="ConfigurationPanelBrush" StartPoint="0,0" EndPoint="0,1">
-        <GradientStop Color="{AppThemeBinding Light=#232E45, Dark=#C2410C}" Offset="0" />
-        <GradientStop Color="{AppThemeBinding Light=#161D2C, Dark=#7C2D12}" Offset="1" />
+        <GradientStop Color="{AppThemeBinding Light=#232E45, Dark=#8A939E}" Offset="0" />
+        <GradientStop Color="{AppThemeBinding Light=#161D2C, Dark=#2D3239}" Offset="1" />
     </LinearGradientBrush>
     <LinearGradientBrush x:Key="ControlPanelBrush" StartPoint="0,0" EndPoint="0,1">
-        <GradientStop Color="{AppThemeBinding Light=#1E273B, Dark=#EA580C}" Offset="0" />
-        <GradientStop Color="{AppThemeBinding Light=#101624, Dark=#9A3412}" Offset="1" />
+        <GradientStop Color="{AppThemeBinding Light=#1E273B, Dark=#828B96}" Offset="0" />
+        <GradientStop Color="{AppThemeBinding Light=#101624, Dark=#272C33}" Offset="1" />
     </LinearGradientBrush>
     <LinearGradientBrush x:Key="PartialResultsBrush" StartPoint="0,0" EndPoint="0,1">
-        <GradientStop Color="{AppThemeBinding Light=#202A3F, Dark=#B45309}" Offset="0" />
-        <GradientStop Color="{AppThemeBinding Light=#121923, Dark=#7C2D12}" Offset="1" />
+        <GradientStop Color="{AppThemeBinding Light=#202A3F, Dark=#7D868F}" Offset="0" />
+        <GradientStop Color="{AppThemeBinding Light=#121923, Dark=#242A31}" Offset="1" />
     </LinearGradientBrush>
     <LinearGradientBrush x:Key="FullResultsBrush" StartPoint="0,0" EndPoint="0,1">
-        <GradientStop Color="{AppThemeBinding Light=#1C2638, Dark=#9A3412}" Offset="0" />
-        <GradientStop Color="{AppThemeBinding Light=#0F151F, Dark=#7C2D12}" Offset="1" />
+        <GradientStop Color="{AppThemeBinding Light=#1C2638, Dark=#76808A}" Offset="0" />
+        <GradientStop Color="{AppThemeBinding Light=#0F151F, Dark=#1F242A}" Offset="1" />
     </LinearGradientBrush>
     <LinearGradientBrush x:Key="HistoryPanelBrush" StartPoint="0,0" EndPoint="0,1">
-        <GradientStop Color="{AppThemeBinding Light=#222E45, Dark=#C2410C}" Offset="0" />
-        <GradientStop Color="{AppThemeBinding Light=#141B28, Dark=#8A2C0D}" Offset="1" />
+        <GradientStop Color="{AppThemeBinding Light=#222E45, Dark=#9099A3}" Offset="0" />
+        <GradientStop Color="{AppThemeBinding Light=#141B28, Dark=#30363D}" Offset="1" />
     </LinearGradientBrush>
     <LinearGradientBrush x:Key="StatisticsPanelBrush" StartPoint="0,0" EndPoint="0,1">
-        <GradientStop Color="{AppThemeBinding Light=#1E2435, Dark=#EA580C}" Offset="0" />
-        <GradientStop Color="{AppThemeBinding Light=#111723, Dark=#9A3412}" Offset="1" />
+        <GradientStop Color="{AppThemeBinding Light=#1E2435, Dark=#828B95}" Offset="0" />
+        <GradientStop Color="{AppThemeBinding Light=#111723, Dark=#252B32}" Offset="1" />
     </LinearGradientBrush>
 
     <Style x:Key="PanelBorderStyle" TargetType="Border">
@@ -36,12 +36,12 @@
         <Setter Property="Padding" Value="0" />
         <Setter Property="Stroke">
             <Setter.Value>
-                <SolidColorBrush Color="{AppThemeBinding Light=#3A7CA5, Dark=#EA580C}" />
+                <SolidColorBrush Color="{AppThemeBinding Light=#3A7CA5, Dark=#9AA3B1}" />
             </Setter.Value>
         </Setter>
         <Setter Property="Shadow">
             <Setter.Value>
-                <Shadow Brush="{AppThemeBinding Light=#883A7CA5, Dark=#88EA580C}" Offset="0,4" Radius="12" Opacity="0.45" />
+                <Shadow Brush="{AppThemeBinding Light=#883A7CA5, Dark=#6697A1B2}" Offset="0,4" Radius="12" Opacity="0.45" />
             </Setter.Value>
         </Setter>
     </Style>
@@ -49,7 +49,7 @@
     <Style x:Key="PanelSectionBorderStyle" TargetType="Border">
         <Setter Property="StrokeShape" Value="RoundRectangle 10" />
         <Setter Property="StrokeThickness" Value="0" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#242F47, Dark=#8B3D0A}" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#242F47, Dark=#802C343D}" />
     </Style>
 
     <Style x:Key="CanvasBorderStyle" TargetType="Border">
@@ -57,10 +57,10 @@
         <Setter Property="StrokeThickness" Value="1" />
         <Setter Property="Stroke" Value="Transparent" />
         <Setter Property="Padding" Value="10" />
-        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#1A2436, Dark=#2B1608}"/>
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#1A2436, Dark=#1D2329}"/>
         <Setter Property="Shadow">
             <Setter.Value>
-                <Shadow Brush="{AppThemeBinding Light=#663A7CA5, Dark=#66EA580C}" Offset="0,6" Radius="14" Opacity="0.5" />
+                <Shadow Brush="{AppThemeBinding Light=#663A7CA5, Dark=#66495766}" Offset="0,6" Radius="14" Opacity="0.5" />
             </Setter.Value>
         </Setter>
     </Style>


### PR DESCRIPTION
## Summary
- restyle dark mode panel gradients with cool gray tones for a metallic glass feel
- adjust dark theme borders, shadows, and canvas/background fills to match the refreshed palette

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cabda5bd2c8333a403cb98e0643947