### PR TITLE
Stream video export frames to reduce memory usage

### DIFF
--- a/ElectricalImpedanceTomography/Helpers/AviVideoWriter.cs
+++ b/ElectricalImpedanceTomography/Helpers/AviVideoWriter.cs
@@ -31,153 +31,26 @@ internal static class AviVideoWriter
         if (framesPerSecond <= 0)
             throw new ArgumentOutOfRangeException(nameof(framesPerSecond));
 
-        int maxFrameSize = frames.Max(f => f.Length);
-        if (maxFrameSize == 0)
+        int frameSize = frames[0].Length;
+        if (frameSize == 0)
             throw new ArgumentException("Frame data was empty.", nameof(frames));
-        if (frames.Any(f => f.Length != maxFrameSize))
+        if (frames.Any(f => f.Length != frameSize))
             throw new ArgumentException("All frames must have the same size.", nameof(frames));
 
-        uint microSecPerFrame = (uint)Math.Round(1_000_000d / framesPerSecond);
-        uint bytesPerSecond = (uint)(maxFrameSize * framesPerSecond);
-        uint suggestedBufferSize = (uint)maxFrameSize;
-        uint totalFrames = (uint)frames.Count;
-
-        using var writer = new BinaryWriter(stream, Encoding.ASCII, leaveOpen: true);
-
-        WriteFourCC(writer, "RIFF");
-        long riffSizePos = writer.BaseStream.Position;
-        writer.Write(0);
-        WriteFourCC(writer, "AVI ");
-
-        long hdrlListStart = writer.BaseStream.Position;
-        WriteFourCC(writer, "LIST");
-        long hdrlSizePos = writer.BaseStream.Position;
-        writer.Write(0);
-        WriteFourCC(writer, "hdrl");
-
-        WriteAviHeader(writer,
-                       microSecPerFrame,
-                       bytesPerSecond,
-                       suggestedBufferSize,
-                       totalFrames,
-                       (uint)width,
-                       (uint)height,
-                       (uint)framesPerSecond,
-                       (uint)maxFrameSize,
-                       BitsPerPixel);
-
-        long hdrlListEnd = writer.BaseStream.Position;
-        UpdateChunkSize(writer, hdrlSizePos, hdrlListEnd);
-
-        long moviListStart = writer.BaseStream.Position;
-        WriteFourCC(writer, "LIST");
-        long moviSizePos = writer.BaseStream.Position;
-        writer.Write(0);
-        WriteFourCC(writer, "movi");
-
-        var indexEntries = new List<AviIndexEntry>(frames.Count);
-
+        using var writer = BeginWrite(stream, width, height, framesPerSecond, frameSize);
         foreach (var frame in frames)
-        {
-            long chunkStart = writer.BaseStream.Position;
-            WriteFourCC(writer, "00db");
-            writer.Write(frame.Length);
-            writer.Write(frame);
-            if ((frame.Length & 1) == 1)
-                writer.Write((byte)0);
+            writer.WriteFrame(frame);
 
-            uint offset = (uint)(chunkStart - moviListStart - 4);
-            indexEntries.Add(new AviIndexEntry(VideoChunkFourCc, AviIfKeyFrame, offset, (uint)frame.Length));
-        }
-
-        long moviListEnd = writer.BaseStream.Position;
-        UpdateChunkSize(writer, moviSizePos, moviListEnd);
-
-        WriteFourCC(writer, "idx1");
-        writer.Write(indexEntries.Count * 16);
-        foreach (var entry in indexEntries)
-        {
-            writer.Write(entry.ChunkId);
-            writer.Write(entry.Flags);
-            writer.Write(entry.Offset);
-            writer.Write(entry.Size);
-        }
-
-        long fileEnd = writer.BaseStream.Position;
-        UpdateChunkSize(writer, riffSizePos, fileEnd);
-        writer.BaseStream.Seek(fileEnd, SeekOrigin.Begin);
+        writer.Complete();
     }
 
