### PR TITLE
Add mesh deletion support from saved meshes panel

### DIFF
--- a/BusinessLayer/DAQPersistence.cs
+++ b/BusinessLayer/DAQPersistence.cs
@@ -27,13 +27,14 @@ namespace BusinessLayer
         public EITMeasurement LoadEITMeasurement(string name, DateTime savedAt) => _daqRepository.LoadEITMeasurement(name, savedAt);        
         public void DeleteEITMeasurement(string name, DateTime savedAt) => _daqRepository.DeleteEITMeasurement(name, savedAt);        
         public void SaveFEMMesh(FEMMesh mesh, string name) => _meshRepository.SaveFEMMesh(mesh, name);        
-        public void SaveLBMGrid(LBMGrid grid, string name) => _meshRepository.SaveLBMGrid(grid, name);        
-        public FEMMesh LoadFEMMesh(string filePath) => _meshRepository.LoadFEMMesh(filePath);        
-        public LBMGrid LoadLBMGrid(string filePath) => _meshRepository.LoadLBMGrid(filePath);        
-        public IEnumerable<DiscretizationInfo> GetDiscretizationInfos() => _meshRepository.GetDiscretizationInfos();        
-        public bool ConnectHardware() => _daqRepository.Connect();        
-        public bool DisconnectHardware() => _daqRepository.Disconnect();        
-        public bool ChangeHardwarePort(string portName) => _daqRepository.ChangePort(portName);        
+        public void SaveLBMGrid(LBMGrid grid, string name) => _meshRepository.SaveLBMGrid(grid, name);
+        public FEMMesh LoadFEMMesh(string filePath) => _meshRepository.LoadFEMMesh(filePath);
+        public LBMGrid LoadLBMGrid(string filePath) => _meshRepository.LoadLBMGrid(filePath);
+        public IEnumerable<DiscretizationInfo> GetDiscretizationInfos() => _meshRepository.GetDiscretizationInfos();
+        public void DeleteMesh(string filePath) => _meshRepository.DeleteMesh(filePath);
+        public bool ConnectHardware() => _daqRepository.Connect();
+        public bool DisconnectHardware() => _daqRepository.Disconnect();
+        public bool ChangeHardwarePort(string portName) => _daqRepository.ChangePort(portName);
         public void SetFrequency(double frequency) => _daqRepository.SetExcitationFrequency(frequency);
     }
 }

--- a/BusinessLayer/IDAQPersistence.cs
+++ b/BusinessLayer/IDAQPersistence.cs
@@ -21,6 +21,7 @@ namespace BusinessLayer
         FEMMesh LoadFEMMesh(string filePath);
         LBMGrid LoadLBMGrid(string filePath);
         IEnumerable<DiscretizationInfo> GetDiscretizationInfos();
+        void DeleteMesh(string filePath);
         bool ConnectHardware();
         bool DisconnectHardware();
         bool ChangeHardwarePort(string portName);

--- a/DataAccessLayer/IMeshRepository.cs
+++ b/DataAccessLayer/IMeshRepository.cs
@@ -11,5 +11,6 @@ namespace DataAccessLayer
         FEMMesh LoadFEMMesh(string filePath);
         LBMGrid LoadLBMGrid(string filePath);
         IEnumerable<DiscretizationInfo> GetDiscretizationInfos();
+        void DeleteMesh(string filePath);
     }
 }

--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -78,6 +78,24 @@ namespace DataAccessLayer
             }
         }
 
+        public void DeleteMesh(string filePath)
+        {
+            if (string.IsNullOrWhiteSpace(filePath))
+                throw new ArgumentException("File path required.", nameof(filePath));
+
+            if (!File.Exists(filePath))
+                return;
+
+            File.Delete(filePath);
+
+            if (string.Equals(Path.GetExtension(filePath), ".eitmesh", StringComparison.OrdinalIgnoreCase))
+            {
+                var stlFile = Path.ChangeExtension(filePath, ".stl");
+                if (!string.IsNullOrEmpty(stlFile) && File.Exists(stlFile))
+                    File.Delete(stlFile);
+            }
+        }
+
         public FEMMesh LoadFEMMesh(string filePath)
         {
             if (!File.Exists(filePath))

--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -389,6 +389,15 @@ namespace ElectricalImpedanceTomography.ViewModels
             MeshChanged?.Invoke();
         }
 
+        public void DeleteMesh(DiscretizationInfo mesh)
+        {
+            if (mesh == null)
+                return;
+
+            _daqService.DeleteMesh(mesh.FilePath);
+            LoadAvailableMeshes();
+        }
+
         private void ApplyMeshFilter()
         {
             FilteredMeshes.Clear();

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -532,6 +532,13 @@
                                             <Border.GestureRecognizers>
                                                 <TapGestureRecognizer Tapped="OnMeshSelected"/>
                                             </Border.GestureRecognizers>
+                                            <Border.ContextFlyout>
+                                                <MenuFlyout>
+                                                    <MenuFlyoutItem Text="Delete"
+                                                                    Clicked="OnDeleteMeshClicked"
+                                                                    CommandParameter="{Binding .}"/>
+                                                </MenuFlyout>
+                                            </Border.ContextFlyout>
                                         </Border>
                                     </DataTemplate>
                                 </BindableLayout.ItemTemplate>

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -5,6 +5,7 @@ using SkiaSharp.Views.Maui;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Discretizer;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 
 namespace ElectricalImpedanceTomography.Views;
@@ -493,6 +494,25 @@ public partial class MeshingPage : ContentPage
                 MeshCanvas.InvalidateSurface();
             }
         }
+    }
+
+    private async void OnDeleteMeshClicked(object sender, EventArgs e)
+    {
+        if (sender is not MenuFlyoutItem item)
+            return;
+
+        if (item.CommandParameter is not DiscretizationInfo info)
+            return;
+
+        bool confirm = await DisplayAlert("Delete Mesh",
+            $"Are you sure you want to delete \"{info.Name}\"?",
+            "OK",
+            "Cancel");
+
+        if (!confirm)
+            return;
+
+        _viewModel.DeleteMesh(info);
     }
 
     private bool PointInTriangle(SKPoint p, SKPoint a, SKPoint b, SKPoint c)

--- a/ServiceLayer/DAQService.cs
+++ b/ServiceLayer/DAQService.cs
@@ -215,6 +215,21 @@ namespace ServiceLayer
             }
         }
 
+        public void DeleteMesh(string filePath)
+        {
+            try
+            {
+                _daqPersistence.DeleteMesh(filePath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
         public bool ConnectHardware()
         {
             try

--- a/ServiceLayer/IDAQService.cs
+++ b/ServiceLayer/IDAQService.cs
@@ -21,6 +21,7 @@ namespace ServiceLayer
         FEMMesh LoadFEMMesh(string filePath);
         LBMGrid LoadLBMGrid(string filePath);
         IEnumerable<DiscretizationInfo> GetDiscretizationInfos();
+        void DeleteMesh(string filePath);
         bool ConnectHardware();
         bool DisconnectHardware();
         bool ChangeHardwarePort(string portName);


### PR DESCRIPTION
## Summary
- add a context flyout to saved meshes so users can delete entries with confirmation
- extend view model and service layers to remove mesh files and refresh the list

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc27cb891083338ff12604cd5a5c76