### PR TITLE
Fix FEM/LBM total variation and regularization gradients

### DIFF
--- a/Utility/Classes/ConductivityDistribution.cs
+++ b/Utility/Classes/ConductivityDistribution.cs
@@ -10,8 +10,8 @@ namespace Utility.Classes
 
         public ConductivityDistribution(Dictionary<int, double> conductivities)
         {
-            IdValuePairs = new Dictionary<int, double>();
-            Conductivities = conductivities;
+            Conductivities = new Dictionary<int, double>(conductivities);
+            IdValuePairs = Conductivities;
         }
 
         /// <summary>
@@ -44,9 +44,13 @@ namespace Utility.Classes
         }
 
         public override Dictionary<int,double> Get() => Conductivities;
-        public override void Set(Dictionary<int, double> conductivites) => Conductivities = conductivites;
-        public override double GetValue(int key) => Conductivities[key];
+        public override void Set(Dictionary<int, double> conductivites)
+        {
+            Conductivities = new Dictionary<int, double>(conductivites);
+            IdValuePairs = Conductivities;
+        }
+        public override double GetValue(int key) => Conductivities.TryGetValue(key, out var value) ? value : 0.0;
         public override void SetValue(int key, double value) => Conductivities[key] = value;
-    
+
     }
 }

--- a/Utility/Classes/PotentialDistribution.cs
+++ b/Utility/Classes/PotentialDistribution.cs
@@ -11,8 +11,8 @@ namespace Utility.Classes
 
         public PotentialDistribution(Dictionary<int, double> potentials)
         {
-            IdValuePairs = new Dictionary<int, double>();
-            Potentials = potentials;
+            Potentials = new Dictionary<int, double>(potentials);
+            IdValuePairs = Potentials;
         }
 
         public double GetPotential(int FEMVertexId)
@@ -31,8 +31,12 @@ namespace Utility.Classes
         }
 
         public override Dictionary<int, double> Get() => Potentials;
-        public override void Set(Dictionary<int, double> potentials) => Potentials = potentials;
-        public override double GetValue(int key) => Potentials[key];
+        public override void Set(Dictionary<int, double> potentials)
+        {
+            Potentials = new Dictionary<int, double>(potentials);
+            IdValuePairs = Potentials;
+        }
+        public override double GetValue(int key) => Potentials.TryGetValue(key, out var value) ? value : 0.0;
         public override void SetValue(int key, double value) => Potentials[key] = value;
     }
 }

--- a/Utility/Classes/ReconstructionParameters/RegularizationTechnique.cs
+++ b/Utility/Classes/ReconstructionParameters/RegularizationTechnique.cs
@@ -1,4 +1,5 @@
-﻿using Utility.Classes.Discretizer;
+﻿using System.Linq;
+using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Solvers;
@@ -131,19 +132,24 @@ namespace Utility.Classes.ReconstructionParameters
         public ConductivityDistribution EvaluateGradient(IDiscretization discretization, ConductivityDistribution sigma)
         {
             // Gradient is -λ * Δσ.
-            ScalarField laplacian;
             if (discretization is FEMMesh femMesh)
-                laplacian = FiniteElementOperators.CalculateLaplacian(femMesh, sigma.ToPotentialDistribution());
-            else if (discretization is LBMGrid lbmGrid)
-                laplacian = LatticeBoltzmannOperators.CalculateLaplacian(lbmGrid, sigma.ToPotentialDistribution());
-            else
-                throw new NotSupportedException($"Mesh type {discretization.GetType().Name} not supported for First-Order Tikhonov regularization.");
-            
-            var gradientDict = laplacian.IdValuePairs.ToDictionary(
-                kvp => kvp.Key,
-                kvp => -_lambda * kvp.Value
-            );
-            return new ConductivityDistribution(gradientDict);
+            {
+                var laplacian = FiniteElementOperators.CalculateLaplacian(femMesh, sigma.ToPotentialDistribution());
+                var projected = FiniteElementOperators.ProjectVertexFieldToElements(femMesh, laplacian);
+                var gradientDict = projected.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => -_lambda * kvp.Value);
+                return new ConductivityDistribution(gradientDict);
+            }
+            if (discretization is LBMGrid lbmGrid)
+            {
+                var laplacian = LatticeBoltzmannOperators.CalculateLaplacian(lbmGrid, sigma.ToPotentialDistribution());
+                var gradientDict = laplacian.Get().ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => -_lambda * kvp.Value);
+                return new ConductivityDistribution(gradientDict);
+            }
+            throw new NotSupportedException($"Mesh type {discretization.GetType().Name} not supported for First-Order Tikhonov regularization.");
         }
     }
 
