### PR TITLE
Add drive pattern strategy infrastructure and support opposite pattern

### DIFF
--- a/BusinessLayer/IReconstructionPersistence.cs
+++ b/BusinessLayer/IReconstructionPersistence.cs
@@ -28,8 +28,8 @@ namespace BusinessLayer
         public ReconstructionResult InverseSolveLbm(int maxIterationCount, double gradientStepSize, double redularizationStepSize, double excitationAmplitude, double tolerance = 1e-6);
 
 
-        public List<double[]> SimulateFemMeasurements(FEMMesh mesh, double excitationAmplitude);
-        public EITMeasurement SimulateLbmMeasurements(LBMGrid mesh, double excitationAmplitude);
+        public List<double[]> SimulateFemMeasurements(FEMMesh mesh, double excitationAmplitude, DrivePattern drivePattern);
+        public EITMeasurement SimulateLbmMeasurements(LBMGrid mesh, double excitationAmplitude, DrivePattern drivePattern);
 
         // --- Graph-based Reconstruction ---
         /// <summary>

--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -38,6 +38,8 @@ namespace BusinessLayer
 
         private bool _initialized = false;
 
+        private DrivePattern _drivePattern = DrivePattern.Adjecent;
+
         // --- Background reconstruction bookkeeping ---
         // Holds the running reconstruction task.  The task performs full
         // cycles of the inverse solver until a stop is requested.
@@ -73,6 +75,7 @@ namespace BusinessLayer
                 _initialDistributionType = parameters.InitialDistributionType;
                 var initSigma = _initialSigma ?? ConductivityDistributionFactory.CreateInitialDistribution(discretization, _initialDistributionType);
                 _numericOptimizer = NumericOptimizerFactory.Create(parameters.NumericOptimizer, initSigma);
+                _drivePattern = parameters.DrivePattern;
 
                 _inverseModel = InverseModelFactory.Create(_discretization, _numericOptimizer, _regularizer, _errorMetric, _differentialEquationSolver);
 
@@ -351,11 +354,11 @@ namespace BusinessLayer
             {
                 FEMMesh measMesh = (FEMMesh)mesh.DeepCopy();
                 measMesh.SetConductivityDistribution(originalSigma);
-                measurementFrames = SimulateFemMeasurements(measMesh, 1.0);
+                measurementFrames = SimulateFemMeasurements(measMesh, 1.0, _drivePattern);
             }
             else
             {
-                measurementFrames = SimulateFemMeasurements(mesh, 1.0);
+                measurementFrames = SimulateFemMeasurements(mesh, 1.0, _drivePattern);
             }
 
             ConductivityDistribution initialSigma = _initialSigma ?? ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
@@ -465,11 +468,11 @@ namespace BusinessLayer
             {
                 LBMGrid measMesh = (LBMGrid)mesh.DeepCopy();
                 measMesh.SetConductivityDistribution(originalSigma);
-                measurementFrames = SimulateLbmMeasurements(measMesh, 1.0);
+                measurementFrames = SimulateLbmMeasurements(measMesh, 1.0, _drivePattern);
             }
             else
             {
-                measurementFrames = SimulateLbmMeasurements(mesh, 1.0);
+                measurementFrames = SimulateLbmMeasurements(mesh, 1.0, _drivePattern);
             }
 
             ConductivityDistribution initialSigma = _initialSigma ?? mesh.GetConductivityDistribution();
@@ -563,10 +566,10 @@ namespace BusinessLayer
             {
                 FEMMesh measMesh = (FEMMesh)mesh.DeepCopy();
                 measMesh.SetConductivityDistribution(originalConductivityDistribution);
-                simulatedMeasurements = SimulateFemMeasurements(measMesh, excitationAmplitude);
+                simulatedMeasurements = SimulateFemMeasurements(measMesh, excitationAmplitude, _drivePattern);
             }
             else
-                simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude);
+                simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude, _drivePattern);
             
             ConductivityDistribution initialConductivityDistribution = _initialSigma ?? ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
             mesh.SetConductivityDistribution(initialConductivityDistribution);
