### PR TITLE
Add MP4 export pipeline with Windows transcoding fallback

### DIFF
--- a/ElectricalImpedanceTomography/Helpers/AviVideoWriter.cs
+++ b/ElectricalImpedanceTomography/Helpers/AviVideoWriter.cs
@@ -271,7 +271,7 @@ internal static class AviVideoWriter
             if ((frameData.Length & 1) == 1)
                 _writer.Write((byte)0);
 
-            uint offset = (uint)(chunkStart - _moviListStart - 4);
+            uint offset = (uint)(chunkStart - _moviListStart);
             _indexEntries.Add(new AviIndexEntry(_chunkFourCc, AviIfKeyFrame, offset, (uint)frameData.Length));
             _frameCount++;
         }

--- a/ElectricalImpedanceTomography/Helpers/Mp4VideoExporter.cs
+++ b/ElectricalImpedanceTomography/Helpers/Mp4VideoExporter.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ElectricalImpedanceTomography.Helpers;
+
+internal static partial class Mp4VideoExporter
+{
+    public static partial Task<bool> TryExportAsync(IReadOnlyList<string> frameImagePaths,
+                                                    int width,
+                                                    int height,
+                                                    int framesPerSecond,
+                                                    string outputFilePath,
+                                                    CancellationToken cancellationToken);
+}

--- a/ElectricalImpedanceTomography/Helpers/Mp4VideoExporter.other.cs
+++ b/ElectricalImpedanceTomography/Helpers/Mp4VideoExporter.other.cs
@@ -1,0 +1,18 @@
+#if !WINDOWS
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ElectricalImpedanceTomography.Helpers;
+
+internal static partial class Mp4VideoExporter
+{
+    public static partial Task<bool> TryExportAsync(IReadOnlyList<string> frameImagePaths,
+                                                    int width,
+                                                    int height,
+                                                    int framesPerSecond,
+                                                    string outputFilePath,
+                                                    CancellationToken cancellationToken)
+        => Task.FromResult(false);
+}
+#endif