-    private static void WriteAviHeader(BinaryWriter writer,
-                                       uint microSecPerFrame,
-                                       uint bytesPerSecond,
-                                       uint suggestedBufferSize,
-                                       uint totalFrames,
-                                       uint width,
-                                       uint height,
-                                       uint framesPerSecond,
-                                       uint imageSize,
-                                       ushort bitsPerPixel)
+    public static AviVideoStream BeginWrite(Stream stream,
+                                            int width,
+                                            int height,
+                                            int framesPerSecond,
+                                            int frameSize)
     {
-        WriteFourCC(writer, "avih");
-        writer.Write(56);
-        writer.Write(microSecPerFrame);
-        writer.Write(bytesPerSecond);
-        writer.Write(0u);
-        writer.Write(AviMainHeaderHasIndex);
-        writer.Write(totalFrames);
-        writer.Write(0u);
-        writer.Write(1u);
-        writer.Write(suggestedBufferSize);
-        writer.Write(width);
-        writer.Write(height);
-        writer.Write(0u);
-        writer.Write(0u);
-        writer.Write(0u);
-        writer.Write(0u);
-
-        long strlListStart = writer.BaseStream.Position;
-        WriteFourCC(writer, "LIST");
-        long strlSizePos = writer.BaseStream.Position;
-        writer.Write(0);
-        WriteFourCC(writer, "strl");
-
-        WriteFourCC(writer, "strh");
-        writer.Write(56);
-        writer.Write(ToFourCC("vids"));
-        writer.Write(BiRgbCompression);
-        writer.Write(0u);
-        writer.Write((ushort)0);
-        writer.Write((ushort)0);
-        writer.Write(0u);
-        writer.Write(1u);
-        writer.Write(framesPerSecond);
-        writer.Write(0u);
-        writer.Write(totalFrames);
-        writer.Write(suggestedBufferSize);
-        writer.Write(uint.MaxValue);
-        writer.Write(0u);
-        writer.Write((short)0);
-        writer.Write((short)0);
-        writer.Write((short)width);
-        writer.Write((short)height);
-
-        WriteFourCC(writer, "strf");
-        writer.Write(40);
-        writer.Write(40u);
-        writer.Write((int)width);
-        writer.Write((int)height);
-        writer.Write((ushort)1);
-        writer.Write(bitsPerPixel);
-        writer.Write(BiRgbCompression);
-        writer.Write(imageSize);
-        writer.Write(0u);
-        writer.Write(0u);
-        writer.Write(0u);
-        writer.Write(0u);
-
-        long strlListEnd = writer.BaseStream.Position;
-        UpdateChunkSize(writer, strlSizePos, strlListEnd);
+        return new AviVideoStream(stream, width, height, framesPerSecond, frameSize);
     }
 
     private static void WriteFourCC(BinaryWriter writer, string fourCc)
@@ -218,5 +91,192 @@ internal static class AviVideoWriter
         public uint Flags { get; }
         public uint Offset { get; }
         public uint Size { get; }