@@ -165,8 +171,8 @@ namespace Utility.Classes.ReconstructionParameters
             else
                 throw new NotSupportedException($"Mesh type {discretization.GetType().Name} not supported.");
 
-            // Calculate L2-norm squared of the Laplacian field
-            double normSq = laplacian.IdValuePairs.Values.Sum(v => v * v);
+            // Calculate L2-norm squared of the Laplacian field (Eq. (A.5))
+            double normSq = laplacian.Get().Values.Sum(v => v * v);
             return 0.5 * _lambda * normSq;
         }
 
@@ -174,25 +180,26 @@ namespace Utility.Classes.ReconstructionParameters
         {
             // Gradient is λ * Δ^2 σ (bi-Laplacian).
             // This is achieved by applying the Laplacian operator twice.
-            ScalarField laplacian1, laplacian2;
             if (discretization is FEMMesh femMesh)
             {
-                laplacian1 = FiniteElementOperators.CalculateLaplacian(femMesh, sigma.ToPotentialDistribution());
-                laplacian2 = FiniteElementOperators.CalculateLaplacian(femMesh, laplacian1); // Apply again
+                var laplacian1 = FiniteElementOperators.CalculateLaplacian(femMesh, sigma.ToPotentialDistribution());
+                var laplacian2 = FiniteElementOperators.CalculateLaplacian(femMesh, laplacian1); // Δ(Δγ)
+                var projected = FiniteElementOperators.ProjectVertexFieldToElements(femMesh, laplacian2);
+                var gradientDict = projected.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => _lambda * kvp.Value);
+                return new ConductivityDistribution(gradientDict);
             }
-            else if (discretization is LBMGrid lbmGrid)
+            if (discretization is LBMGrid lbmGrid)
             {
-                laplacian1 = LatticeBoltzmannOperators.CalculateLaplacian(lbmGrid, sigma.ToPotentialDistribution());
-                laplacian2 = LatticeBoltzmannOperators.CalculateLaplacian(lbmGrid, laplacian1); // Apply again
+                var laplacian1 = LatticeBoltzmannOperators.CalculateLaplacian(lbmGrid, sigma.ToPotentialDistribution());
+                var laplacian2 = LatticeBoltzmannOperators.CalculateLaplacian(lbmGrid, laplacian1);
+                var gradientDict = laplacian2.Get().ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => _lambda * kvp.Value);
+                return new ConductivityDistribution(gradientDict);
             }
-            else
-                throw new NotSupportedException($"Mesh type {discretization.GetType().Name} not supported.");
-
-            var gradientDict = laplacian2.IdValuePairs.ToDictionary(
-                 kvp => kvp.Key,
-                 kvp => _lambda * kvp.Value
-             );
-            return new ConductivityDistribution(gradientDict);
+            throw new NotSupportedException($"Mesh type {discretization.GetType().Name} not supported.");
         }
     }
 
@@ -237,43 +244,40 @@ namespace Utility.Classes.ReconstructionParameters
 
             // 1. Calculate the gradient field: ∇σ
             VectorField gradSigma;
-            if (discretization is FEMMesh femMesh) // Note: Gradient is on elements, Divergence is on nodes. This needs careful handling.
+            Dictionary<int, double> divergence;
+            if (discretization is FEMMesh femMesh)
+            {
                 gradSigma = FiniteElementOperators.CalculateElementWiseGradient(femMesh, sigma.ToPotentialDistribution());
+                var normalizedGradData = gradSigma.Data.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp =>
+                    {
+                        double mag = Math.Sqrt(kvp.Value.X * kvp.Value.X + kvp.Value.Y * kvp.Value.Y);
+                        double divisor = Math.Max(mag, Epsilon);
+                        return (kvp.Value.X / divisor, kvp.Value.Y / divisor);
+                    });
+                var normalizedGradField = new VectorField(normalizedGradData);
+                divergence = FiniteElementOperators.CalculateElementWiseDivergence(femMesh, normalizedGradField);
+            }
             else if (discretization is LBMGrid grid)
