### PR TITLE
Add asynchronous reconstruction metric calculations and UI

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -6,9 +6,11 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -94,6 +96,19 @@ namespace ElectricalImpedanceTomography.ViewModels
         public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
         public event EventHandler<ReconstructionFrame>? ReconstructionFrameUpdated;
 
+        public ObservableCollection<ReconstructionMetricGroupViewModel> MetricGroups { get; } = [];
+
+        private readonly Dictionary<string, ReconstructionMetricViewModel> _metricsByKey = new();
+        private readonly object _metricUpdateLock = new();
+        private readonly object _gradientLock = new();
+        private readonly object _errorMetricLock = new();
+        private CancellationTokenSource? _metricUpdateCts;
+        private ReconstructionResult? _latestResult;
+        private ReconstructionFrame? _latestFrame;
+        private Dictionary<int, double>? _previousGradientSnapshot;
+        private IErrorMetric? _cachedErrorMetric;
+        private ErrorMetric _cachedErrorMetricChoice;
+
         public ReconstructionPageViewModel(IReconstructionService reconstructionService)
         {
             _reconstructionService = reconstructionService;
@@ -114,6 +129,16 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             // Use global reconstruction parameters stored in the workspace
             ReconstructionParameters = Workspace.GetReconstructionParameters();
+
+            InitializeMetricGroups();
+            PropertyChanged += OnViewModelPropertyChanged;
+
+            UpdateMetric(MetricKeys.ErrorMetric, ReconstructionParameters.ErrorMetric.ToString());
+            UpdateMetric(MetricKeys.RegularizationWeight, FormatDouble(RegularizationWeight, "G3"));
+            UpdateMetric(MetricKeys.IterationCount, IterationCount.ToString(CultureInfo.InvariantCulture));
+            UpdateMetric(MetricKeys.ElapsedTime, FormatElapsed(ElapsedTime));
+            UpdateMetric(MetricKeys.Residual, FormatDouble(Residual));
+            UpdateMetric(MetricKeys.Correlation, FormatDouble(Correlation));
 
             _reconstructionService.ReconstructionUpdated += OnServiceReconstructionUpdated;
             _reconstructionService.ReconstructionFrameUpdated += OnServiceFrameUpdated;
@@ -146,6 +171,65 @@ namespace ElectricalImpedanceTomography.ViewModels
                 _resetMetricsOnStart = true;
 
             _lastRunSignature = signature;
+        }
+
+        private void InitializeMetricGroups()
+        {
+            MetricGroups.Clear();
+            _metricsByKey.Clear();
+
+            RegisterMetric("Progress & Timing", MetricKeys.ElapsedTime, "Elapsed Time");
+            RegisterMetric("Progress & Timing", MetricKeys.IterationCount, "Iterations");
+            RegisterMetric("Progress & Timing", MetricKeys.IterationsPerSecond, "Iterations / Second");
+            RegisterMetric("Progress & Timing", MetricKeys.TimePerIteration, "Seconds / Iteration");
+
+            RegisterMetric("Error Norms", MetricKeys.Residual, "Residual L2 Norm");
+            RegisterMetric("Error Norms", MetricKeys.Rmse, "RMSE (σ)");
+            RegisterMetric("Error Norms", MetricKeys.Mae, "MAE (σ)");
+            RegisterMetric("Error Norms", MetricKeys.Mape, "MAPE (σ)");
+            RegisterMetric("Error Norms", MetricKeys.ResidualDropPerIteration, "Residual Drop / Iteration");
+
+            RegisterMetric("Similarity Scores", MetricKeys.Correlation, "Pearson Correlation");
+            RegisterMetric("Similarity Scores", MetricKeys.Psnr, "PSNR (dB)");
+            RegisterMetric("Similarity Scores", MetricKeys.Ssim, "SSIM");
+
+            RegisterMetric("Improvement", MetricKeys.RmseImprovement, "RMSE Improvement vs. Initial");
+            RegisterMetric("Improvement", MetricKeys.MaeImprovement, "MAE Improvement vs. Initial");
+
+            RegisterMetric("Misfit & Regularization", MetricKeys.ErrorMetric, "Misfit Metric");
+            RegisterMetric("Misfit & Regularization", MetricKeys.MisfitValue, "Misfit Value");
+            RegisterMetric("Misfit & Regularization", MetricKeys.RegularizationWeight, "Regularization Weight");
+            RegisterMetric("Misfit & Regularization", MetricKeys.RegularizationEnergy, "Regularization Energy");
+            RegisterMetric("Misfit & Regularization", MetricKeys.RegularizationRange, "Regularization Range");
+
+            RegisterMetric("Gradient & Field Diagnostics", MetricKeys.GradientNorm, "Gradient L2 Norm");
+            RegisterMetric("Gradient & Field Diagnostics", MetricKeys.GradientAngleChange, "Gradient Angle Δ");
+            RegisterMetric("Gradient & Field Diagnostics", MetricKeys.PotentialRange, "Potential Range");
+            RegisterMetric("Gradient & Field Diagnostics", MetricKeys.AdjointRange, "Adjoint Range");
+
+            RegisterMetric("Electrode Measurements", MetricKeys.ElectrodeRmse, "Electrode RMSE");
+            RegisterMetric("Electrode Measurements", MetricKeys.ElectrodeMae, "Electrode MAE");
+            RegisterMetric("Electrode Measurements", MetricKeys.ElectrodeMape, "Electrode MAPE");
+        }
+
+        private void RegisterMetric(string groupTitle, string key, string name)
+        {
+            var group = MetricGroups.FirstOrDefault(g => g.Title == groupTitle);
+            if (group is null)
+            {
+                group = new ReconstructionMetricGroupViewModel(groupTitle);
+                MetricGroups.Add(group);
+            }
+
+            var metricVm = new ReconstructionMetricViewModel(key, name);
+            group.Metrics.Add(metricVm);
+            _metricsByKey[key] = metricVm;
+        }
+
+        private void UpdateMetric(string key, string value)
+        {
+            if (_metricsByKey.TryGetValue(key, out var metric))
+                metric.Value = value;
         }
 
         public void ResetReconstructionMetrics()