+    }
+
+    internal sealed class AviVideoStream : IDisposable
+    {
+        private readonly BinaryWriter _writer;
+        private readonly List<AviIndexEntry> _indexEntries = new();
+        private readonly long _riffSizePos;
+        private readonly long _hdrlSizePos;
+        private readonly long _moviSizePos;
+        private readonly long _moviListStart;
+        private readonly long _avihTotalFramesPos;
+        private readonly long _strhTotalFramesPos;
+        private readonly uint _frameSize;
+        private readonly uint _bytesPerSecond;
+        private readonly uint _suggestedBufferSize;
+        private readonly uint _width;
+        private readonly uint _height;
+        private readonly uint _framesPerSecond;
+        private readonly uint _microSecPerFrame;
+        private bool _completed;
+        private uint _frameCount;
+
+        public AviVideoStream(Stream stream, int width, int height, int framesPerSecond, int frameSize)
+        {
+            ArgumentNullException.ThrowIfNull(stream);
+
+            if (width <= 0)
+                throw new ArgumentOutOfRangeException(nameof(width));
+            if (height <= 0)
+                throw new ArgumentOutOfRangeException(nameof(height));
+            if (framesPerSecond <= 0)
+                throw new ArgumentOutOfRangeException(nameof(framesPerSecond));
+            if (frameSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(frameSize));
+
+            _width = (uint)width;
+            _height = (uint)height;
+            _framesPerSecond = (uint)framesPerSecond;
+            _frameSize = (uint)frameSize;
+            _bytesPerSecond = (uint)(frameSize * (long)framesPerSecond);
+            _suggestedBufferSize = (uint)frameSize;
+            _microSecPerFrame = (uint)Math.Round(1_000_000d / framesPerSecond);
+
+            _writer = new BinaryWriter(stream, Encoding.ASCII, leaveOpen: true);
+
+            WriteFourCC(_writer, "RIFF");
+            _riffSizePos = _writer.BaseStream.Position;
+            _writer.Write(0);
+            WriteFourCC(_writer, "AVI ");
+
+            WriteFourCC(_writer, "LIST");
+            _hdrlSizePos = _writer.BaseStream.Position;
+            _writer.Write(0);
+            WriteFourCC(_writer, "hdrl");
+
+            WriteFourCC(_writer, "avih");
+            _writer.Write(56);
+            _writer.Write(_microSecPerFrame);
+            _writer.Write(_bytesPerSecond);
+            _writer.Write(0u);
+            _writer.Write(AviMainHeaderHasIndex);
+            _avihTotalFramesPos = _writer.BaseStream.Position;
+            _writer.Write(0u);
+            _writer.Write(0u);
+            _writer.Write(1u);
+            _writer.Write(_suggestedBufferSize);
+            _writer.Write(_width);
+            _writer.Write(_height);
+            _writer.Write(0u);
+            _writer.Write(0u);
+            _writer.Write(0u);
+            _writer.Write(0u);
+
+            WriteFourCC(_writer, "LIST");
+            long strlSizePos = _writer.BaseStream.Position;
+            _writer.Write(0);
+            WriteFourCC(_writer, "strl");
+
+            WriteFourCC(_writer, "strh");
+            _writer.Write(56);
+            _writer.Write(ToFourCC("vids"));
+            _writer.Write(BiRgbCompression);
+            _writer.Write(0u);
+            _writer.Write((ushort)0);
+            _writer.Write((ushort)0);
+            _writer.Write(0u);
+            _writer.Write(1u);
+            _writer.Write(_framesPerSecond);
+            _writer.Write(0u);
+            _strhTotalFramesPos = _writer.BaseStream.Position;
+            _writer.Write(0u);
+            _writer.Write(_suggestedBufferSize);
+            _writer.Write(uint.MaxValue);
+            _writer.Write(0u);
+            _writer.Write((short)0);
+            _writer.Write((short)0);
+            _writer.Write((short)width);
+            _writer.Write((short)height);
+
+            WriteFourCC(_writer, "strf");
+            _writer.Write(40);
+            _writer.Write(40u);
+            _writer.Write(width);
+            _writer.Write(height);
+            _writer.Write((ushort)1);
+            _writer.Write(BitsPerPixel);
+            _writer.Write(BiRgbCompression);
+            _writer.Write(_frameSize);
+            _writer.Write(0u);
+            _writer.Write(0u);
+            _writer.Write(0u);
+            _writer.Write(0u);
+
+            long strlListEnd = _writer.BaseStream.Position;
+            UpdateChunkSize(_writer, strlSizePos, strlListEnd);
+
+            long hdrlListEnd = _writer.BaseStream.Position;
+            UpdateChunkSize(_writer, _hdrlSizePos, hdrlListEnd);
+
+            WriteFourCC(_writer, "LIST");
+            _moviSizePos = _writer.BaseStream.Position;
+            _writer.Write(0);
+            WriteFourCC(_writer, "movi");
+            _moviListStart = _writer.BaseStream.Position;
+        }
+
+        public void WriteFrame(ReadOnlySpan<byte> frameData)
+        {
+            if (_completed)
+                throw new InvalidOperationException("Cannot write frames after the stream has been completed.");
+            if ((uint)frameData.Length != _frameSize)
+                throw new ArgumentException("Frame size did not match the expected size.", nameof(frameData));
+
+            long chunkStart = _writer.BaseStream.Position;
+            WriteFourCC(_writer, "00db");
+            _writer.Write(frameData.Length);
+            _writer.Write(frameData);
+
+            if ((frameData.Length & 1) == 1)
+                _writer.Write((byte)0);
+
+            uint offset = (uint)(chunkStart - _moviListStart - 4);
+            _indexEntries.Add(new AviIndexEntry(VideoChunkFourCc, AviIfKeyFrame, offset, (uint)frameData.Length));
+            _frameCount++;
+        }
+
+        public void Complete()
+        {
+            if (_completed)
+                return;
+            if (_frameCount == 0)
+                throw new InvalidOperationException("At least one frame must be written before completing the stream.");
+
+            long moviListEnd = _writer.BaseStream.Position;
+            UpdateChunkSize(_writer, _moviSizePos, moviListEnd);
+
+            WriteFourCC(_writer, "idx1");
+            _writer.Write(_indexEntries.Count * 16);
+            foreach (var entry in _indexEntries)
+            {
+                _writer.Write(entry.ChunkId);
+                _writer.Write(entry.Flags);
+                _writer.Write(entry.Offset);
+                _writer.Write(entry.Size);
+            }
+
+            long fileEnd = _writer.BaseStream.Position;
+            UpdateChunkSize(_writer, _riffSizePos, fileEnd);
+
+            long current = _writer.BaseStream.Position;
+            _writer.BaseStream.Seek(_avihTotalFramesPos, SeekOrigin.Begin);
+            _writer.Write(_frameCount);
+            _writer.BaseStream.Seek(_strhTotalFramesPos, SeekOrigin.Begin);
+            _writer.Write(_frameCount);
+            _writer.BaseStream.Seek(current, SeekOrigin.Begin);
+
+            _writer.Flush();
+            _completed = true;
+        }
+
+        public void Dispose()
+        {
+            if (!_completed && _frameCount > 0)
+                Complete();
+
+            _writer.Dispose();
+        }
     }
 }

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -456,79 +456,106 @@ namespace ElectricalImpedanceTomography.ViewModels
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var frameData = new List<byte[]>(frames.Count);
+                    AviVideoWriter.AviVideoStream? videoStream = null;
                     int videoWidth = 0;
                     int videoHeight = 0;