@@ -820,11 +823,11 @@ namespace BusinessLayer
             {
                 LBMGrid measMesh = (LBMGrid)lbmGrid.DeepCopy();
                 measMesh.SetConductivityDistribution(originalConductivityDistribution);
-                measurementFrames = SimulateLbmMeasurements(measMesh, 1.0);
+                measurementFrames = SimulateLbmMeasurements(measMesh, 1.0, _drivePattern);
             }
             else
             {
-                measurementFrames = SimulateLbmMeasurements(lbmGrid, 1.0);
+                measurementFrames = SimulateLbmMeasurements(lbmGrid, 1.0, _drivePattern);
             }
 
             // Container to hold partial results from reconstrucion
@@ -871,7 +874,7 @@ namespace BusinessLayer
                                             frames);
         }
 
-        public EITMeasurement SimulateLbmMeasurements(LBMGrid mesh, double exciationAmplitude)
+        public EITMeasurement SimulateLbmMeasurements(LBMGrid mesh, double exciationAmplitude, DrivePattern drivePattern)
         {
             if (_differentialEquationSolver == null)
                 throw new NullReferenceException("Differential equation solver was null, check initializiation code!");
@@ -881,9 +884,12 @@ namespace BusinessLayer
             var electrodes = Workspace.GetCurrentGlobalLbmElectrodes();
             int electrodeCount = electrodes.Count;
 
-            double[,] measurementFrames = new double[electrodeCount, electrodeCount];
+            var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
+            int cycleLength = Math.Max(1, strategy.GetCycleLength(electrodeCount));
 
-            for (int i = 0; i < electrodeCount; i++)
+            double[,] measurementFrames = new double[cycleLength, electrodeCount];
+
+            for (int i = 0; i < cycleLength; i++)
             {
                 foreach (var el in electrodes)
                 {
@@ -894,12 +900,14 @@ namespace BusinessLayer
                     el.Current = 0.0;
                 }
 
-                electrodes[i % electrodeCount].IsExcitation = true;
-                electrodes[i % electrodeCount].IsMeasuring = false;
-                electrodes[i % electrodeCount].Current = exciationAmplitude;
-                electrodes[(i + 1) % electrodeCount].IsGround = true;
-                electrodes[(i + 1) % electrodeCount].IsMeasuring = false;
-                electrodes[(i + 1) % electrodeCount].Current = -exciationAmplitude;
+                var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
+
+                electrodes[excitationIndex].IsExcitation = true;
+                electrodes[excitationIndex].IsMeasuring = false;
+                electrodes[excitationIndex].Current = exciationAmplitude;
+                electrodes[groundIndex].IsGround = true;
+                electrodes[groundIndex].IsMeasuring = false;
+                electrodes[groundIndex].Current = -exciationAmplitude;
 
                 LBMBoundaryCondition boundaryCondition = new LBMBoundaryCondition(electrodes);
                 Workspace.SetCurrentGlobalLbmBoundaryCondition(boundaryCondition);
@@ -947,7 +955,7 @@ namespace BusinessLayer
 
             _regularizationWeight = regularization;
 
-            List<double[]> simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude);
+            List<double[]> simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude, _drivePattern);
             
             // 2) Initialize conductivity (σ^{(0)}) based on user selection
             ConductivityDistribution sigma = ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
@@ -1128,7 +1136,7 @@ namespace BusinessLayer
             return mesh;
         }
 
