### PR TITLE
Add progress popup for reconstruction video export

### DIFF
--- a/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
+++ b/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
@@ -83,11 +83,14 @@
           <Compile Update="Controls\PlusMinusEntryControl.xaml.cs">
             <DependentUpon>PlusMinusEntryControl.xaml</DependentUpon>
           </Compile>
+          <Compile Update="Views\VideoExportProgressPopup.xaml.cs">
+            <DependentUpon>VideoExportProgressPopup.xaml</DependentUpon>
+          </Compile>
         </ItemGroup>
 
         <ItemGroup>
-	  <MauiXaml Update="Controls\NavBarControl.xaml">
-	    <Generator>MSBuild:Compile</Generator>
+          <MauiXaml Update="Controls\NavBarControl.xaml">
+            <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
           <MauiXaml Update="Views\BoundaryConditionPopup.xaml">
             <Generator>MSBuild:Compile</Generator>
@@ -108,6 +111,9 @@
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
           <MauiXaml Update="Views\ReconstructionPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\VideoExportProgressPopup.xaml">
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
         </ItemGroup>

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Utility.Classes;
 using Utility.Classes.Discretizer;
@@ -58,6 +59,33 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         [ObservableProperty]
         private string reconstructionSearchText = string.Empty;
+
+        [ObservableProperty]
+        private bool videoExportIsRunning;
+
+        [ObservableProperty]
+        private bool videoExportHasResult;
+
+        [ObservableProperty]
+        private bool videoExportWasSuccessful;
+
+        [ObservableProperty]
+        private string videoExportHeading = "Video Generation in Progress";
+
+        [ObservableProperty]
+        private string videoExportStatusMessage = string.Empty;
+
+        [ObservableProperty]
+        private double videoExportProgress;
+
+        [ObservableProperty]
+        private string videoExportProgressPercentText = "0%";
+
+        [ObservableProperty]
+        private string? videoExportFilePath;
+
+        [ObservableProperty]
+        private VideoExportResult? videoExportResult;
 
         public ObservableCollection<ReconstructionInfo> AvailableReconstructions { get; } = [];
         public ObservableCollection<ReconstructionInfo> FilteredReconstructions { get; } = [];
@@ -393,7 +421,9 @@ namespace ElectricalImpedanceTomography.ViewModels
         public async Task<VideoExportResult> ExportReconstructionVideoAsync(SKSize distributionCanvasSize,
                                                                             SKSize colorbarCanvasSize,
                                                                             SKSize residualCanvasSize,
-                                                                            PotentialDisplayMode mode)
+                                                                            PotentialDisplayMode mode,
+                                                                            IProgress<VideoExportProgressReport>? progress = null,
+                                                                            CancellationToken cancellationToken = default)
         {
             var frames = Workspace.GetReconstructionFrames().ToList();
             if (frames.Count == 0)
@@ -402,6 +432,9 @@ namespace ElectricalImpedanceTomography.ViewModels
             var discretization = Workspace.GetDiscretization();
             if (discretization == null)
                 return VideoExportResult.CreateFailure("No Mesh", "Unable to determine the discretization for rendering.");
+
+            progress?.Report(new VideoExportProgressReport(0.0,
+                                                            "Preparing reconstruction frames for video generation..."));
 
             var results = Workspace.GetReconstructionResults().ToList();
             var residualHistory = results
@@ -421,12 +454,22 @@ namespace ElectricalImpedanceTomography.ViewModels
             {
                 await Task.Run(() =>
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     var frameData = new List<byte[]>(frames.Count);
                     int videoWidth = 0;
                     int videoHeight = 0;
 
+                    double totalSteps = frames.Count + 1.0;
+
                     for (int i = 0; i < frames.Count; i++)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        double progressValue = (i + 1) / totalSteps;
+                        progress?.Report(new VideoExportProgressReport(progressValue,
+                                                                        $"Rendering frame {i + 1} of {frames.Count}..."));
+
                         var context = ReconstructionVideoRenderer.FindResultForFrame(results, i, out int resultIndex);
                         int residualCount = resultIndex >= 0
                             ? Math.Min(resultIndex + 1, residualHistory.Count)
@@ -475,6 +518,11 @@ namespace ElectricalImpedanceTomography.ViewModels
                         frameData.Add(rawFrame);
                     }
 
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    progress?.Report(new VideoExportProgressReport(Math.Min(0.98, frames.Count / (frames.Count + 1.0)),
+                                                                    "Encoding video stream..."));
+
                     using var stream = File.Create(filePath);
                     AviVideoWriter.Write(stream,
                                          frameData,
@@ -483,12 +531,93 @@ namespace ElectricalImpedanceTomography.ViewModels
                                          Workspace.ReconstructionVideoFramesPerSecond);
                 });
 
