### PR TITLE
Add conductivity-aware W2 error metric option

### DIFF
--- a/Utility/Classes/Factories/ErrorMetricFactory.cs
+++ b/Utility/Classes/Factories/ErrorMetricFactory.cs
@@ -1,4 +1,5 @@
-﻿using Utility.Classes.ReconstructionParameters;
+﻿using Utility.Classes.Reconstruction.ErrorMetrics;
+using Utility.Classes.ReconstructionParameters;
 
 using Workspace = Utility.Classes.Application.Workspace;
 
@@ -13,6 +14,7 @@ namespace Utility.Classes.Factories
         {
             ErrorMetric.L2 => CreateL2Metric(),
             ErrorMetric.Wasserstein2 => CreateWasserstein2Metirc(),
+            ErrorMetric.ConductivityAwareW2 => CreateConductivityAwareW2Metric(),
             _ => throw new NotSupportedException()
         };
 
@@ -31,6 +33,15 @@ namespace Utility.Classes.Factories
             var metric = new Wasserstein2ErrorMetric();
 
             Workspace.AddLogMessage("ErrorMetricFactory", "Created Wasserstein2ErrorMetric object.");
+
+            return metric;
+        }
+
+        private static ConductivityAwareW2Metric CreateConductivityAwareW2Metric()
+        {
+            var metric = new ConductivityAwareW2Metric();
+
+            Workspace.AddLogMessage("ErrorMetricFactory", "Created ConductivityAwareW2Metric object.");
 
             return metric;
         }

--- a/Utility/Classes/ReconstructionParameters/ErrorMetric.cs
+++ b/Utility/Classes/ReconstructionParameters/ErrorMetric.cs
@@ -11,7 +11,8 @@ namespace Utility.Classes.ReconstructionParameters
     public enum ErrorMetric
     {
         L2 = 1,
-        Wasserstein2 = 2
+        Wasserstein2 = 2,
+        ConductivityAwareW2 = 3
     }
 
     /// <summary>

--- a/Utility/Tests/ErrorMetricTests.cs
+++ b/Utility/Tests/ErrorMetricTests.cs
@@ -1,4 +1,6 @@
 ﻿using System.Linq;
+using Utility.Classes.Factories;
+using Utility.Classes.Reconstruction.ErrorMetrics;
 using Utility.Classes.ReconstructionParameters;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
@@ -73,6 +75,14 @@ namespace Utility.Tests
 
             var phi = w2.EvaluateAdjointSource(mesh, meas, sim);
             Assert.Equal(meas.Length, phi.Length);
+        }
+
+        [Fact]
+        public void ErrorMetricFactory_Returns_ConductivityAwareW2Metric()
+        {
+            var metric = ErrorMetricFactory.Create(ErrorMetric.ConductivityAwareW2);
+
+            Assert.IsType<ConductivityAwareW2Metric>(metric);
         }
 
         private static FEMMesh TinyFEM()


### PR DESCRIPTION
## Summary
- expose the conductivity-aware W2 error metric through the reconstruction parameter enum
- update the error metric factory to construct the conductivity-aware W2 implementation
- add a regression test that checks the factory returns the conductivity-aware W2 metric

## Testing
- `dotnet test ElectricalImpedanceTomography.sln` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ad830bf08333b2c9b4598719d8ee