+            {
                 gradSigma = LatticeBoltzmannOperators.CalculateGradient(grid, sigma.ToPotentialDistribution());
-            else
-                throw new NotSupportedException($"Mesh type {discretization.GetType().Name} not supported.");
-
-            // 2. Normalize the gradient field: ∇σ / (||∇σ|| + ε)
-            var normalizedGradData = gradSigma.Data.ToDictionary(
-                kvp => kvp.Key,
-                kvp =>
-                {
-                    double mag = Math.Sqrt(kvp.Value.X * kvp.Value.X + kvp.Value.Y * kvp.Value.Y);
-                    double divisor = mag + Epsilon;
-                    return (kvp.Value.X / divisor, kvp.Value.Y / divisor);
-                }
-            );
-            var normalizedGradField = new VectorField(normalizedGradData);
-
-            // 3. Calculate the divergence of the normalized field: ∇·(...)
-            ScalarField divergence;
-            if (discretization is LBMGrid lbmGrid)
-            {
-                divergence = LatticeBoltzmannOperators.CalculateDivergence(lbmGrid, normalizedGradField);
-            }
-            else if (discretization is FEMMesh)
-            {
-                // NOTE: Implementing divergence on an FEM mesh is complex.
-                // It requires integrating over element patches, similar to the Laplacian.
-                // This is a placeholder for that advanced implementation.
-                throw new NotImplementedException("Divergence for FEM meshes is not yet implemented in the operators helper.");
+                var normalizedGradData = gradSigma.Data.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp =>
+                    {
+                        double mag = Math.Sqrt(kvp.Value.X * kvp.Value.X + kvp.Value.Y * kvp.Value.Y);
+                        double divisor = Math.Max(mag, Epsilon);
+                        return (kvp.Value.X / divisor, kvp.Value.Y / divisor);
+                    });
+                var normalizedGradField = new VectorField(normalizedGradData);
+                divergence = LatticeBoltzmannOperators.CalculateDivergence(grid, normalizedGradField).Get();
             }
             else
                 throw new NotSupportedException($"Mesh type {discretization.GetType().Name} not supported.");
 