+                progress?.Report(new VideoExportProgressReport(1.0, "Video generation completed."));
                 return VideoExportResult.CreateSuccess(filePath);
+            }
+            catch (OperationCanceledException)
+            {
+                if (File.Exists(filePath))
+                {
+                    try
+                    {
+                        File.Delete(filePath);
+                    }
+                    catch
+                    {
+                        // Ignore any errors encountered during cleanup.
+                    }
+                }
+
+                return VideoExportResult.CreateFailure("Export Aborted", "The video export was aborted.");
             }
             catch (Exception ex)
             {
                 return VideoExportResult.CreateFailure("Export Failed", ex.Message);
             }
+        }
+
+        public void BeginVideoExportProgress()
+        {
+            VideoExportIsRunning = true;
+            VideoExportHasResult = false;
+            VideoExportWasSuccessful = false;
+            VideoExportHeading = "Video Generation in Progress";
+            VideoExportStatusMessage = "Preparing video generation...";
+            UpdateVideoExportProgressCore(0.0);
+            VideoExportFilePath = null;
+            VideoExportResult = null;
+        }
+
+        public void UpdateVideoExportProgress(VideoExportProgressReport report)
+        {
+            UpdateVideoExportProgressCore(report.Progress);
+            VideoExportStatusMessage = report.StatusMessage;
+        }
+
+        public void NotifyVideoExportAborting()
+        {
+            VideoExportStatusMessage = "Aborting video generation...";
+        }
+
+        public void CompleteVideoExport(VideoExportResult result)
+        {
+            VideoExportIsRunning = false;
+            VideoExportHasResult = true;
+            VideoExportWasSuccessful = result.Success;
+            VideoExportResult = result;
+
+            if (result.Success)
+            {
+                VideoExportHeading = "Video Generated Successfully";
+                VideoExportStatusMessage = "Your reconstruction video is ready.";
+                VideoExportFilePath = result.FilePath;
+                UpdateVideoExportProgressCore(1.0);
+            }
+            else
+            {
+                VideoExportHeading = result.ErrorTitle ?? "Export Failed";
+                VideoExportStatusMessage = result.ErrorMessage ?? "An unknown error occurred during video export.";
+                VideoExportFilePath = null;
+            }
+        }
+
+        public void ResetVideoExportState()
+        {
+            VideoExportIsRunning = false;
+            VideoExportHasResult = false;
+            VideoExportWasSuccessful = false;
+            VideoExportHeading = "Video Generation in Progress";
+            VideoExportStatusMessage = string.Empty;
+            UpdateVideoExportProgressCore(0.0);
+            VideoExportFilePath = null;
+            VideoExportResult = null;
+        }
+
+        private void UpdateVideoExportProgressCore(double progress)
+        {
+            double clamped = Math.Clamp(progress, 0.0, 1.0);
+            VideoExportProgress = clamped;
+            VideoExportProgressPercentText = $"{Math.Round(clamped * 100.0)}%";
         }
 
         private void ApplyReconstructionFilter()

--- a/ElectricalImpedanceTomography/ViewModels/VideoExportProgressReport.cs
+++ b/ElectricalImpedanceTomography/ViewModels/VideoExportProgressReport.cs
@@ -1,0 +1,3 @@
+namespace ElectricalImpedanceTomography.ViewModels;
+
+public sealed record VideoExportProgressReport(double Progress, string StatusMessage);

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -1271,22 +1271,27 @@ public partial class ReconstructionPage : ContentPage
 
         ExportVideoButton.IsEnabled = false;
 
-        var result = await _viewModel.ExportReconstructionVideoAsync(
+        var popup = new VideoExportProgressPopup(_viewModel,
             PotentialDistributionCanvas.CanvasSize,
             PotentialColorbarCanvas.CanvasSize,
             ResidualTrendCanvas.CanvasSize,
             _potMode);
 
+        var popupResult = await this.ShowPopupAsync(popup) as VideoExportPopupResult;
+
         UpdateExportButtonState();
 
-        if (result.Success)
+        if (popupResult is { WasAborted: true, Result: var aborted })
         {
-            await DisplayAlert("Export Complete", $"Video exported to:\n{result.FilePath}", "OK");
+            string title = aborted.ErrorTitle ?? "Export Aborted";
+            string message = aborted.ErrorMessage ?? "The video export was aborted.";
+            await DisplayAlert(title, message, "OK");
         }
-        else
+        else if (popupResult is { Result.Success: false, WasAborted: false })
         {
-            string title = result.ErrorTitle ?? "Export Failed";
-            string message = result.ErrorMessage ?? "Unknown error.";
+            var failure = popupResult.Result;
+            string title = failure.ErrorTitle ?? "Export Failed";
+            string message = failure.ErrorMessage ?? "Unknown error.";
             await DisplayAlert(title, message, "OK");
         }
     }