@@ -191,7 +275,101 @@ namespace ElectricalImpedanceTomography.ViewModels
             Residual = 0.0;
             Correlation = 0.0;
             ElapsedTime = TimeSpan.Zero;
+            IterationCount = 0;
             _reconstructionStopwatch.Reset();
+
+            lock (_metricUpdateLock)
+            {
+                _metricUpdateCts?.Cancel();
+                _metricUpdateCts = null;
+                _latestResult = null;
+                _latestFrame = null;
+            }
+
+            lock (_gradientLock)
+            {
+                _previousGradientSnapshot = null;
+            }
+
+            ResetDynamicMetrics();
+        }
+
+        private void ResetDynamicMetrics()
+        {
+            foreach (var metric in _metricsByKey.Values)
+                metric.Value = "—";
+
+            UpdateMetric(MetricKeys.ErrorMetric, ReconstructionParameters.ErrorMetric.ToString());
+            UpdateMetric(MetricKeys.RegularizationWeight, FormatDouble(RegularizationWeight, "G3"));
+            UpdateMetric(MetricKeys.IterationCount, IterationCount.ToString(CultureInfo.InvariantCulture));
+            UpdateMetric(MetricKeys.ElapsedTime, FormatElapsed(TimeSpan.Zero));
+        }
+
+        private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(RegularizationWeight))
+                UpdateMetric(MetricKeys.RegularizationWeight, FormatDouble(RegularizationWeight, "G3"));
+            else if (e.PropertyName == nameof(ReconstructionParameters))
+                UpdateMetric(MetricKeys.ErrorMetric, ReconstructionParameters.ErrorMetric.ToString());
+        }
+
+        partial void OnElapsedTimeChanged(TimeSpan value)
+        {
+            UpdateMetric(MetricKeys.ElapsedTime, FormatElapsed(value));
+            UpdateIterationsPerSecond();
+            UpdateTimePerIteration();
+        }
+
+        partial void OnIterationCountChanged(int value)
+        {
+            UpdateMetric(MetricKeys.IterationCount, value.ToString(CultureInfo.InvariantCulture));
+            UpdateIterationsPerSecond();
+            UpdateTimePerIteration();
+        }
+
+        partial void OnResidualChanged(double value)
+            => UpdateMetric(MetricKeys.Residual, FormatDouble(value));
+
+        partial void OnCorrelationChanged(double value)
+            => UpdateMetric(MetricKeys.Correlation, FormatDouble(value));
+
+        private void UpdateIterationsPerSecond()
+        {
+            if (IterationCount <= 0 || ElapsedTime.TotalSeconds <= 1e-6)
+            {
+                UpdateMetric(MetricKeys.IterationsPerSecond, "—");
+                return;
+            }
+
+            double ips = IterationCount / Math.Max(ElapsedTime.TotalSeconds, 1e-6);
+            UpdateMetric(MetricKeys.IterationsPerSecond, FormatDouble(ips, "F2"));
+        }
+
+        private void UpdateTimePerIteration()
+        {
+            if (IterationCount <= 0)
+            {
+                UpdateMetric(MetricKeys.TimePerIteration, "—");
+                return;
+            }
+
+            double seconds = ElapsedTime.TotalSeconds / Math.Max(IterationCount, 1);
+            UpdateMetric(MetricKeys.TimePerIteration, $"{seconds.ToString("F2", CultureInfo.InvariantCulture)} s");
+        }
+
+        private void UpdateResidualTrendMetrics()
+        {
+            if (ResidualHistory.Count <= 1)
+            {
+                UpdateMetric(MetricKeys.ResidualDropPerIteration, "—");
+                return;
+            }
+
+            double first = ResidualHistory[0];
+            double last = ResidualHistory[^1];
+            int steps = Math.Max(ResidualHistory.Count - 1, 1);
+            double drop = (first - last) / steps;
+            UpdateMetric(MetricKeys.ResidualDropPerIteration, FormatDouble(drop));
         }
 
         private void StartElapsedTimer()
