### PR TITLE
Add pulsing background animations to main workflow pages

### DIFF
--- a/ElectricalImpedanceTomography/Extensions/VisualElementAnimationExtensions.cs
+++ b/ElectricalImpedanceTomography/Extensions/VisualElementAnimationExtensions.cs
@@ -1,0 +1,45 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace ElectricalImpedanceTomography.Extensions;
+
+public static class VisualElementAnimationExtensions
+{
+    private const string BackgroundPulseAnimationName = "BackgroundPulse";
+
+    public static void StartBackgroundPulse(this VisualElement element, Color startColor, Color endColor, uint duration = 5000)
+    {
+        if (element is null)
+        {
+            return;
+        }
+
+        element.AbortAnimation(BackgroundPulseAnimationName);
+        element.BackgroundColor = startColor;
+
+        var animation = new Animation();
+        animation.Add(0, 0.5, new Animation(v => element.BackgroundColor = InterpolateColor(startColor, endColor, v)));
+        animation.Add(0.5, 1, new Animation(v => element.BackgroundColor = InterpolateColor(endColor, startColor, v)));
+
+        animation.Commit(
+            element,
+            BackgroundPulseAnimationName,
+            length: duration,
+            easing: Easing.Linear,
+            repeat: () => true);
+    }
+
+    public static void StopBackgroundPulse(this VisualElement element)
+    {
+        element?.AbortAnimation(BackgroundPulseAnimationName);
+    }
+
+    private static Color InterpolateColor(in Color start, in Color end, double progress)
+    {
+        float r = (float)(start.Red + (end.Red - start.Red) * progress);
+        float g = (float)(start.Green + (end.Green - start.Green) * progress);
+        float b = (float)(start.Blue + (end.Blue - start.Blue) * progress);
+        float a = (float)(start.Alpha + (end.Alpha - start.Alpha) * progress);
+        return new Color(r, g, b, a);
+    }
+}

--- a/ElectricalImpedanceTomography/Views/DAQPage.xaml
+++ b/ElectricalImpedanceTomography/Views/DAQPage.xaml
@@ -10,7 +10,7 @@
              x:DataType="viewmodels:DAQPageViewModel"
              Shell.NavBarIsVisible="False"
              Title="DAQPage"
-             BackgroundColor="{AppThemeBinding Dark=#121212, Light=#CCCCCC}">
+             BackgroundColor="{AppThemeBinding Dark=#1A1426, Light=#EADFFB}">
     <ContentPage.Resources>
         <Style TargetType="Label">
             <Setter Property="FontFamily" Value="SF Pro Text"/>

--- a/ElectricalImpedanceTomography/Views/DAQPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/DAQPage.xaml.cs
@@ -1,19 +1,42 @@
+using ElectricalImpedanceTomography.Extensions;
 using ElectricalImpedanceTomography.ViewModels;