-        public List<double[]> SimulateFemMeasurements(FEMMesh mesh, double excitationAmplitude)
+        public List<double[]> SimulateFemMeasurements(FEMMesh mesh, double excitationAmplitude, DrivePattern drivePattern)
         {
             List<double[]> measurements = [];
 
@@ -1136,7 +1144,10 @@ namespace BusinessLayer
             var electrodes = deepCopy.GetElectrodes().ToList();
             int electrodeCount = electrodes.Count();
 
-            for (int i = 0; i < electrodeCount; i++)
+            var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
+            int cycleLength = Math.Max(1, strategy.GetCycleLength(electrodeCount));
+
+            for (int i = 0; i < cycleLength; i++)
             {
                 // Clear electrode status
                 foreach(var el in electrodes)
@@ -1149,12 +1160,13 @@ namespace BusinessLayer
                 }
 
                 // Set new electrode setup
-                electrodes[i % electrodeCount].IsExcitation = true;
-                electrodes[i % electrodeCount].IsMeasuring = false;
-                electrodes[i % electrodeCount].Current = excitationAmplitude;
-                electrodes[(i + 1) % electrodeCount].IsGround = true;
-                electrodes[(i + 1) % electrodeCount].IsMeasuring = false;
-                electrodes[(i + 1) % electrodeCount].Current = -excitationAmplitude;
+                var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
+                electrodes[excitationIndex].IsExcitation = true;
+                electrodes[excitationIndex].IsMeasuring = false;
+                electrodes[excitationIndex].Current = excitationAmplitude;
+                electrodes[groundIndex].IsGround = true;
+                electrodes[groundIndex].IsMeasuring = false;
+                electrodes[groundIndex].Current = -excitationAmplitude;
 
                 FEMMesh result = SolveFemForward(deepCopy);
 

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -20,6 +20,7 @@ using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Factories;
+using Utility.Classes.Measurement;
 using Utility.Classes.ReconstructionParameters;
 
 using Workspace = Utility.Classes.Application.Workspace;
@@ -38,6 +39,8 @@ namespace ElectricalImpedanceTomography.ViewModels
         private IDiscretization? _initializedDiscretization;
         private ReconstructionRunSignature? _lastRunSignature;
         private bool _resetMetricsOnStart = true;
+        private bool _updatingDrivePatternSelection;
+        private EITReconstructionParameters? _trackedDrivePatternParameters;
 
         [ObservableProperty]
         private int iterationCount = 0;
@@ -171,6 +174,8 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             InitializeMetricGroups();
             PropertyChanged += OnViewModelPropertyChanged;
+            TrackDrivePatternParameters(ReconstructionParameters);
+            SyncDrivePatternSelection();
 
             //UpdateMetric(MetricKeys.ErrorMetric, ReconstructionParameters.ErrorMetric.ToString());
             //UpdateMetric(MetricKeys.RegularizationWeight, FormatDouble(RegularizationWeight, "G3"));
@@ -210,6 +215,51 @@ namespace ElectricalImpedanceTomography.ViewModels
                 _resetMetricsOnStart = true;
 
             _lastRunSignature = signature;
+        }
+
+        private void TrackDrivePatternParameters(EITReconstructionParameters parameters)
+        {
+            if (_trackedDrivePatternParameters != null)
+                _trackedDrivePatternParameters.PropertyChanged -= OnReconstructionParametersDrivePatternChanged;
+
+            _trackedDrivePatternParameters = parameters;
+            if (_trackedDrivePatternParameters != null)
+                _trackedDrivePatternParameters.PropertyChanged += OnReconstructionParametersDrivePatternChanged;
+        }
+
+        private void OnReconstructionParametersDrivePatternChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(EITReconstructionParameters.DrivePattern))
+                SyncDrivePatternSelection();
+        }
+
+        private void SyncDrivePatternSelection()
+        {
+            if (ReconstructionParameters == null)
+                return;
+
+            SetDrivePattern(ReconstructionParameters.DrivePattern);
+        }
+
+        public void SetDrivePattern(DrivePattern pattern)
+        {
+            if (ReconstructionParameters == null)
+                return;
+
+            if (_updatingDrivePatternSelection)
+                return;
+
+            try
+            {
+                _updatingDrivePatternSelection = true;
+                AdjecentDrivePattern = pattern == DrivePattern.Adjecent;
+                OppositeDrivePattern = pattern == DrivePattern.Opposite;
+                ReconstructionParameters.DrivePattern = pattern;
+            }
+            finally
+            {
+                _updatingDrivePatternSelection = false;
+            }
         }
 
         private void InitializeMetricGroups()
@@ -350,6 +400,11 @@ namespace ElectricalImpedanceTomography.ViewModels
             //    UpdateMetric(MetricKeys.RegularizationWeight, FormatDouble(RegularizationWeight, "G3"));
             //else if (e.PropertyName == nameof(ReconstructionParameters))
             //    UpdateMetric(MetricKeys.ErrorMetric, ReconstructionParameters.ErrorMetric.ToString());