-            // 4. Scale by -λ
-            var gradientDict = divergence.IdValuePairs.ToDictionary(
+            // 4. Scale by -λ (Eq. (A.6))
+            var gradientDict = divergence.ToDictionary(
                 kvp => kvp.Key,
                 kvp => -_lambda * kvp.Value
             );

--- a/Utility/Classes/Solvers/FiniteElementSolver/FiniteElementOperators.cs
+++ b/Utility/Classes/Solvers/FiniteElementSolver/FiniteElementOperators.cs
@@ -1,4 +1,6 @@
-﻿using Utility.Classes.Discretizer.FiniteElementMesh;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes.Discretizer.FiniteElementMesh;
 
 namespace Utility.Classes.Solvers.FiniteElementSolver
 {
@@ -48,6 +50,100 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             }
 
             return new VectorField(gradientData);
+        }
+
+        /// <summary>
+        /// Calculates the divergence of a piecewise constant vector field defined per element
+        /// by integrating the fluxes over the edges (discrete Gauss theorem).
+        /// </summary>
+        /// <remarks>
+        /// This operator is used in the TV gradient (Eq. (A.6)) to assemble
+        /// ∇·(∇γ / ||∇γ||) directly on the conductivity elements.
+        /// </remarks>
+        public static Dictionary<int, double> CalculateElementWiseDivergence(FEMMesh femMesh, VectorField elementField)
+        {
+            var divergence = new Dictionary<int, double>();
+            var elements = femMesh.GetElements().Cast<FEMElement>().ToList();
+            var edgeToElements = BuildEdgeToElementMap(elements);
+
+            foreach (var element in elements)
+            {
+                double centroidX = element.Vertices.Average(v => v.X);
+                double centroidY = element.Vertices.Average(v => v.Y);
+                double elementFlux = 0.0;
+
+                for (int i = 0; i < element.Vertices.Count; i++)
+                {
+                    var vStart = element.Vertices[i];
+                    var vEnd = element.Vertices[(i + 1) % element.Vertices.Count];
+
+                    double edgeDx = vEnd.X - vStart.X;
+                    double edgeDy = vEnd.Y - vStart.Y;
+                    double edgeLength = Math.Sqrt(edgeDx * edgeDx + edgeDy * edgeDy);
+                    if (edgeLength < 1e-12)
+                        continue;
+
+                    // Outward unit normal (rotate edge by +90° and orient away from centroid)
+                    double nx = edgeDy;
+                    double ny = -edgeDx;
+                    double midX = 0.5 * (vStart.X + vEnd.X);
+                    double midY = 0.5 * (vStart.Y + vEnd.Y);
+                    double toCentroidX = centroidX - midX;
+                    double toCentroidY = centroidY - midY;
+                    if (nx * toCentroidX + ny * toCentroidY > 0)
+                    {
+                        nx = -nx;
+                        ny = -ny;
+                    }
+                    double invLength = 1.0 / edgeLength;
+                    nx *= invLength;
+                    ny *= invLength;
+
+                    var key = NormaliseEdgeKey(vStart.GlobalId, vEnd.GlobalId);
+                    edgeToElements.TryGetValue(key, out var attachedElements);
+                    int neighbourId = attachedElements?.FirstOrDefault(id => id != element.Id) ?? -1;
+
+                    var (fx, fy) = elementField.GetVector(element.Id);
+                    double flux;
+                    if (neighbourId >= 0)
+                    {
+                        var (fnx, fny) = elementField.GetVector(neighbourId);
+                        flux = 0.5 * ((fx + fnx) * nx + (fy + fny) * ny);
+                    }
+                    else
+                    {
+                        flux = fx * nx + fy * ny;
+                    }
+
+                    elementFlux += flux * edgeLength;
+                }
+
+                double area = Math.Max(element.Area, 1e-12);
+                divergence[element.Id] = elementFlux / area;
+            }
+
+            return divergence;
+        }
+
+        /// <summary>
+        /// Projects a nodal scalar field (e.g., Δγ at vertices) onto the elements by averaging
+        /// the values of the element's vertices. This allows us to express vertex-based
+        /// operators in the conductivity space (Eq. (A.4)).
+        /// </summary>
+        public static Dictionary<int, double> ProjectVertexFieldToElements(FEMMesh femMesh, ScalarField vertexField)
+        {
+            var projection = new Dictionary<int, double>();
+
+            foreach (var element in femMesh.GetElements().Cast<FEMElement>())
+            {
+                double sum = 0.0;
+                foreach (var v in element.Vertices)
+                    sum += vertexField.GetValue(v.GlobalId);
+
+                projection[element.Id] = sum / element.Vertices.Count;
+            }
+
+            return projection;
         }
 
         /// <summary>
@@ -147,6 +243,30 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             if (!adjacency[u].Contains(v)) adjacency[u].Add(v);
             if (!adjacency[v].Contains(u)) adjacency[v].Add(u);
         }
+
+        private static Dictionary<(int, int), List<int>> BuildEdgeToElementMap(IEnumerable<FEMElement> elements)
+        {
+            var map = new Dictionary<(int, int), List<int>>();
+            foreach (var element in elements)
+            {
+                for (int i = 0; i < element.Vertices.Count; i++)
+                {
+                    int idA = element.Vertices[i].GlobalId;
+                    int idB = element.Vertices[(i + 1) % element.Vertices.Count].GlobalId;
+                    var key = NormaliseEdgeKey(idA, idB);
+                    if (!map.TryGetValue(key, out var list))
+                    {
+                        list = new List<int>();
+                        map[key] = list;
+                    }
+                    if (!list.Contains(element.Id))
+                        list.Add(element.Id);
+                }
+            }
+            return map;
+        }
+
+        private static (int, int) NormaliseEdgeKey(int a, int b) => a < b ? (a, b) : (b, a);
 
         #endregion
     }


### PR DESCRIPTION
## Summary
- keep scalar field dictionaries in sync so regularization terms no longer return zero
- add finite element divergence/projection operators and wire total variation gradient for FEM/LBM
- align first-order and Laplace regularizers with element conductivities and annotate equations

## Testing
- ❌ `dotnet test ElectricalImpedanceTomography.sln` *(command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d45e1b8894833399cab402d9fd336f