--- a/ElectricalImpedanceTomography/Helpers/Mp4VideoExporter.windows.cs
+++ b/ElectricalImpedanceTomography/Helpers/Mp4VideoExporter.windows.cs
@@ -1,0 +1,112 @@
+#if WINDOWS
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Windows.Media.Editing;
+using Windows.Media.MediaProperties;
+using Windows.Media.Transcoding;
+using Windows.Storage;
+
+namespace ElectricalImpedanceTomography.Helpers;
+
+internal static partial class Mp4VideoExporter
+{
+    public static async partial Task<bool> TryExportAsync(IReadOnlyList<string> frameImagePaths,
+                                                          int width,
+                                                          int height,
+                                                          int framesPerSecond,
+                                                          string outputFilePath,
+                                                          CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (frameImagePaths.Count == 0)
+                return false;
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var composition = new MediaComposition();
+            var frameDuration = TimeSpan.FromSeconds(1.0 / Math.Max(framesPerSecond, 1));
+
+            foreach (var framePath in frameImagePaths)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var imageFile = await StorageFile.GetFileFromPathAsync(framePath);
+                cancellationToken.ThrowIfCancellationRequested();
+                var clip = await MediaClip.CreateFromImageFileAsync(imageFile, frameDuration);
+                composition.Clips.Add(clip);
+            }
+
+            if (composition.Clips.Count == 0)
+                return false;
+
+            string resolvedDirectory = Path.GetDirectoryName(outputFilePath) ?? Directory.GetCurrentDirectory();
+            Directory.CreateDirectory(resolvedDirectory);
+
+            var storageFolder = await StorageFolder.GetFolderFromPathAsync(resolvedDirectory);
+            string fileName = Path.GetFileName(outputFilePath);
+            var outputFile = await storageFolder.CreateFileAsync(fileName, CreationCollisionOption.ReplaceExisting);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var profile = MediaEncodingProfile.CreateMp4(VideoEncodingQuality.HD1080p);
+            profile.Video.Width = (uint)Math.Max(width, 1);
+            profile.Video.Height = (uint)Math.Max(height, 1);
+            profile.Video.FrameRate.Numerator = (uint)Math.Max(framesPerSecond, 1);
+            profile.Video.FrameRate.Denominator = 1;
+            profile.Video.PixelAspectRatio.Numerator = 1;
+            profile.Video.PixelAspectRatio.Denominator = 1;
+            profile.Video.Bitrate = (uint)Math.Clamp((long)profile.Video.Width * profile.Video.Height * profile.Video.FrameRate.Numerator * 12,
+                                                     1_000_000,
+                                                     100_000_000);
+            profile.Audio = null;
+
+            var transcodeOperation = composition.RenderToFileAsync(outputFile,
+                                                                   MediaTrimmingPreference.Precise,
+                                                                   profile);
+            using (cancellationToken.Register(() => transcodeOperation.Cancel()))
+            {
+                var transcodeResult = await transcodeOperation;
+
+                if (transcodeResult != TranscodeFailureReason.None)
+                {
+                    try
+                    {
+                        await outputFile.DeleteAsync();
+                    }
+                    catch
+                    {
+                        // Ignore cleanup issues when the transcode fails.
+                    }
+
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch
+        {
+            if (File.Exists(outputFilePath))
+            {
+                try
+                {
+                    File.Delete(outputFilePath);
+                }
+                catch
+                {
+                    // Ignore cleanup errors.
+                }
+            }
+
+            return false;
+        }
+    }
+}
+#endif

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -1196,20 +1196,28 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             string directory = FileSystem.Current.AppDataDirectory;
             Directory.CreateDirectory(directory);
-            string filePath = Path.Combine(directory, $"reconstruction_{DateTime.Now:yyyyMMdd_HHmmss}.avi");
+            string baseFileName = $"reconstruction_{DateTime.Now:yyyyMMdd_HHmmss}";
+            string mp4FilePath = Path.Combine(directory, baseFileName + ".mp4");
+            string aviFallbackFilePath = Path.Combine(directory, baseFileName + ".avi");
+            string? finalFilePath = null;
 
             try
             {
-                await Task.Run(() =>
+                await Task.Run(async () =>
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    AviVideoWriter.AviVideoStream? videoStream = null;
                     int videoWidth = 0;
                     int videoHeight = 0;
-
-                    using var stream = File.Create(filePath);
                     double totalSteps = frames.Count + 1.0;
+                    string tempFrameDirectory = Path.Combine(FileSystem.Current.CacheDirectory,
+                                                             "VideoExportFrames",
+                                                             Guid.NewGuid().ToString("N"));
+
+                    Directory.CreateDirectory(tempFrameDirectory);
+
+                    var encodedFrames = new List<byte[]>(frames.Count);
+                    var frameImagePaths = new List<string>(frames.Count);
 
                     try
                     {
@@ -1251,50 +1259,98 @@ namespace ElectricalImpedanceTomography.ViewModels
                                 throw new InvalidOperationException("Failed to encode video frame to JPEG.");
 
                             var frameBytes = encodedFrame.ToArray();
+                            encodedFrames.Add(frameBytes);
 
-                            if (videoStream == null)
-                            {
-                                videoStream = AviVideoWriter.BeginWrite(stream,
-                                                                        videoWidth,
-                                                                        videoHeight,
-                                                                        Workspace.ReconstructionVideoFramesPerSecond,
-                                                                        frameBytes.Length,
-                                                                        AviVideoWriter.AviVideoCodec.MotionJpeg);
-                            }
-
-                            videoStream.WriteFrame(frameBytes);
+                            string framePath = Path.Combine(tempFrameDirectory, $"frame_{i:D6}.jpg");
+                            await File.WriteAllBytesAsync(framePath, frameBytes, cancellationToken).ConfigureAwait(false);
+                            frameImagePaths.Add(framePath);
                         }
 
                         cancellationToken.ThrowIfCancellationRequested();
 
                         progress?.Report(new VideoExportProgressReport(Math.Min(0.98, frames.Count / (frames.Count + 1.0)),
-                                                                        "Finalizing video stream..."));
+                                                                        "Encoding video stream..."));
 
-                        if (videoStream == null)
-                            throw new InvalidOperationException("Unable to initialize the AVI writer.");
+                        bool mp4Created = await Mp4VideoExporter.TryExportAsync(frameImagePaths,
+                                                                                videoWidth,
+                                                                                videoHeight,
+                                                                                Workspace.ReconstructionVideoFramesPerSecond,
+                                                                                mp4FilePath,
+                                                                                cancellationToken).ConfigureAwait(false);
 
-                        videoStream.Complete();
+                        if (mp4Created)
+                        {
+                            finalFilePath = mp4FilePath;
+                        }
+                        else
+                        {
+                            if (encodedFrames.Count == 0)
+                                throw new InvalidOperationException("No frames were encoded for export.");
+
+                            if (File.Exists(mp4FilePath))
+                            {
+                                try
+                                {
+                                    File.Delete(mp4FilePath);
+                                }
+                                catch
+                                {
+                                    // Ignore failures when cleaning up a partial MP4 export.
+                                }
+                            }
+
+                            using var stream = File.Create(aviFallbackFilePath);
+                            using var videoStream = AviVideoWriter.BeginWrite(stream,
+                                                                             videoWidth,
+                                                                             videoHeight,
+                                                                             Workspace.ReconstructionVideoFramesPerSecond,
+                                                                             encodedFrames[0].Length,
+                                                                             AviVideoWriter.AviVideoCodec.MotionJpeg);
+
+                            foreach (var frame in encodedFrames)
+                            {
+                                cancellationToken.ThrowIfCancellationRequested();
+                                videoStream.WriteFrame(frame);
+                            }
+
+                            videoStream.Complete();
+                            finalFilePath = aviFallbackFilePath;
+                        }
                     }
                     finally
                     {
-                        videoStream?.Dispose();
+                        try
+                        {
+                            if (Directory.Exists(tempFrameDirectory))
+                            {
+                                Directory.Delete(tempFrameDirectory, recursive: true);
+                            }
+                        }
+                        catch
+                        {
+                            // Ignore cleanup errors.
+                        }
                     }
-                });
+                }, cancellationToken);
 
                 progress?.Report(new VideoExportProgressReport(1.0, "Video generation completed."));