+            if (e.PropertyName == nameof(ReconstructionParameters))
+            {
+                TrackDrivePatternParameters(ReconstructionParameters);
+                SyncDrivePatternSelection();
+            }
         }
 
         partial void OnElapsedTimeChanged(TimeSpan value)
@@ -1624,8 +1679,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                 ExcitationCurrentAmplitude,
                 ExcitationElectrodeId,
                 GroundElectrodeId,
-                AdjecentDrivePattern,
-                OppositeDrivePattern);
+                parameters.DrivePattern);
 
             return new ReconstructionRunSignature(mesh, snapshot);
         }
@@ -1645,8 +1699,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             double ExcitationCurrentAmplitude,
             int ExcitationElectrodeId,
             int GroundElectrodeId,
-            bool AdjecentDrivePattern,
-            bool OppositeDrivePattern);
+            DrivePattern DrivePattern);
 
         private record ReconstructionRunSignature(IDiscretization Mesh, ReconstructionParametersSnapshot Parameters);
     }

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -1454,13 +1454,13 @@ public partial class ReconstructionPage : ContentPage
     private void OnAdjecentDrivePatternChecked(object sender, CheckedChangedEventArgs e)
     {
         if (e.Value)
-            _viewModel.OppositeDrivePattern = false;
+            _viewModel.SetDrivePattern(DrivePattern.Adjecent);
     }
 
     private void OnOppositeDrivePatternChecked(object sender, CheckedChangedEventArgs e)
     {
         if (e.Value)
-            _viewModel.AdjecentDrivePattern = false;
+            _viewModel.SetDrivePattern(DrivePattern.Opposite);
     }
 
     private void OnPotentialModeChanged(object? sender, int index)

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -38,6 +38,8 @@ namespace ServiceLayer
         private int _framesPerCycle;
         private MeasurementNoiseType _measurementNoiseType = MeasurementNoiseType.None;
         private double _measurementNoiseAmplitude;
+        private DrivePattern _drivePattern = DrivePattern.Adjecent;
+        private IDrivePatternStrategy _drivePatternStrategy = DrivePatternStrategyProvider.GetStrategy(DrivePattern.Adjecent);
         private readonly Random _noiseRandom = new();
 
         public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