+using Microsoft.Maui.Graphics;
 
 namespace ElectricalImpedanceTomography.Views;
 
 public partial class DAQPage : ContentPage
 {
-	private readonly DAQPageViewModel _viewModel;
+        private readonly DAQPageViewModel _viewModel;
 
-	public DAQPage()
-	{
-		InitializeComponent();
+        public DAQPage()
+        {
+                InitializeComponent();
 
-		_viewModel = Utility.Composition.Container.ResolveObject<DAQPageViewModel>();
+                _viewModel = Utility.Composition.Container.ResolveObject<DAQPageViewModel>();
 
-		BindingContext = _viewModel;
-	}
+                BindingContext = _viewModel;
+        }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        var (startColor, endColor) = GetBackgroundPulseColors();
+        this.StartBackgroundPulse(startColor, endColor);
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        this.StopBackgroundPulse();
+    }
+
+    private static (Color Start, Color End) GetBackgroundPulseColors()
+    {
+        var theme = Application.Current?.RequestedTheme ?? AppTheme.Light;
+        return theme == AppTheme.Dark
+            ? (Color.FromArgb("#1A1426"), Color.FromArgb("#2A2140"))
+            : (Color.FromArgb("#EADFFB"), Color.FromArgb("#DCD1F5"));
+    }
 
     private void OnStopButtonPressed(object sender, EventArgs e)
     {

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml
@@ -10,7 +10,7 @@
              x:DataType="viewmodels:MainPageViewModel"
              Shell.NavBarIsVisible="False"
              Title="MainPage"
-             BackgroundColor="{AppThemeBinding Dark=#121212, Light=#CCCCCC}">
+             BackgroundColor="{AppThemeBinding Dark=#101B2B, Light=#D7E4F8}">
     <ContentPage.Resources>
         <Style TargetType="Label">
             <Setter Property="FontFamily" Value="SF Pro Text"/>

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using ElectricalImpedanceTomography.ViewModels;
+using ElectricalImpedanceTomography.Extensions;
 using SkiaSharp;
+using Microsoft.Maui.Graphics;
 using Utility.Classes.Application;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
@@ -38,10 +40,26 @@ namespace ElectricalImpedanceTomography.Views
         protected override void OnAppearing()
         {
             base.OnAppearing();
+            var (startColor, endColor) = GetBackgroundPulseColors();
+            this.StartBackgroundPulse(startColor, endColor);
             MeshCanvasView?.InvalidateSurface();
             if (ConsoleScroll != null && ConsoleStack != null)
                 MainThread.BeginInvokeOnMainThread(async () =>
                     await ConsoleScroll.ScrollToAsync(0, ConsoleStack.Height, false));
+        }
+
+        protected override void OnDisappearing()
+        {
+            base.OnDisappearing();
+            this.StopBackgroundPulse();
+        }
+
+        private static (Color Start, Color End) GetBackgroundPulseColors()
+        {
+            var theme = Application.Current?.RequestedTheme ?? AppTheme.Light;
+            return theme == AppTheme.Dark
+                ? (Color.FromArgb("#101B2B"), Color.FromArgb("#1A2F45"))
+                : (Color.FromArgb("#D7E4F8"), Color.FromArgb("#C8D6F2"));
         }
 
         private void OnLoadMeasurementClicked(object sender, EventArgs e)

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -9,7 +9,7 @@
              Title="MeshingPage"
              Shell.NavBarIsVisible="False"
              x:DataType="viewmodels:MeshingPageViewModel"
-             BackgroundColor="{AppThemeBinding Dark=#121212, Light=#CCCCCC}">
+             BackgroundColor="{AppThemeBinding Dark=#102024, Light=#D4EFE7}">
     <ContentPage.MenuBarItems>
         <MenuBarItem Text="Edit" IsEnabled="False">
             <MenuFlyoutItem Text="Undo"

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -1,9 +1,11 @@
+using ElectricalImpedanceTomography.Extensions;
 using ElectricalImpedanceTomography.ViewModels;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Discretizer;
+using Microsoft.Maui.Graphics;
 
 namespace ElectricalImpedanceTomography.Views;
 
@@ -56,11 +58,27 @@ public partial class MeshingPage : ContentPage
     protected override void OnAppearing()
     {
         base.OnAppearing();
+        var (startColor, endColor) = GetBackgroundPulseColors();
+        this.StartBackgroundPulse(startColor, endColor);
         _viewModel.LoadAvailableMeshes();
         _viewModel.LoadMeshFromWorkspace();
         if (_viewModel.GetCurrentMesh() == null)
             _viewModel.GenerateMesh();
         _viewModel.InvokeMeshChanged();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        this.StopBackgroundPulse();
+    }
+
+    private static (Color Start, Color End) GetBackgroundPulseColors()
+    {
+        var theme = Application.Current?.RequestedTheme ?? AppTheme.Light;
+        return theme == AppTheme.Dark
+            ? (Color.FromArgb("#102024"), Color.FromArgb("#1C3737"))
+            : (Color.FromArgb("#D4EFE7"), Color.FromArgb("#C2E3DA"));
     }
 
     private SKColor ColorForValue(double val, double max)

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -8,7 +8,7 @@
              x:Class="ElectricalImpedanceTomography.Views.ReconstructionPage"
              Title="ReconstructionPage"
              Shell.NavBarIsVisible="False"
-             BackgroundColor="{AppThemeBinding Dark=#121212, Light=#CCCCCC}"
+             BackgroundColor="{AppThemeBinding Dark=#1B1A13, Light=#F2E7D8}"
              x:DataType="viewmodels:ReconstructionPageViewModel">
     <ContentPage.MenuBarItems>
         <MenuBarItem Text="Reconstruction">

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Maui.Views;
+using ElectricalImpedanceTomography.Extensions;
 using ElectricalImpedanceTomography.ViewModels;
 using Microsoft.Maui.ApplicationModel;
 using SkiaSharp;
@@ -10,6 +11,7 @@ using Utility.Classes.Measurement;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Microsoft.Maui.Graphics;
 
 using Workspace = Utility.Classes.Application.Workspace;
 
@@ -82,7 +84,23 @@ public partial class ReconstructionPage : ContentPage
     protected override void OnAppearing()
     {
         base.OnAppearing();
+        var (startColor, endColor) = GetBackgroundPulseColors();
+        this.StartBackgroundPulse(startColor, endColor);
         _viewModel.LoadAvailableReconstructions();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        this.StopBackgroundPulse();
+    }
+
+    private static (Color Start, Color End) GetBackgroundPulseColors()
+    {
+        var theme = Application.Current?.RequestedTheme ?? AppTheme.Light;
+        return theme == AppTheme.Dark
+            ? (Color.FromArgb("#1B1A13"), Color.FromArgb("#2A281E"))
+            : (Color.FromArgb("#F2E7D8"), Color.FromArgb("#E6DAC9"));
     }
 
     private IDiscretization? GetDiscretization()


### PR DESCRIPTION
## Summary
- add a reusable VisualElement extension to animate background color pulses
- start and stop page-specific background pulses on the main, meshing, DAQ, and reconstruction pages with theme-aware palettes
- align XAML defaults with the animated starting colours for each page

## Testing
- dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cae0e014b88333a587bbc341f79f28