-                return VideoExportResult.CreateSuccess(filePath);
+                string path = finalFilePath ?? mp4FilePath;
+                return VideoExportResult.CreateSuccess(path);
             }
             catch (OperationCanceledException)
             {
-                if (File.Exists(filePath))
+                foreach (var path in new[] { mp4FilePath, aviFallbackFilePath })
                 {
-                    try
+                    if (File.Exists(path))
                     {
-                        File.Delete(filePath);
-                    }
-                    catch
-                    {
-                        // Ignore any errors encountered during cleanup.
+                        try
+                        {
+                            File.Delete(path);
+                        }
+                        catch
+                        {
+                            // Ignore any errors encountered during cleanup.
+                        }
                     }
                 }
 
@@ -1302,6 +1358,21 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
             catch (Exception ex)
             {
+                foreach (var path in new[] { mp4FilePath, aviFallbackFilePath })
+                {
+                    if (File.Exists(path))
+                    {
+                        try
+                        {
+                            File.Delete(path);
+                        }
+                        catch
+                        {
+                            // Ignore cleanup errors when reporting the failure.
+                        }
+                    }
+                }
+
                 return VideoExportResult.CreateFailure("Export Failed", ex.Message);
             }
         }


### PR DESCRIPTION
## Summary
- add a platform-specific MP4 exporter that uses Windows MediaComposition to transcode rendered frames
- update the reconstruction video export flow to render JPEG frames to disk, attempt MP4 output, and fall back to AVI when needed
- clean up temporary frame assets and produced files when cancellation or failures occur

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: dotnet CLI is unavailable in this container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d532dd695c8333beb0ad025d6f2788