@@ -99,8 +101,8 @@ namespace ServiceLayer
         {
             try
             {
-                var measurement = _reconstructionPersistence.SimulateLbmMeasurements(mesh, excitaionAmplitude);
                 var parameters = Workspace.GetReconstructionParameters();
+                var measurement = _reconstructionPersistence.SimulateLbmMeasurements(mesh, excitaionAmplitude, parameters.DrivePattern);
                 var noisyFrames = CloneMeasurementsWithNoise(measurement.Frames,
                     parameters.MeasurementNoiseType,
                     parameters.MeasurementNoiseAmplitude);
@@ -147,7 +149,11 @@ namespace ServiceLayer
                 _reconstructionPersistence.SetConductivityDistributions(_originalSigma, _initialSigma);
                 _reconstructionPersistence.InitializeReconstruction(discretization, parameters, reinit);
 
-                _framesPerCycle = (discretization.GetElectrodes().Count > 0) ? discretization.GetElectrodes().Count : 1;
+                _drivePattern = parameters.DrivePattern;
+                _drivePatternStrategy = DrivePatternStrategyProvider.GetStrategy(_drivePattern);
+
+                var electrodeCount = discretization.GetElectrodes().Count;
+                _framesPerCycle = electrodeCount > 0 ? Math.Max(1, _drivePatternStrategy.GetCycleLength(electrodeCount)) : 1;
 
                 _measurementNoiseType = parameters.MeasurementNoiseType;
                 _measurementNoiseAmplitude = parameters.MeasurementNoiseAmplitude;
@@ -246,8 +252,8 @@ namespace ServiceLayer
         {
             try
             {
-                var frames = _reconstructionPersistence.SimulateFemMeasurements(mesh, excitationAmplitude);
                 var parameters = Workspace.GetReconstructionParameters();
+                var frames = _reconstructionPersistence.SimulateFemMeasurements(mesh, excitationAmplitude, parameters.DrivePattern);
                 return CloneMeasurementsWithNoise(frames,
                     parameters.MeasurementNoiseType,
                     parameters.MeasurementNoiseAmplitude);
@@ -269,6 +275,44 @@ namespace ServiceLayer
         ///     the workspace and deep-copied inside the persistence layer so
         ///     that it remains unchanged.
         /// </summary>
+        private (int ExcitationIndex, int GroundIndex) GetDrivePatternPair(int electrodeCount, int stepIndex)
+        {
+            if (electrodeCount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(electrodeCount), "Electrode count must be positive.");
+
+            int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(electrodeCount));
+            var (excitation, ground) = _drivePatternStrategy.GetElectrodePair(electrodeCount, stepIndex % cycleLength);
+            return (excitation, ground);
+        }
+
+        private void ApplyDrivePatternToElectrodes<TElectrode>(IList<TElectrode> electrodes, double excitationAmplitude, int stepIndex)
+            where TElectrode : Electrode
+        {
+            if (electrodes.Count == 0)
+                return;
+
+            foreach (var el in electrodes)
+            {
+                el.Current = 0.0;
+                el.IsExcitation = false;
+                el.IsGround = false;
+                el.IsMeasuring = true;
+                el.Potential = 0.0;
+            }
+
+            var (excitationIndex, groundIndex) = GetDrivePatternPair(electrodes.Count, stepIndex);
+
+            var excitation = electrodes[excitationIndex];
+            excitation.IsExcitation = true;
+            excitation.IsMeasuring = false;
+            excitation.Current = excitationAmplitude;
+
+            var ground = electrodes[groundIndex];
+            ground.IsGround = true;
+            ground.IsMeasuring = false;
+            ground.Current = -excitationAmplitude;
+        }
+
         private void EnsureSimulatedMeasurements()
         {
             if (_simulatedMeasurements.Count > 0)
@@ -279,12 +323,12 @@ namespace ServiceLayer
 
             if (_discretization is FEMMesh && original is FEMMesh femOrig)
             {
-                var frames = _reconstructionPersistence.SimulateFemMeasurements(femOrig, _excitationAmplitude);
+                var frames = _reconstructionPersistence.SimulateFemMeasurements(femOrig, _excitationAmplitude, _drivePattern);
                 _simulatedMeasurements = CloneMeasurementsWithNoise(frames, _measurementNoiseType, _measurementNoiseAmplitude);
             }
             else if (_discretization is LBMGrid && original is LBMGrid lbmOrig)
             {
-                var measurement = _reconstructionPersistence.SimulateLbmMeasurements(lbmOrig, _excitationAmplitude);
+                var measurement = _reconstructionPersistence.SimulateLbmMeasurements(lbmOrig, _excitationAmplitude, _drivePattern);
                 _simulatedMeasurements = CloneMeasurementsWithNoise(measurement.Frames, _measurementNoiseType, _measurementNoiseAmplitude);
             }
             else
@@ -349,25 +393,12 @@ namespace ServiceLayer
                 // each frame so that the boundary condition reflects the
                 // rotating drive pattern.
                 int electrodeCount = femMesh.GetElectrodes().Count;
-                int exc = _simMeasurementIndex % electrodeCount;
-                var measurement = _simulatedMeasurements[exc];
+                int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(electrodeCount));
+                int stepIndex = _simMeasurementIndex % cycleLength;
+                var measurement = _simulatedMeasurements[stepIndex];
 
                 var electrodes = femMesh.GetElectrodes().Cast<FEMElectrode>().ToList();
-
-                // Reset electrode state before assigning the new excitation
-                // pattern.
-                foreach (var el in electrodes)
-                {
-                    el.Current = 0.0;
-                    el.IsExcitation = false;
-                    el.IsGround = false;
-                    el.Potential = 0.0;
-                }
-
-                electrodes[exc].IsExcitation = true;
-                electrodes[exc].Current = _excitationAmplitude;
-                electrodes[(exc + 1) % electrodeCount].IsGround = true;
-                electrodes[(exc + 1) % electrodeCount].Current = -_excitationAmplitude;
+                ApplyDrivePatternToElectrodes(electrodes, _excitationAmplitude, stepIndex);
 
                 var bc = new FEMBoundaryCondition(electrodes);
 
@@ -397,24 +428,13 @@ namespace ServiceLayer
                 EnsureSimulatedMeasurements();
 
                 var electrodes = lbmGrid.GetElectrodes().Cast<LBMElectrode>().ToList();
-
-                foreach (var el in electrodes)
-                {
-                    el.Current = 0.0;
-                    el.IsExcitation = false;
-                    el.IsGround = false;
-                    el.Potential = 0.0;
-                }
-
                 int electrodeCount = electrodes.Count;
-                int exc = _simMeasurementIndex % electrodeCount;
-                electrodes[exc].IsExcitation = true;
-                electrodes[exc].Current = _excitationAmplitude;
-                electrodes[(exc + 1) % electrodeCount].IsGround = true;
-                electrodes[(exc + 1) % electrodeCount].Current = -_excitationAmplitude;
+                int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(electrodeCount));
+                int stepIndex = _simMeasurementIndex % cycleLength;
+                ApplyDrivePatternToElectrodes(electrodes, _excitationAmplitude, stepIndex);
 
                 var bc = new LBMBoundaryCondition(electrodes);
-                double[] measurement = _simulatedMeasurements[exc];
+                double[] measurement = _simulatedMeasurements[stepIndex];
                 var frame = _reconstructionPersistence.Step(measurement, bc, _stepSize, _regularizationWeight);
                 _simMeasurementIndex++;
                 Workspace.AddReconstructionFrameToWorkspace(frame);
@@ -504,18 +524,7 @@ namespace ServiceLayer
 
                     for (int i = 0; i < _simulatedMeasurements.Count; i++)
                     {
-                        foreach (var el in electrodes)
-                        {
-                            el.Current = 0.0;
-                            el.IsExcitation = false;
-                            el.IsGround = false;
-                            el.Potential = 0.0;
-                        }
-
-                        electrodes[i % electrodeCount].IsExcitation = true;
-                        electrodes[i % electrodeCount].Current = _excitationAmplitude;
-                        electrodes[(i + 1) % electrodeCount].IsGround = true;
-                        electrodes[(i + 1) % electrodeCount].Current = -_excitationAmplitude;
+                        ApplyDrivePatternToElectrodes(electrodes, _excitationAmplitude, i);
 
                         var bc = new FEMBoundaryCondition(electrodes);
                         var measurement = _simulatedMeasurements[i];
@@ -562,18 +571,20 @@ namespace ServiceLayer
                 {
                     EnsureSimulatedMeasurements();
 
-                    foreach (var measurement in _simulatedMeasurements)
+                    for (int i = 0; i < _simulatedMeasurements.Count; i++)
                     {
                         var electrodes = lbmGrid.GetElectrodes().Cast<LBMElectrode>().ToList();
+                        ApplyDrivePatternToElectrodes(electrodes, _excitationAmplitude, i);
                         var bc = new LBMBoundaryCondition(electrodes);
 
+                        var measurement = _simulatedMeasurements[i];
                         var frame = _reconstructionPersistence.Step(measurement, bc, _stepSize, _regularizationWeight);
 
                         Workspace.AddReconstructionFrameToWorkspace(frame);
                         _currentCycleFrames.Add(frame);
                         ReconstructionFrameUpdated?.Invoke(this, frame);
 
-                        lbmGrid.ShiftExcitationElectrodes(DrivePattern.Adjecent);
+                        lbmGrid.ShiftExcitationElectrodes(_drivePattern);
                     }
 
                     var frameCount = _currentCycleFrames.Count;

--- a/Utility/Classes/Discretizer/Discretization.cs
+++ b/Utility/Classes/Discretizer/Discretization.cs
@@ -168,25 +168,51 @@ namespace Utility.Classes.Discretizer
 
             ResetElectrodes();
 
-            switch(drivePattern)
+            var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
+            int cycleLength = Math.Max(1, strategy.GetCycleLength(electrodeCount));
+
+            int currentStep = 0;
+            bool stepFound = false;
+            for (int step = 0; step < cycleLength; step++)
             {
-                case DrivePattern.Adjecent:
-                    int newExcitationElectrodeId = (excitationElectrodeId + 1) % electrodeCount;
-                    _electrodes[newExcitationElectrodeId].Current = excitationCurrent;
-                    _electrodes[newExcitationElectrodeId].IsExcitation = true;
-                    _electrodes[newExcitationElectrodeId].IsMeasuring = false;
-                    
-                    int newGroundElectrodeId = (groundElectrodeId + 1) % electrodeCount;
-                    _electrodes[newGroundElectrodeId].Current = groundCurrent;
-                    _electrodes[newGroundElectrodeId].IsGround = true;
-                    _electrodes[newGroundElectrodeId].IsMeasuring = false;
+                var pair = strategy.GetElectrodePair(electrodeCount, step);
+                if (pair.Excitation == excitationElectrodeId && pair.Ground == groundElectrodeId)
+                {
+                    currentStep = step;
+                    stepFound = true;
                     break;
-                case DrivePattern.Opposite:
-                    //TODO
-                    break;
-                default:
-                    break;
+                }
             }
+
+            if (!stepFound)
+            {
+                for (int step = 0; step < cycleLength; step++)
+                {
+                    var pair = strategy.GetElectrodePair(electrodeCount, step);
+                    if (pair.Excitation == excitationElectrodeId)
+                    {
+                        currentStep = step;
+                        stepFound = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!stepFound)
+                currentStep = excitationElectrodeId % cycleLength;
+
+            int nextStep = (currentStep + 1) % cycleLength;
+            var (nextExcitationElectrodeId, nextGroundElectrodeId) = strategy.GetElectrodePair(electrodeCount, nextStep);
+
+            var nextExcitation = _electrodes[nextExcitationElectrodeId];
+            nextExcitation.Current = excitationCurrent;
+            nextExcitation.IsExcitation = true;
+            nextExcitation.IsMeasuring = false;
+
+            var nextGround = _electrodes[nextGroundElectrodeId];
+            nextGround.Current = groundCurrent;
+            nextGround.IsGround = true;
+            nextGround.IsMeasuring = false;
         }
 
         protected abstract IEnumerable<int> StateKeys();                       

--- a/Utility/Classes/Measurement/DrivePatternStrategy.cs
+++ b/Utility/Classes/Measurement/DrivePatternStrategy.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Utility.Classes.Measurement
+{
+    public interface IDrivePatternStrategy
+    {
+        (int Excitation, int Ground) GetElectrodePair(int electrodeCount, int stepIndex);
+
+        int GetCycleLength(int electrodeCount);
+    }
+
+    public abstract class DrivePatternStrategyBase : IDrivePatternStrategy
+    {
+        public virtual int GetCycleLength(int electrodeCount)
+        {
+            if (electrodeCount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(electrodeCount), "Electrode count must be positive.");
+
+            return electrodeCount;
+        }
+
+        public abstract (int Excitation, int Ground) GetElectrodePair(int electrodeCount, int stepIndex);
+
+        protected static int NormalizeStepIndex(int stepIndex, int cycleLength)
+        {
+            if (cycleLength <= 0)
+                throw new ArgumentOutOfRangeException(nameof(cycleLength), "Cycle length must be positive.");
+
+            int normalized = stepIndex % cycleLength;
+            return normalized < 0 ? normalized + cycleLength : normalized;
+        }
+
+        protected static int NormalizeElectrodeIndex(int index, int electrodeCount)
+        {
+            if (electrodeCount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(electrodeCount), "Electrode count must be positive.");
+
+            int normalized = index % electrodeCount;
+            return normalized < 0 ? normalized + electrodeCount : normalized;
+        }
+    }
+
+    internal sealed class AdjacentDrivePatternStrategy : DrivePatternStrategyBase
+    {
+        public override (int Excitation, int Ground) GetElectrodePair(int electrodeCount, int stepIndex)
+        {
+            int cycleLength = GetCycleLength(electrodeCount);
+            int normalizedStep = NormalizeStepIndex(stepIndex, cycleLength);
+            int excitation = normalizedStep;
+            int ground = NormalizeElectrodeIndex(excitation + 1, electrodeCount);
+            return (excitation, ground);
+        }
+    }
+
+    internal sealed class OppositeDrivePatternStrategy : DrivePatternStrategyBase
+    {
+        public override (int Excitation, int Ground) GetElectrodePair(int electrodeCount, int stepIndex)
+        {
+            int cycleLength = GetCycleLength(electrodeCount);
+            int normalizedStep = NormalizeStepIndex(stepIndex, cycleLength);
+            int excitation = normalizedStep;
+
+            int offset = Math.Max(1, electrodeCount / 2);
+            int ground = NormalizeElectrodeIndex(excitation + offset, electrodeCount);
+
+            if (ground == excitation)
+                ground = NormalizeElectrodeIndex(excitation + 1, electrodeCount);
+
+            return (excitation, ground);
+        }
+    }
+
+    public static class DrivePatternStrategyProvider
+    {
+        private static readonly ConcurrentDictionary<DrivePattern, IDrivePatternStrategy> Strategies = new();
+
+        static DrivePatternStrategyProvider()
+        {
+            Strategies[DrivePattern.Adjecent] = new AdjacentDrivePatternStrategy();
+            Strategies[DrivePattern.Opposite] = new OppositeDrivePatternStrategy();
+        }
+
+        public static void RegisterStrategy(DrivePattern pattern, IDrivePatternStrategy strategy, bool overwrite = false)
+        {
+            if (strategy == null)
+                throw new ArgumentNullException(nameof(strategy));
+
+            if (!overwrite && Strategies.ContainsKey(pattern))
+                throw new ArgumentException($"A strategy for drive pattern '{pattern}' is already registered.", nameof(pattern));
+
+            Strategies[pattern] = strategy;
+        }
+
+        public static IDrivePatternStrategy GetStrategy(DrivePattern pattern)
+        {
+            if (!Strategies.TryGetValue(pattern, out var strategy))
+                throw new NotSupportedException($"No drive pattern strategy registered for '{pattern}'.");
+
+            return strategy;
+        }
+    }
+}

--- a/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
+++ b/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
@@ -1,6 +1,7 @@
 ﻿using Utility.Classes.Discretizer;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Utility.Classes.Factories;
+using Utility.Classes.Measurement;
 
 namespace Utility.Classes.ReconstructionParameters
 {
@@ -26,6 +27,9 @@ namespace Utility.Classes.ReconstructionParameters
         [ObservableProperty]
         private double measurementNoiseAmplitude = 0.0;
 
+        [ObservableProperty]
+        private DrivePattern drivePattern = DrivePattern.Adjecent;
+
         public DiscretizationType Mesh = DiscretizationType.FEM;
 
         public EITReconstructionParameters()
@@ -38,6 +42,7 @@ namespace Utility.Classes.ReconstructionParameters
             InitialDistributionType = InitialDistributionTypes.Homogeneous;
             MeasurementNoiseType = MeasurementNoiseType.None;
             MeasurementNoiseAmplitude = 0.0;
+            DrivePattern = DrivePattern.Adjecent;
             Mesh = DiscretizationType.FEM;
         }
 
@@ -48,7 +53,8 @@ namespace Utility.Classes.ReconstructionParameters
                                            NumericOptimizer numericOptimizer,
                                            InitialDistributionTypes initialDistributionType = InitialDistributionTypes.SlightlyDiffering,
                                            MeasurementNoiseType measurementNoiseType = MeasurementNoiseType.None,
-                                           double measurementNoiseAmplitude = 0.0)
+                                           double measurementNoiseAmplitude = 0.0,
+                                           DrivePattern drivePattern = DrivePattern.Adjecent)
         {
             DifferentialEquationSolver = differentialEquationSolver;
             RegularizationTechnique = regularizationTechnique;
@@ -58,6 +64,7 @@ namespace Utility.Classes.ReconstructionParameters
             InitialDistributionType = initialDistributionType;
             MeasurementNoiseType = measurementNoiseType;
             MeasurementNoiseAmplitude = measurementNoiseAmplitude;
+            DrivePattern = drivePattern;
 
             Mesh = (differentialEquationSolver == DifferentialEquationSolver.FEM) ? DiscretizationType.FEM : DiscretizationType.LBM;
         }


### PR DESCRIPTION
## Summary
- introduce a drive-pattern strategy provider and register adjacent/opposite implementations
- propagate the selected drive pattern through reconstruction parameters, view models, services, and persistence
- update measurement simulation and electrode shifting to use the registered strategies, enabling opposite-drive reconstruction

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f58cdbe88333856cef79edede47a