--- a/ElectricalImpedanceTomography/Views/VideoExportProgressPopup.xaml
+++ b/ElectricalImpedanceTomography/Views/VideoExportProgressPopup.xaml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<toolkit:Popup
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:toolkit="clr-namespace:CommunityToolkit.Maui.Views;assembly=CommunityToolkit.Maui"
+    x:Class="ElectricalImpedanceTomography.Views.VideoExportProgressPopup"
+    CanBeDismissedByTappingOutsideOfPopup="False"
+    Color="#66000000">
+
+    <Border
+        StrokeShape="RoundRectangle 18"
+        StrokeThickness="0"
+        Padding="24"
+        WidthRequest="420"
+        BackgroundColor="{AppThemeBinding Light=#F8FAFC, Dark=#111827}">
+        <Border.Shadow>
+            <Shadow
+                Brush="{AppThemeBinding Light=#1F2937, Dark=#000000}"
+                Radius="24"
+                Opacity="0.25" />
+        </Border.Shadow>
+
+        <VerticalStackLayout Spacing="24">
+            <Label
+                Text="{Binding VideoExportHeading}"
+                FontSize="20"
+                FontAttributes="Bold"
+                HorizontalOptions="Center"
+                TextColor="{AppThemeBinding Light=#0F172A, Dark=#E2E8F0}" />
+
+            <Border
+                StrokeShape="RoundRectangle 16"
+                BackgroundColor="{AppThemeBinding Light=#E0F2FE, Dark=#1D3A5F}"
+                Padding="20"
+                HorizontalOptions="Center"
+                IsVisible="{Binding VideoExportIsRunning}">
+                <ActivityIndicator
+                    WidthRequest="48"
+                    HeightRequest="48"
+                    IsRunning="{Binding VideoExportIsRunning}"
+                    Color="{AppThemeBinding Light=#2563EB, Dark=#60A5FA}" />
+            </Border>
+
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+                <ProgressBar
+                    Progress="{Binding VideoExportProgress}"
+                    HeightRequest="8"
+                    VerticalOptions="Center"
+                    ProgressColor="{AppThemeBinding Light=#2563EB, Dark=#60A5FA}"
+                    BackgroundColor="{AppThemeBinding Light=#E2E8F0, Dark=#1F2A3A}" />
+                <Label
+                    Grid.Column="1"
+                    Text="{Binding VideoExportProgressPercentText}"
+                    FontAttributes="Bold"
+                    FontSize="16"
+                    VerticalOptions="Center"
+                    TextColor="{AppThemeBinding Light=#0F172A, Dark=#E2E8F0}" />
+            </Grid>
+
+            <Label
+                Text="{Binding VideoExportStatusMessage}"
+                FontSize="14"
+                TextColor="{AppThemeBinding Light=#334155, Dark=#CBD5F5}"
+                LineBreakMode="WordWrap" />
+
+            <Border
+                IsVisible="{Binding VideoExportWasSuccessful}"
+                StrokeShape="RoundRectangle 12"
+                BackgroundColor="{AppThemeBinding Light=#ECFDF5, Dark=#0F2A1F}"
+                Padding="16">
+                <VerticalStackLayout Spacing="4">
+                    <Label
+                        Text="Saved to"
+                        FontAttributes="Bold"
+                        FontSize="14"
+                        TextColor="{AppThemeBinding Light=#047857, Dark=#6EE7B7}" />
+                    <Label
+                        Text="{Binding VideoExportFilePath}"
+                        FontSize="13"
+                        TextColor="{AppThemeBinding Light=#064E3B, Dark=#A7F3D0}"
+                        LineBreakMode="CharacterWrap" />
+                </VerticalStackLayout>
+            </Border>
+
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="16">
+                <Button
+                    x:Name="AbortButton"
+                    Text="Abort"
+                    Clicked="OnAbortClicked"
+                    IsVisible="{Binding VideoExportIsRunning}"
+                    BackgroundColor="{AppThemeBinding Light=#F87171, Dark=#7F1D1D}"
+                    TextColor="White"
+                    CornerRadius="10"
+                    Padding="12,8"
+                    FontAttributes="Bold" />
+                <Button
+                    Grid.Column="1"
+                    Text="Done"
+                    Clicked="OnDoneClicked"
+                    IsVisible="{Binding VideoExportHasResult}"
+                    IsEnabled="{Binding VideoExportHasResult}"
+                    BackgroundColor="{AppThemeBinding Light=#2563EB, Dark=#1D4ED8}"
+                    TextColor="White"
+                    CornerRadius="10"
+                    Padding="18,8"
+                    FontAttributes="Bold" />
+            </Grid>
+        </VerticalStackLayout>
+    </Border>
+</toolkit:Popup>