-
-                    double totalSteps = frames.Count + 1.0;
-
-                    for (int i = 0; i < frames.Count; i++)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        double progressValue = (i + 1) / totalSteps;
-                        progress?.Report(new VideoExportProgressReport(progressValue,
-                                                                        $"Rendering frame {i + 1} of {frames.Count}..."));
-
-                        var context = ReconstructionVideoRenderer.FindResultForFrame(results, i, out int resultIndex);
-                        int residualCount = resultIndex >= 0
-                            ? Math.Min(resultIndex + 1, residualHistory.Count)
-                            : residualHistory.Count;
-
-                        using var image = ReconstructionVideoRenderer.RenderFrameSnapshot(frames[i],
-                                                                                           context,
-                                                                                           discretization,
-                                                                                           residualHistory,
-                                                                                           residualCount,
-                                                                                           distributionSize,
-                                                                                           colorbarSize,
-                                                                                           residualSize,
-                                                                                           mode);
-
-                        if (videoWidth == 0 || videoHeight == 0)
-                        {
-                            videoWidth = image.Width;
-                            videoHeight = image.Height;
-                        }
-                        else if (image.Width != videoWidth || image.Height != videoHeight)
-                        {
-                            throw new InvalidOperationException("All exported frames must share the same dimensions.");
-                        }
-
-                        var imageInfo = new SKImageInfo(image.Width,
-                                                        image.Height,
-                                                        SKColorType.Bgra8888,
-                                                        SKAlphaType.Premul);
-
-                        using var bitmap = new SKBitmap(imageInfo);
-                        if (!image.ReadPixels(imageInfo, bitmap.GetPixels(), bitmap.RowBytes))
-                            throw new InvalidOperationException("Failed to read frame pixels for video export.");
-
-                        var pixelBytes = MemoryMarshal.AsBytes(bitmap.GetPixelSpan());
-                        int rowBytes = bitmap.RowBytes;
-                        var rawFrame = new byte[rowBytes * image.Height];
-
-                        for (int y = 0; y < image.Height; y++)
-                        {
-                            var sourceRow = pixelBytes.Slice(y * rowBytes, rowBytes);
-                            var destinationRow = rawFrame.AsSpan((image.Height - 1 - y) * rowBytes, rowBytes);
-                            sourceRow.CopyTo(destinationRow);
-                        }
-
-                        frameData.Add(rawFrame);
-                    }
-
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    progress?.Report(new VideoExportProgressReport(Math.Min(0.98, frames.Count / (frames.Count + 1.0)),
-                                                                    "Encoding video stream..."));
+                    int expectedFrameSize = 0;
+                    byte[]? reusableFrameBuffer = null;
 
                     using var stream = File.Create(filePath);