@@ -321,6 +499,570 @@ namespace ElectricalImpedanceTomography.ViewModels
             return numerator / denominator;
         }
 
+        private void RequestMetricUpdate(ReconstructionResult? result, ReconstructionFrame? frame)
+        {
+            lock (_metricUpdateLock)
+            {
+                if (result != null)
+                    _latestResult = result;
+                if (frame != null)
+                    _latestFrame = frame;
+
+                var snapshotResult = _latestResult;
+                var snapshotFrame = _latestFrame;
+
+                if (snapshotResult is null && snapshotFrame is null)
+                    return;
+
+                _metricUpdateCts?.Cancel();
+                _metricUpdateCts = new CancellationTokenSource();
+                var token = _metricUpdateCts.Token;
+
+                Task.Run(() => ComputeMetricsAsync(snapshotResult, snapshotFrame, token), token);
+            }
+        }
+
+        private async Task ComputeMetricsAsync(ReconstructionResult? result, ReconstructionFrame? frame, CancellationToken token)
+        {
+            try
+            {
+                DistributionMetrics? distributionMetrics = null;
+                if (result != null)
+                {
+                    distributionMetrics = ComputeDistributionMetrics(result, token);
+                }
+
+                token.ThrowIfCancellationRequested();
+
+                var measurementMetrics = ComputeElectrodeMetrics(token);
+
+                token.ThrowIfCancellationRequested();
+
+                frame ??= result?.Frames.LastOrDefault();
+                var fieldMetrics = ComputeFieldMetrics(frame, token);
+
+                token.ThrowIfCancellationRequested();
+
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    if (distributionMetrics.HasValue)
+                    {
+                        var metrics = distributionMetrics.Value;
+                        UpdateMetric(MetricKeys.Rmse, FormatDouble(metrics.Rmse));
+                        UpdateMetric(MetricKeys.Mae, FormatDouble(metrics.Mae));
+                        UpdateMetric(MetricKeys.Mape, FormatPercent(metrics.Mape));
+                        UpdateMetric(MetricKeys.Psnr, FormatDouble(metrics.Psnr, "F2"));
+                        UpdateMetric(MetricKeys.Ssim, FormatDouble(metrics.Ssim, "F3"));
+                        UpdateMetric(MetricKeys.RmseImprovement, FormatPercent(metrics.RmseImprovement));
+                        UpdateMetric(MetricKeys.MaeImprovement, FormatPercent(metrics.MaeImprovement));
+                    }
+
+                    if (measurementMetrics.HasValue)
+                    {
+                        var m = measurementMetrics.Value;
+                        UpdateMetric(MetricKeys.ElectrodeRmse, FormatDouble(m.Rmse));
+                        UpdateMetric(MetricKeys.ElectrodeMae, FormatDouble(m.Mae));
+                        UpdateMetric(MetricKeys.ElectrodeMape, FormatPercent(m.Mape));
+                        UpdateMetric(MetricKeys.MisfitValue, m.Misfit.HasValue ? FormatDouble(m.Misfit.Value, "G4") : "—");
+                    }
+                    else
+                    {
+                        UpdateMetric(MetricKeys.ElectrodeRmse, "—");
+                        UpdateMetric(MetricKeys.ElectrodeMae, "—");
+                        UpdateMetric(MetricKeys.ElectrodeMape, "—");
+                        UpdateMetric(MetricKeys.MisfitValue, "—");
+                    }
+
+                    if (fieldMetrics.HasData)
+                    {
+                        UpdateMetric(MetricKeys.GradientNorm, FormatDouble(fieldMetrics.GradientNorm));
+                        UpdateMetric(MetricKeys.GradientAngleChange,
+                                     fieldMetrics.GradientAngle.HasValue
+                                         ? $"{FormatDouble(fieldMetrics.GradientAngle.Value, "F1")}°"
+                                         : "—");
+                        UpdateMetric(MetricKeys.PotentialRange, FormatRange(fieldMetrics.PotentialRange));
+                        UpdateMetric(MetricKeys.AdjointRange, FormatRange(fieldMetrics.AdjointRange));
+                        UpdateMetric(MetricKeys.RegularizationRange, FormatRange(fieldMetrics.RegularizationRange));
+                        UpdateMetric(MetricKeys.RegularizationEnergy, FormatDouble(fieldMetrics.RegularizationEnergy));
+
+                        if (fieldMetrics.GradientSnapshot != null)
+                        {
+                            lock (_gradientLock)
+                            {
+                                _previousGradientSnapshot = fieldMetrics.GradientSnapshot;
+                            }
+                        }
+                    }
+                });
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Metric computation failed: {ex}");
+            }
+        }
+
+        private static DistributionMetrics? ComputeDistributionMetrics(ReconstructionResult result, CancellationToken token)
+        {
+            var reconstructed = result.ReconstructedConductivityDistribution.Conductivities;
+            if (reconstructed.Count == 0)
+                return null;
+
+            var original = result.OriginalConductivityDistribution.Conductivities;
+            var initial = result.InitialConductivitiyDistribution.Conductivities;
+
+            int count = reconstructed.Count;
+            double[] recon = new double[count];
+            double[] orig = new double[count];
+            double[] init = new double[count];
+
+            double sumSq = 0.0;
+            double sumAbs = 0.0;
+            double sumPct = 0.0;
+            double maxAbs = 0.0;
+
+            int index = 0;
+            foreach (var kv in reconstructed)
+            {
+                token.ThrowIfCancellationRequested();
+
+                double r = kv.Value;
+                original.TryGetValue(kv.Key, out double o);
+                initial.TryGetValue(kv.Key, out double i);
+
+                recon[index] = r;
+                orig[index] = o;
+                init[index] = i;
+
+                double diff = r - o;
+                sumSq += diff * diff;
+                sumAbs += Math.Abs(diff);
+                sumPct += Math.Abs(diff) / Math.Max(Math.Abs(o), 1e-6);
+
+                maxAbs = Math.Max(maxAbs, Math.Abs(o));
+                maxAbs = Math.Max(maxAbs, Math.Abs(r));
+                index++;
+            }
+
+            double mse = sumSq / Math.Max(count, 1);
+            double rmse = Math.Sqrt(mse);
+            double mae = sumAbs / Math.Max(count, 1);
+            double mape = sumPct / Math.Max(count, 1);
+
+            double psnr;
+            if (mse <= 1e-12)
+            {
+                psnr = double.PositiveInfinity;
+            }
+            else
+            {
+                double peak = maxAbs <= 1e-12 ? 1.0 : maxAbs;
+                psnr = 20.0 * Math.Log10(peak / Math.Sqrt(mse));
+            }
+
+            double initialRmse = 0.0;
+            double initialMae = 0.0;
+            for (int i = 0; i < count; i++)
+            {
+                token.ThrowIfCancellationRequested();
+                double diffInit = init[i] - orig[i];
+                initialRmse += diffInit * diffInit;
+                initialMae += Math.Abs(diffInit);
+            }
+
+            initialRmse = Math.Sqrt(initialRmse / Math.Max(count, 1));
+            initialMae /= Math.Max(count, 1);
+
+            double rmseImprovement = initialRmse > 1e-9 ? (initialRmse - rmse) / initialRmse : 0.0;
+            double maeImprovement = initialMae > 1e-9 ? (initialMae - mae) / initialMae : 0.0;
+
+            double ssim = ComputeSsim(orig, recon);
+
+            return new DistributionMetrics(rmse, mae, mape, psnr, ssim, rmseImprovement, maeImprovement);
+        }
+
+        private static double ComputeSsim(double[] reference, double[] test)
+        {
+            if (reference.Length == 0 || reference.Length != test.Length)
+                return double.NaN;
+
+            double meanRef = 0.0;
+            double meanTest = 0.0;
+            for (int i = 0; i < reference.Length; i++)
+            {
+                meanRef += reference[i];
+                meanTest += test[i];
+            }
+
+            int n = reference.Length;
+            meanRef /= n;
+            meanTest /= n;
+
+            double varianceRef = 0.0;
+            double varianceTest = 0.0;
+            double covariance = 0.0;
+
+            for (int i = 0; i < n; i++)
+            {
+                double refDelta = reference[i] - meanRef;
+                double testDelta = test[i] - meanTest;
+                varianceRef += refDelta * refDelta;
+                varianceTest += testDelta * testDelta;
+                covariance += refDelta * testDelta;
+            }
+
+            varianceRef /= n;
+            varianceTest /= n;
+            covariance /= n;
+
+            const double c1 = 0.01 * 0.01;
+            const double c2 = 0.03 * 0.03;
+
+            double numerator = (2 * meanRef * meanTest + c1) * (2 * covariance + c2);
+            double denominator = (meanRef * meanRef + meanTest * meanTest + c1) * (varianceRef + varianceTest + c2);
+
+            if (denominator <= 1e-12)
+                return double.NaN;
+
+            return numerator / denominator;
+        }
+
+        private MeasurementMetrics? ComputeElectrodeMetrics(CancellationToken token)
+        {
+            var discretization = Workspace.GetDiscretization();
+            var original = Workspace.GetOriginalDiscretization();
+
+            if (discretization == null || original == null)
+                return null;
+
+            var simulated = discretization.GetElectrodePotentials();
+            var measured = original.GetElectrodePotentials();
+
+            if (simulated.Length == 0 || measured.Length == 0 || simulated.Length != measured.Length)
+                return null;
+
+            double sumSq = 0.0;
+            double sumAbs = 0.0;
+            double sumPct = 0.0;
+
+            for (int i = 0; i < simulated.Length; i++)
+            {
+                token.ThrowIfCancellationRequested();
+
+                double diff = simulated[i] - measured[i];
+                sumSq += diff * diff;
+                sumAbs += Math.Abs(diff);
+                sumPct += Math.Abs(diff) / Math.Max(Math.Abs(measured[i]), 1e-6);
+            }
+
+            int n = simulated.Length;
+            double rmse = Math.Sqrt(sumSq / Math.Max(n, 1));
+            double mae = sumAbs / Math.Max(n, 1);
+            double mape = sumPct / Math.Max(n, 1);
+
+            double? misfit = null;
+            try
+            {
+                var metric = GetErrorMetric(ReconstructionParameters.ErrorMetric);
+                misfit = metric.Evaluate(discretization, measured, simulated);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Misfit evaluation failed: {ex.Message}");
+            }
+
+            return new MeasurementMetrics(rmse, mae, mape, misfit);
+        }
+
+        private FieldMetrics ComputeFieldMetrics(ReconstructionFrame? frame, CancellationToken token)
+        {
+            if (frame == null)
+                return FieldMetrics.Empty;
+
+            var gradient = frame.ConductivityGradient.Conductivities;
+            double gradientNorm = 0.0;
+            foreach (var kv in gradient)
+            {
+                token.ThrowIfCancellationRequested();
+                gradientNorm += kv.Value * kv.Value;
+            }
+            gradientNorm = Math.Sqrt(gradientNorm);
+
+            double? gradientAngle = null;
+            Dictionary<int, double>? previous;
+            lock (_gradientLock)
+            {
+                previous = _previousGradientSnapshot;
+            }
+
+            if (previous != null && previous.Count > 0 && gradient.Count > 0)
+            {
+                gradientAngle = ComputeGradientAngle(previous, gradient);
+            }
+
+            var potentialRange = ComputeRange(frame.CalculatedPotentialDistribution?.Potentials);
+            var adjointRange = ComputeRange(frame.CalculatedAdjointDistribution?.Potentials);
+            var regularizationRange = ComputeRange(frame.CalculatedRegularization?.Conductivities);
+            double regularizationEnergy = ComputeRegularizationEnergy(frame.CalculatedRegularization?.Conductivities, token);
+
+            var gradientSnapshot = new Dictionary<int, double>(gradient);
+
+            return new FieldMetrics(true,
+                                    gradientNorm,
+                                    gradientAngle,
+                                    potentialRange,
+                                    adjointRange,
+                                    regularizationRange,
+                                    regularizationEnergy,
+                                    gradientSnapshot);
+        }
+
+        private static double ComputeGradientAngle(Dictionary<int, double> previous, Dictionary<int, double> current)
+        {
+            double dot = 0.0;
+            double prevNorm = 0.0;
+            double currNorm = 0.0;
+
+            foreach (var kv in current)
+            {
+                double value = kv.Value;
+                currNorm += value * value;
+                if (previous.TryGetValue(kv.Key, out double prevValue))
+                    dot += prevValue * value;
+            }
+
+            foreach (var kv in previous)
+            {
+                double value = kv.Value;
+                prevNorm += value * value;
+            }
+
+            double denom = Math.Sqrt(prevNorm) * Math.Sqrt(currNorm);
+            if (denom <= 1e-12)
+                return double.NaN;
+
+            double cosTheta = dot / denom;
+            cosTheta = Math.Clamp(cosTheta, -1.0, 1.0);
+            return Math.Acos(cosTheta) * (180.0 / Math.PI);
+        }
+
+        private static RangeMetrics ComputeRange(IReadOnlyDictionary<int, double>? values)
+        {
+            if (values == null || values.Count == 0)
+                return RangeMetrics.Empty;
+
+            double min = double.PositiveInfinity;
+            double max = double.NegativeInfinity;
+
+            foreach (var value in values.Values)
+            {
+                if (double.IsNaN(value) || double.IsInfinity(value))
+                    continue;
+
+                if (value < min)
+                    min = value;
+                if (value > max)
+                    max = value;
+            }
+
+            if (double.IsPositiveInfinity(min) || double.IsNegativeInfinity(max))
+                return RangeMetrics.Empty;
+
+            return new RangeMetrics(min, max);
+        }
+
+        private static double ComputeRegularizationEnergy(IReadOnlyDictionary<int, double>? values, CancellationToken token)
+        {
+            if (values == null || values.Count == 0)
+                return double.NaN;
+
+            double sum = 0.0;
+            foreach (var kv in values)
+            {
+                token.ThrowIfCancellationRequested();
+                sum += kv.Value * kv.Value;
+            }
+
+            return Math.Sqrt(sum);
+        }
+
+        private static string FormatDouble(double value, string format = "F3")
+        {
+            if (double.IsNaN(value))
+                return "—";
+            if (double.IsPositiveInfinity(value))
+                return "∞";
+            if (double.IsNegativeInfinity(value))
+                return "-∞";
+            return value.ToString(format, CultureInfo.InvariantCulture);
+        }
+
+        private static string FormatPercent(double value)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+                return "—";
+            return value.ToString("P1", CultureInfo.InvariantCulture);
+        }
+
+        private static string FormatElapsed(TimeSpan value)
+            => value.TotalHours >= 1.0
+                ? value.ToString("hh\\:mm\\:ss")
+                : value.ToString("mm\\:ss");
+
+        private static string FormatRange(RangeMetrics range)
+        {
+            if (!range.HasValue)
+                return "—";
+
+            double delta = range.Max.Value - range.Min.Value;
+            return $"{range.Min.Value.ToString("F3", CultureInfo.InvariantCulture)} to {range.Max.Value.ToString("F3", CultureInfo.InvariantCulture)} (Δ {delta.ToString("F3", CultureInfo.InvariantCulture)})";
+        }
+
+        private IErrorMetric GetErrorMetric(ErrorMetric choice)
+        {
+            lock (_errorMetricLock)
+            {
+                if (_cachedErrorMetric == null || _cachedErrorMetricChoice != choice)
+                {
+                    _cachedErrorMetric = ErrorMetricFactory.Create(choice);
+                    _cachedErrorMetricChoice = choice;
+                }
+
+                return _cachedErrorMetric;
+            }
+        }
+
+        private static class MetricKeys
+        {
+            public const string ElapsedTime = "elapsedTime";
+            public const string IterationCount = "iterationCount";
+            public const string IterationsPerSecond = "iterationsPerSecond";
+            public const string TimePerIteration = "timePerIteration";
+            public const string Residual = "residual";
+            public const string Rmse = "rmse";
+            public const string Mae = "mae";
+            public const string Mape = "mape";
+            public const string ResidualDropPerIteration = "residualDrop";
+            public const string Correlation = "correlation";
+            public const string Psnr = "psnr";
+            public const string Ssim = "ssim";
+            public const string RmseImprovement = "rmseImprovement";
+            public const string MaeImprovement = "maeImprovement";
+            public const string ErrorMetric = "errorMetric";
+            public const string MisfitValue = "misfitValue";
+            public const string RegularizationWeight = "regularizationWeight";
+            public const string RegularizationEnergy = "regularizationEnergy";
+            public const string RegularizationRange = "regularizationRange";
+            public const string GradientNorm = "gradientNorm";
+            public const string GradientAngleChange = "gradientAngle";
+            public const string PotentialRange = "potentialRange";
+            public const string AdjointRange = "adjointRange";
+            public const string ElectrodeRmse = "electrodeRmse";
+            public const string ElectrodeMae = "electrodeMae";
+            public const string ElectrodeMape = "electrodeMape";
+        }
+
+        private readonly struct DistributionMetrics
+        {
+            public DistributionMetrics(double rmse,
+                                       double mae,
+                                       double mape,
+                                       double psnr,
+                                       double ssim,
+                                       double rmseImprovement,
+                                       double maeImprovement)
+            {
+                Rmse = rmse;
+                Mae = mae;
+                Mape = mape;
+                Psnr = psnr;
+                Ssim = ssim;
+                RmseImprovement = rmseImprovement;
+                MaeImprovement = maeImprovement;
+            }
+
+            public double Rmse { get; }
+            public double Mae { get; }
+            public double Mape { get; }
+            public double Psnr { get; }
+            public double Ssim { get; }
+            public double RmseImprovement { get; }
+            public double MaeImprovement { get; }
+        }
+
+        private readonly struct MeasurementMetrics
+        {
+            public MeasurementMetrics(double rmse, double mae, double mape, double? misfit)
+            {
+                Rmse = rmse;
+                Mae = mae;
+                Mape = mape;
+                Misfit = misfit;
+            }
+
+            public double Rmse { get; }
+            public double Mae { get; }
+            public double Mape { get; }
+            public double? Misfit { get; }
+        }
+
+        private readonly struct FieldMetrics
+        {
+            public static FieldMetrics Empty { get; } = new(false,
+                                                              0.0,
+                                                              null,
+                                                              RangeMetrics.Empty,
+                                                              RangeMetrics.Empty,
+                                                              RangeMetrics.Empty,
+                                                              double.NaN,
+                                                              null);
+
+            public FieldMetrics(bool hasData,
+                                double gradientNorm,
+                                double? gradientAngle,
+                                RangeMetrics potentialRange,
+                                RangeMetrics adjointRange,
+                                RangeMetrics regularizationRange,
+                                double regularizationEnergy,
+                                Dictionary<int, double>? gradientSnapshot)
+            {
+                HasData = hasData;
+                GradientNorm = gradientNorm;
+                GradientAngle = gradientAngle;
+                PotentialRange = potentialRange;
+                AdjointRange = adjointRange;
+                RegularizationRange = regularizationRange;
+                RegularizationEnergy = regularizationEnergy;
+                GradientSnapshot = gradientSnapshot;
+            }
+
+            public bool HasData { get; }
+            public double GradientNorm { get; }
+            public double? GradientAngle { get; }
+            public RangeMetrics PotentialRange { get; }
+            public RangeMetrics AdjointRange { get; }
+            public RangeMetrics RegularizationRange { get; }
+            public double RegularizationEnergy { get; }
+            public Dictionary<int, double>? GradientSnapshot { get; }
+        }
+
+        private readonly struct RangeMetrics
+        {
+            public static RangeMetrics Empty { get; } = new RangeMetrics(null, null);
+
+            public RangeMetrics(double? min, double? max)
+            {
+                Min = min;
+                Max = max;
+            }
+
+            public double? Min { get; }
+            public double? Max { get; }
+            public bool HasValue => Min.HasValue && Max.HasValue;
+        }
+
         public void StartBackgroundReconstruction()
         {
             PrepareForNewReconstruction();
@@ -383,6 +1125,8 @@ namespace ElectricalImpedanceTomography.ViewModels
             ElapsedTime = _reconstructionStopwatch.Elapsed;
             IterationCount++;
             ResidualHistory.Add(Residual);
+            UpdateResidualTrendMetrics();
+            RequestMetricUpdate(result, null);
 
             if(IterationCount % 10 == 0)
             {
@@ -394,7 +1138,10 @@ namespace ElectricalImpedanceTomography.ViewModels
         }
 
         private void OnServiceFrameUpdated(object? sender, ReconstructionFrame frame)
-            => ReconstructionFrameUpdated?.Invoke(this, frame);
+        {
+            RequestMetricUpdate(null, frame);
+            ReconstructionFrameUpdated?.Invoke(this, frame);
+        }
 
         public void SaveReconstruction()
         {
@@ -695,5 +1442,32 @@ namespace ElectricalImpedanceTomography.ViewModels
             bool OppositeDrivePattern);
 
         private record ReconstructionRunSignature(IDiscretization Mesh, ReconstructionParametersSnapshot Parameters);
+    }
+
+    public sealed partial class ReconstructionMetricGroupViewModel : ObservableObject
+    {
+        public ReconstructionMetricGroupViewModel(string title)
+        {
+            Title = title;
+        }
+
+        public string Title { get; }
+
+        public ObservableCollection<ReconstructionMetricViewModel> Metrics { get; } = [];
+    }
+
+    public sealed partial class ReconstructionMetricViewModel : ObservableObject
+    {
+        public ReconstructionMetricViewModel(string key, string name)
+        {
+            Key = key;
+            Name = name;
+        }
+
+        public string Key { get; }
+        public string Name { get; }
+
+        [ObservableProperty]
+        private string value = "—";
     }
 }

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -462,26 +462,27 @@
                     </Border.Stroke>
                     <VerticalStackLayout Margin="16" Spacing="16">
                         <Label Text="Reconstruction Statistics" HorizontalOptions="Center" FontSize="16"  TextColor="{AppThemeBinding Light=#F0F4FF, Dark=#262E38}"/>