--- a/ElectricalImpedanceTomography/Views/VideoExportProgressPopup.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/VideoExportProgressPopup.xaml.cs
@@ -1,0 +1,124 @@
+using CommunityToolkit.Maui.Views;
+using ElectricalImpedanceTomography.Helpers;
+using ElectricalImpedanceTomography.ViewModels;
+using SkiaSharp;
+using System;
+using System.Threading;
+
+namespace ElectricalImpedanceTomography.Views;
+
+public partial class VideoExportProgressPopup : Popup
+{
+    private readonly ReconstructionPageViewModel _viewModel;
+    private readonly SKSize _distributionCanvasSize;
+    private readonly SKSize _colorbarCanvasSize;
+    private readonly SKSize _residualCanvasSize;
+    private readonly PotentialDisplayMode _mode;
+
+    private CancellationTokenSource? _cancellationTokenSource;
+    private bool _closeOnCompletion;
+
+    public VideoExportProgressPopup(ReconstructionPageViewModel viewModel,
+                                    SKSize distributionCanvasSize,
+                                    SKSize colorbarCanvasSize,
+                                    SKSize residualCanvasSize,
+                                    PotentialDisplayMode mode)
+    {
+        InitializeComponent();
+
+        _viewModel = viewModel;
+        BindingContext = viewModel;
+        _distributionCanvasSize = distributionCanvasSize;
+        _colorbarCanvasSize = colorbarCanvasSize;
+        _residualCanvasSize = residualCanvasSize;
+        _mode = mode;
+    }
+
+    protected override void OnOpened()
+    {
+        base.OnOpened();
+        StartExport();
+    }
+
+    private async void StartExport()
+    {
+        _cancellationTokenSource = new CancellationTokenSource();
+        _viewModel.BeginVideoExportProgress();
+
+        var progress = new Progress<VideoExportProgressReport>(report =>
+        {
+            _viewModel.UpdateVideoExportProgress(report);
+        });
+
+        var token = _cancellationTokenSource.Token;
+        VideoExportResult result;
+
+        try
+        {
+            result = await _viewModel.ExportReconstructionVideoAsync(
+                _distributionCanvasSize,
+                _colorbarCanvasSize,
+                _residualCanvasSize,
+                _mode,
+                progress,
+                token);
+        }
+        catch (Exception ex)
+        {
+            result = VideoExportResult.CreateFailure("Export Failed", ex.Message);
+        }
+
+        _viewModel.CompleteVideoExport(result);
+
+        if (_closeOnCompletion)
+        {
+            Close(new VideoExportPopupResult(result, true));
+        }
+    }
+
+    private void OnAbortClicked(object sender, EventArgs e)
+    {
+        if (_cancellationTokenSource == null)
+            return;
+
+        if (!_cancellationTokenSource.IsCancellationRequested)
+        {
+            AbortButton.IsEnabled = false;
+            _viewModel.NotifyVideoExportAborting();
+            _cancellationTokenSource.Cancel();
+            _closeOnCompletion = true;
+        }
+    }
+
+    private void OnDoneClicked(object sender, EventArgs e)
+    {
+        var result = _viewModel.VideoExportResult
+                     ?? VideoExportResult.CreateFailure("Export Failed", "No export result was produced.");
+
+        Close(new VideoExportPopupResult(result, false));
+    }
+
+    protected override void OnClosed()
+    {
+        base.OnClosed();
+
+        if (_cancellationTokenSource != null)
+        {
+            try
+            {
+                _cancellationTokenSource.Cancel();
+            }
+            catch
+            {
+                // Ignore cancellation errors when tearing down the popup.
+            }
+
+            _cancellationTokenSource.Dispose();
+            _cancellationTokenSource = null;
+        }
+
+        _viewModel.ResetVideoExportState();
+    }
+}
+
+public sealed record VideoExportPopupResult(VideoExportResult Result, bool WasAborted);


### PR DESCRIPTION
## Summary
- add a modern video export progress popup with spinner, progress bar, percentage indicator, and final success details
- wire the popup into the reconstruction page so users can cancel exports or acknowledge successful completion
- report export progress from the view model, including cancellation handling and cleanup

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d50c4647a08333b85ca30415d31dce