-                    AviVideoWriter.Write(stream,
-                                         frameData,
-                                         videoWidth,
-                                         videoHeight,
-                                         Workspace.ReconstructionVideoFramesPerSecond);
+                    double totalSteps = frames.Count + 1.0;
+
+                    try
+                    {
+                        for (int i = 0; i < frames.Count; i++)
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            double progressValue = (i + 1) / totalSteps;
+                            progress?.Report(new VideoExportProgressReport(progressValue,
+                                                                            $"Rendering frame {i + 1} of {frames.Count}..."));
+
+                            var context = ReconstructionVideoRenderer.FindResultForFrame(results, i, out int resultIndex);
+                            int residualCount = resultIndex >= 0
+                                ? Math.Min(resultIndex + 1, residualHistory.Count)
+                                : residualHistory.Count;
+
+                            using var image = ReconstructionVideoRenderer.RenderFrameSnapshot(frames[i],
+                                                                                               context,
+                                                                                               discretization,
+                                                                                               residualHistory,
+                                                                                               residualCount,
+                                                                                               distributionSize,
+                                                                                               colorbarSize,
+                                                                                               residualSize,
+                                                                                               mode);
+
+                            if (videoWidth == 0 || videoHeight == 0)
+                            {
+                                videoWidth = image.Width;
+                                videoHeight = image.Height;
+                            }
+                            else if (image.Width != videoWidth || image.Height != videoHeight)
+                            {
+                                throw new InvalidOperationException("All exported frames must share the same dimensions.");
+                            }
+
+                            var imageInfo = new SKImageInfo(image.Width,
+                                                            image.Height,
+                                                            SKColorType.Bgra8888,
+                                                            SKAlphaType.Premul);
+
+                            using var bitmap = new SKBitmap(imageInfo);
+                            if (!image.ReadPixels(imageInfo, bitmap.GetPixels(), bitmap.RowBytes))
+                                throw new InvalidOperationException("Failed to read frame pixels for video export.");
+
+                            var pixelBytes = MemoryMarshal.AsBytes(bitmap.GetPixelSpan());
+                            int rowBytes = bitmap.RowBytes;
+                            int frameSize = rowBytes * image.Height;
+
+                            if (reusableFrameBuffer == null || reusableFrameBuffer.Length < frameSize)
+                                reusableFrameBuffer = GC.AllocateUninitializedArray<byte>(frameSize);
+
+                            var rawFrame = reusableFrameBuffer.AsSpan(0, frameSize);
+
+                            for (int y = 0; y < image.Height; y++)
+                            {
+                                var sourceRow = pixelBytes.Slice(y * rowBytes, rowBytes);
+                                var destinationRow = rawFrame.Slice((image.Height - 1 - y) * rowBytes, rowBytes);
+                                sourceRow.CopyTo(destinationRow);
+                            }
+
+                            if (videoStream == null)
+                            {
+                                expectedFrameSize = frameSize;
+                                videoStream = AviVideoWriter.BeginWrite(stream,
+                                                                        videoWidth,
+                                                                        videoHeight,
+                                                                        Workspace.ReconstructionVideoFramesPerSecond,
+                                                                        expectedFrameSize);
+                            }
+                            else if (frameSize != expectedFrameSize)
+                            {
+                                throw new InvalidOperationException("All exported frames must share the same size.");
+                            }
+
+                            videoStream.WriteFrame(rawFrame);
+                        }
+
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        progress?.Report(new VideoExportProgressReport(Math.Min(0.98, frames.Count / (frames.Count + 1.0)),
+                                                                        "Finalizing video stream..."));
+
+                        if (videoStream == null)
+                            throw new InvalidOperationException("Unable to initialize the AVI writer.");
+
+                        videoStream.Complete();
+                    }
+                    finally
+                    {
+                        videoStream?.Dispose();
+                    }
                 });
 
                 progress?.Report(new VideoExportProgressReport(1.0, "Video generation completed."));


### PR DESCRIPTION
## Summary
- stream AVI video frames directly to disk instead of buffering them all in memory
- add a reusable buffer when rendering frames to reduce allocations and improve encoding throughput
- expose an incremental AVI writer helper that finalizes headers and index entries on completion

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d50fcdb1a88333bc86493e3291a667