-                        <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
-                            <Border Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="{AppThemeBinding Light=#252F44, Dark=#353F4C}">
-                                <VerticalStackLayout Spacing="2">
-                                    <Label Text="Elapsed Time" FontAttributes="None" FontSize="12" TextColor="#9DAAD3"/>
-                                    <Label Text="{Binding ElapsedTime, StringFormat='{0:mm\\:ss}'}" FontSize="18" TextColor="#F0F4FF"/>
-                                </VerticalStackLayout>
-                            </Border>
-                            <Border Grid.Column="1" Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="{AppThemeBinding Light=#252F44, Dark=#3A4452}">
-                                <VerticalStackLayout Spacing="2">
-                                    <Label Text="Residual" FontAttributes="None" FontSize="12" TextColor="#9DAAD3"/>
-                                    <Label Text="{Binding Residual, StringFormat='{0:F3}'}" FontSize="18" TextColor="#F0F4FF"/>
-                                </VerticalStackLayout>
-                            </Border>
-                            <Border Grid.Row="1" Grid.ColumnSpan="2" Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="{AppThemeBinding Light=#252F44, Dark=#353F4C}">
-                                <VerticalStackLayout Spacing="2">
-                                    <Label Text="Correlation" FontAttributes="None" FontSize="12" TextColor="#9DAAD3"/>
-                                    <Label Text="{Binding Correlation, StringFormat='{0:F3}'}" FontSize="18" TextColor="#F0F4FF"/>
-                                </VerticalStackLayout>
-                            </Border>
-                        </Grid>
+                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding MetricGroups}" Spacing="12">
+                            <BindableLayout.ItemTemplate>
+                                <DataTemplate x:DataType="viewmodels:ReconstructionMetricGroupViewModel">
+                                    <Border Style="{StaticResource PanelSectionBorderStyle}" BackgroundColor="{AppThemeBinding Light=#252F44, Dark=#353F4C}">
+                                        <VerticalStackLayout Spacing="8">
+                                            <Label Text="{Binding Title}" FontSize="14" FontAttributes="Bold" TextColor="#F0F4FF"/>
+                                            <VerticalStackLayout BindableLayout.ItemsSource="{Binding Metrics}" Spacing="6">
+                                                <BindableLayout.ItemTemplate>
+                                                    <DataTemplate x:DataType="viewmodels:ReconstructionMetricViewModel">
+                                                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                                                            <Label Text="{Binding Name}" FontAttributes="None" FontSize="12" TextColor="#9DAAD3"/>
+                                                            <Label Grid.Column="1" Text="{Binding Value}" FontSize="16" TextColor="#F0F4FF" HorizontalOptions="End"/>
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </BindableLayout.ItemTemplate>
+                                            </VerticalStackLayout>
+                                        </VerticalStackLayout>
+                                    </Border>
+                                </DataTemplate>
+                            </BindableLayout.ItemTemplate>
+                        </VerticalStackLayout>
                         <skia:SKCanvasView x:Name="ResidualTrendCanvas"
                                                   HeightRequest="170"
                                                   PaintSurface="OnResidualTrendCanvasPaintSurface"/>


### PR DESCRIPTION
## Summary
- add metric groups, asynchronous computation, and background cancellation for reconstruction statistics in the view-model
- compute distribution, measurement, and field diagnostics such as RMSE, SSIM, electrode MAE/MAPE, and gradient energy while caching error metrics
- restructure the reconstruction page statistics panel to display grouped metric cards bound to the new metrics collection

## Testing
- `dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d51f0ea5788333a183274859810c0a