### PR TITLE
Document reconstruction metrics and solver helpers

### DIFF
--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -622,6 +622,11 @@ namespace Utility.Classes.Factories
 
         #endregion
 
+        /// <summary>
+        /// Perturbs the conductivity values of every element in the
+        /// discretization using zero-mean Gaussian noise with a 5% relative
+        /// standard deviation.
+        /// </summary>
         public static void AddGaussianNoise(IDiscretization discretization)
         {
             if (discretization == null) throw new ArgumentNullException(nameof(discretization));
@@ -650,6 +655,10 @@ namespace Utility.Classes.Factories
             Workspace.AddLogMessage("MeshFactory", "Added gaussian noise to mesh conductivities.");
         }
 
+        /// <summary>
+        /// Validates that a polygonal perimeter contains at least three
+        /// distinct consecutive points.
+        /// </summary>
         private static void ValidatePerimeter(IList<(double x, double y)> perimeter)
         {
             if (perimeter is null || perimeter.Count < 3)
@@ -663,6 +672,10 @@ namespace Utility.Classes.Factories
             }
         }
 
+        /// <summary>
+        /// Implements the ray casting test to determine whether a point lies
+        /// inside a polygon.
+        /// </summary>
         private static bool IsPointInPolygon(double x, double y, IList<(double x, double y)> polygon)
         {
             bool inside = false;

--- a/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
@@ -421,6 +421,14 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
 
             return result;
         }
+        /// <summary>
+        /// Numerically stable softplus implementation that avoids overflow
+        /// and catastrophic cancellation for very large positive or negative
+        /// arguments.  The metric relies on this helper while smoothing the
+        /// electrode histogram prior to the optimal transport solve.
+        /// </summary>
+        /// <param name="x">Input value to be transformed.</param>
+        /// <returns><c>log(1 + exp(x))</c> computed in a stable manner.</returns>
         private static double Softplus(double x)
         {
             if (x > 50) // avoid overflow
@@ -430,6 +438,14 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return Log1p(Math.Exp(x));
         }
 
+        /// <summary>
+        /// Evaluates <c>log(1 + x)</c> while maintaining precision for tiny
+        /// arguments where the naive formulation would lose significant
+        /// digits.  This is required because the softplus helper frequently
+        /// forwards very small exponentials when κ is large.
+        /// </summary>
+        /// <param name="x">Offset from unity.</param>
+        /// <returns>Accurate value of <c>log(1 + x)</c>.</returns>
         private static double Log1p(double x)
         {
             // For very small x, use series expansion to avoid loss of precision
@@ -438,6 +454,13 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return Math.Log(1.0 + x);
         }
 
+        /// <summary>
+        /// Computes the logistic sigmoid in a branch-safe fashion.  The
+        /// expression is symmetric but we split the domains to avoid overflow
+        /// when evaluating <c>exp(±x)</c> for large magnitudes.
+        /// </summary>
+        /// <param name="x">Input value.</param>
+        /// <returns>Logistic sigmoid σ(x).</returns>
         private static double Sigmoid(double x)
         {
             if (x >= 0)
@@ -452,6 +475,12 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             }
         }
 
+        /// <summary>
+        /// Squares the conductivity-aware geodesic distances to obtain the
+        /// quadratic ground cost used by the Wasserstein-2 metric.
+        /// </summary>
+        /// <param name="distances">Pairwise soft geodesic distances.</param>
+        /// <returns>Cost matrix with entries <c>d(x, y)^2</c>.</returns>
         private static double[,] BuildCostMatrix(double[,] distances)
         {
             int m = distances.GetLength(0);
@@ -466,6 +495,13 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return cost;
         }
 
+        /// <summary>
+        /// Builds the purely geometric quadratic cost between electrode
+        /// centroids.  This baseline is blended with the physics-aware ground
+        /// cost when <c>α &lt; 1</c>.
+        /// </summary>
+        /// <param name="electrodePositions">Electrode centroid coordinates.</param>
+        /// <returns>Squared Euclidean distance matrix.</returns>
         private static double[,] BuildGeometricCost(IReadOnlyList<(double x, double y)> electrodePositions)
         {
             int m = electrodePositions.Count;
@@ -485,12 +521,29 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
 
         private sealed record OptimalTransportResult(double[,] Plan, double[] SourcePotential, double[] TargetPotential);
 
+        /// <summary>
+        /// Solves the discrete optimal transport problem and packages both
+        /// the primal transport plan and the dual Kantorovich potentials so
+        /// that the caller can directly reuse them for gradient evaluation.
+        /// </summary>
+        /// <param name="cost">Quadratic ground cost matrix.</param>
+        /// <param name="mu">Source histogram.</param>
+        /// <param name="nu">Target histogram.</param>
+        /// <returns>Optimal plan together with source/target potentials.</returns>
         private static OptimalTransportResult SolveOptimalTransport(double[,] cost, double[] mu, double[] nu)
         {
             var plan = SolveOptimalTransportPrimal(cost, mu, nu, out var alpha, out var beta);
             return new OptimalTransportResult(plan, alpha, beta);
         }
-        
+
+        /// <summary>
+        /// Convenience wrapper that creates a non-negative LP variable for the
+        /// OR-Tools solver while documenting the intent of each transport
+        /// decision variable.
+        /// </summary>
+        /// <param name="solver">Active linear solver instance.</param>
+        /// <param name="name">Human-readable variable name.</param>
+        /// <returns>OR-Tools variable constrained to be ≥ 0.</returns>
         private static Variable MakeNonNegativeVariable(Solver solver, string name)
         {
             return solver.MakeNumVar(0.0, double.PositiveInfinity, name);
@@ -554,6 +607,13 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return planMatrix;
         }
 
+        /// <summary>
+        /// Computes the Frobenius inner product between a ground cost and the
+        /// optimal transport plan, i.e. <c>Σᵢⱼ Cᵢⱼ Γᵢⱼ</c>.
+        /// </summary>
+        /// <param name="matrix">Ground cost matrix.</param>
+        /// <param name="plan">Transport plan.</param>
+        /// <returns>Weighted sum of costs.</returns>
         private static double WeightedSum(double[,] matrix, double[,] plan)
         {
             int m = matrix.GetLength(0);
@@ -565,6 +625,16 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return sum;
         }
 
+        /// <summary>
+        /// Forms the convex combination of the conductivity-aware and purely
+        /// geometric Kantorovich potentials.  The factor of ½ follows directly
+        /// from the derivative of the quadratic objective with respect to the
+        /// source histogram.
+        /// </summary>
+        /// <param name="alpha">Blend weight favouring physics-aware costs.</param>
+        /// <param name="phys">Source potential from the conductive transport solve.</param>
+        /// <param name="geo">Optional source potential from the geometric solve.</param>
+        /// <returns>Blended source potential g_μ.</returns>
         private double[] BlendPotentials(double alpha, double[] phys, double[]? geo)
         {
             int n = phys.Length;
@@ -630,6 +700,15 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return ComputeSoftDistancesAndOccupancies(mesh, nodes);
         }
 
+        /// <summary>
+        /// Associates each electrode with the nearest vertex in the graph that
+        /// is derived from the FEM mesh.  The mapping provides the bridge
+        /// between electrode boundary conditions and the graph-based geodesic
+        /// solver.
+        /// </summary>
+        /// <param name="mesh">Mesh that defines both the graph and electrodes.</param>
+        /// <param name="electrodePositions">Electrode centroid coordinates.</param>
+        /// <returns>Array mapping electrode indices to graph node indices.</returns>
         private static int[] MapElectrodesToGraphNodes(FEMMesh mesh, IReadOnlyList<(double x, double y)> electrodePositions)
         {
             var graph = mesh.ToGraph();
@@ -660,6 +739,15 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return mapping;
         }
 
+        /// <summary>
+        /// Runs the conductivity-aware soft geodesic solver for every
+        /// electrode pair and stores the resulting distances and edge
+        /// occupancies.  The occupancies enable efficient reuse during
+        /// gradient back-propagation.
+        /// </summary>
+        /// <param name="mesh">Finite-element mesh providing the conductivity graph.</param>
+        /// <param name="electrodeNodes">Indices of graph nodes attached to electrodes.</param>
+        /// <returns>Distances and edge metadata for subsequent computations.</returns>
         private SoftGeodesicResult ComputeSoftDistancesAndOccupancies(FEMMesh mesh, int[] electrodeNodes)
         {
             // Build graph data from the discretization.
@@ -771,6 +859,17 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return d;
         }
 
+        /// <summary>
+        /// Constructs the soft transition probabilities for the entropy
+        /// regularised shortest-path problem.  The resulting Markov chain
+        /// encodes the likelihood of traversing each edge when moving toward
+        /// the target node under the soft Bellman policy.
+        /// </summary>
+        /// <param name="nodeCount">Number of nodes in the graph.</param>
+        /// <param name="adjacency">Weighted adjacency lists.</param>
+        /// <param name="d">Soft distance vector.</param>
+        /// <param name="target">Destination node.</param>
+        /// <returns>Per-node transition probability lists.</returns>
         private static List<Transition>[] BuildTransitions(int nodeCount, IList<DirectedEdge>[] adjacency, double[] d, int target)
         {
             var transitions = new List<Transition>[nodeCount];
@@ -807,6 +906,15 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return transitions;
         }
 
+        /// <summary>
+        /// Builds an LU factorisation of the reduced transition matrix (with
+        /// the absorbing target removed) so that multiple right-hand sides can
+        /// be solved efficiently when accumulating edge occupancies for each
+        /// source electrode.
+        /// </summary>
+        /// <param name="transitions">Transition probabilities towards the target.</param>
+        /// <param name="target">Index of the absorbing target node.</param>
+        /// <returns>LU decomposition and node-index mapping.</returns>
         private static (LU<double> lu, Dictionary<int, int> indexMap) FactoriseTransitions(List<Transition>[] transitions, int target)
         {
             int nodeCount = transitions.Length;
@@ -836,6 +944,19 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return (lu, indexMap);
         }
 
+        /// <summary>
+        /// Accumulates expected edge visitation counts for a soft geodesic
+        /// random walk originating from <paramref name="sourceNode"/> and
+        /// terminating at <paramref name="targetNode"/>.
+        /// </summary>
+        /// <param name="nodeCount">Number of vertices in the graph.</param>
+        /// <param name="edges">Edge metadata including σ and geometry.</param>
+        /// <param name="transitions">Soft transition probabilities.</param>
+        /// <param name="lu">LU factorisation of the reduced transition matrix.</param>
+        /// <param name="indexMap">Mapping from node id to LU row index.</param>
+        /// <param name="sourceNode">Start node of the walk.</param>
+        /// <param name="targetNode">Absorbing target node.</param>
+        /// <returns>Expected number of traversals per edge.</returns>
         private static double[] ComputeEdgeOccupancies(int nodeCount,
                                                         IReadOnlyList<EdgeInfo> edges,
                                                         List<Transition>[] transitions,
@@ -873,6 +994,15 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return rho;
         }
 
+        /// <summary>
+        /// Contracts the optimal transport plan with the edge occupancy
+        /// sensitivities to yield the conductivity derivative of the OT cost
+        /// term.
+        /// </summary>
+        /// <param name="mesh">Source FEM mesh.</param>
+        /// <param name="geodesics">Soft geodesic cache.</param>
+        /// <param name="gamma">Optimal transport plan Γ.</param>
+        /// <returns>Element-indexed gradient contribution.</returns>
         private Dictionary<int, double> ComputeCostGradient(FEMMesh mesh, SoftGeodesicResult geodesics, double[,] gamma)
         {
             var gradient = new Dictionary<int, double>();
@@ -910,6 +1040,14 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return gradient;
         }
 
+        /// <summary>
+        /// Computes the classical FEM adjoint gradient component
+        /// <c>-∇ϕ·∇λ</c> for each conductivity element.
+        /// </summary>
+        /// <param name="mesh">Finite-element mesh used in the forward solve.</param>
+        /// <param name="phi">Forward potential distribution.</param>
+        /// <param name="lambda">Adjoint potential distribution.</param>
+        /// <returns>Dictionary of element gradients.</returns>
         private static Dictionary<int, double> ComputeAdjointConductivityGradient(FEMMesh mesh, PotentialDistribution phi, PotentialDistribution lambda)
         {
             var result = new Dictionary<int, double>();
@@ -923,6 +1061,13 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return result;
         }
 
+        /// <summary>
+        /// Evaluates the gradient of a nodal potential over a single
+        /// triangular FEM element using the stored basis-function gradients.
+        /// </summary>
+        /// <param name="element">Element for which the gradient is required.</param>
+        /// <param name="potential">Potential values defined at element nodes.</param>
+        /// <returns>Gradient components (∂/∂x, ∂/∂y).</returns>
         private static (double dx, double dy) ComputeElementGradient(FEMElement element, PotentialDistribution potential)
         {
             double gx = 0.0, gy = 0.0;
@@ -936,6 +1081,14 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return (gx, gy);
         }
 
+        /// <summary>
+        /// Aggregates the adjoint and cost contributions into a single
+        /// conductivity distribution that matches the mesh element ordering.
+        /// </summary>
+        /// <param name="mesh">Mesh describing the element indices.</param>
+        /// <param name="adjoint">Optional PDE adjoint component.</param>
+        /// <param name="cost">Transport-cost component.</param>
+        /// <returns>Combined conductivity gradient.</returns>
         private static ConductivityDistribution MergeGradientComponents(FEMMesh mesh,
                                                                          Dictionary<int, double>? adjoint,
                                                                          Dictionary<int, double> cost)
@@ -953,6 +1106,14 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return new ConductivityDistribution(merged);
         }
 
+        /// <summary>
+        /// Spreads an electrode-indexed adjoint source vector onto mesh nodes
+        /// by proportionally distributing the values across the FEM vertices
+        /// covered by each electrode.
+        /// </summary>
+        /// <param name="mesh">Mesh containing the electrode definitions.</param>
+        /// <param name="electrodeSource">Adjoint source per electrode.</param>
+        /// <returns>Node-indexed adjoint source.</returns>
         internal static Dictionary<int, double> LiftElectrodeSourceToNodes(FEMMesh mesh, double[] electrodeSource)
 
         {

--- a/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
+++ b/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
@@ -5,6 +5,9 @@ using Utility.Classes.Measurement;
 
 namespace Utility.Classes.ReconstructionParameters
 {
+    /// <summary>
+    /// Data transfer object that captures all user-configurable reconstruction options.
+    /// </summary>
     public partial class EITReconstructionParameters : ObservableObject
     {
         [ObservableProperty]
@@ -32,6 +35,9 @@ namespace Utility.Classes.ReconstructionParameters
 
         public DiscretizationType Mesh = DiscretizationType.FEM;
 
+        /// <summary>
+        /// Creates a parameter set using the default reconstruction configuration.
+        /// </summary>
         public EITReconstructionParameters()
         {
             DifferentialEquationSolver = DifferentialEquationSolver.FEM;
@@ -46,6 +52,10 @@ namespace Utility.Classes.ReconstructionParameters
             Mesh = DiscretizationType.FEM;
         }
 
+        /// <summary>
+        /// Creates a parameter set with the provided solver, regularisation,
+        /// and noise configuration.
+        /// </summary>
         public EITReconstructionParameters(DifferentialEquationSolver differentialEquationSolver,
                                            RegularizationTechnique regularizationTechnique,
                                            ErrorMetric errorMetric,

--- a/Utility/Classes/ReconstructionParameters/MeasurementNoiseType.cs
+++ b/Utility/Classes/ReconstructionParameters/MeasurementNoiseType.cs
@@ -1,5 +1,8 @@
 ﻿namespace Utility.Classes.ReconstructionParameters
 {
+    /// <summary>
+    /// Enumerates the supported synthetic noise models for measurement data.
+    /// </summary>
     public enum MeasurementNoiseType
     {
         None = 0,

--- a/Utility/Classes/Solvers/FiniteElementSolver/FiniteElementOperators.cs
+++ b/Utility/Classes/Solvers/FiniteElementSolver/FiniteElementOperators.cs
@@ -205,6 +205,10 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
 
         #region Private Helpers
 
+        /// <summary>
+        /// Computes the cotangent of the angle at <paramref name="p3"/> for the
+        /// triangle defined by <paramref name="p1"/>-<paramref name="p2"/>-<paramref name="p3"/>.
+        /// </summary>
         private static double Cotangent(FEMVertex p1, FEMVertex p2, FEMVertex p3)
         {
             // Calculate cotangent of the angle at p3 for the triangle p1-p2-p3
@@ -220,6 +224,9 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             return Math.Abs(crossProductMagnitude) < 1e-12 ? 0 : dotProduct / crossProductMagnitude;
         }
 
+        /// <summary>
+        /// Builds an undirected vertex adjacency map for the supplied mesh.
+        /// </summary>
         private static Dictionary<int, List<int>> BuildAdjacencyMap(FEMMesh mesh)
         {
             var adjacency = new Dictionary<int, List<int>>();
@@ -234,6 +241,9 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             return adjacency;
         }
 
+        /// <summary>
+        /// Inserts an undirected edge into the adjacency map.
+        /// </summary>
         private static void AddEdge(Dictionary<int, List<int>> adjacency, int u, int v)
         {
             if (!adjacency.ContainsKey(u)) adjacency[u] = [];
@@ -242,6 +252,10 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             if (!adjacency[v].Contains(u)) adjacency[v].Add(u);
         }
 
+        /// <summary>
+        /// Builds a mapping from undirected edges to the list of elements that
+        /// share the edge.
+        /// </summary>
         private static Dictionary<(int, int), List<int>> BuildEdgeToElementMap(IEnumerable<FEMElement> elements)
         {
             var map = new Dictionary<(int, int), List<int>>();
@@ -264,6 +278,9 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             return map;
         }
 
+        /// <summary>
+        /// Returns an ordered key for an undirected edge.
+        /// </summary>
         private static (int, int) NormaliseEdgeKey(int a, int b) => a < b ? (a, b) : (b, a);
 
         #endregion

--- a/Utility/Classes/Solvers/FiniteElementSolver/FiniteElementSolver.cs
+++ b/Utility/Classes/Solvers/FiniteElementSolver/FiniteElementSolver.cs
@@ -52,6 +52,14 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             SystemRHS = new Complex[N_phi + L];
         }
 
+        /// <summary>
+        /// Solves the forward CEM problem on the provided discretization by
+        /// assembling the block saddle-point system and applying the configured
+        /// numeric linear solver.
+        /// </summary>
+        /// <param name="discretization">Finite-element discretization.</param>
+        /// <param name="boundaryCondition">Boundary condition carrying electrode drives.</param>
+        /// <returns>Computed potential distribution.</returns>
         public PotentialDistribution SolveForward(IDiscretization discretization, BoundaryCondition boundaryCondition)
         {
             var femMesh = discretization as FEMMesh ?? throw new InvalidCastException();
@@ -61,6 +69,15 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             return Solve(femMesh, bcElectrodes);
         }
 
+        /// <summary>
+        /// Reuses the forward assembly to solve the adjoint CEM problem driven
+        /// by an electrode source vector.  This feeds reconstruction
+        /// algorithms that require ∇·(σ∇λ) solves.
+        /// </summary>
+        /// <param name="discretization">Finite-element discretization.</param>
+        /// <param name="boundaryCondition">Boundary condition providing electrode metadata.</param>
+        /// <param name="adjointSource">Adjoint current density per electrode.</param>
+        /// <returns>Adjoint potential distribution.</returns>
         public PotentialDistribution SolveAdjoint(IDiscretization discretization, BoundaryCondition boundaryCondition, Complex[] adjointSource)
         {
             var femMesh = discretization as FEMMesh ?? throw new InvalidCastException();
@@ -131,7 +148,10 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
 
         #region Assembly
 
-        /// <summary>Eq (1.2.3)</summary>
+        /// <summary>
+        /// Assembles the FEM stiffness matrix K = ∫ σ ∇φ_i · ∇φ_j using the
+        /// conductivity stored on each element.
+        /// </summary>
         private void BuildStiffnessMatrix(FEMMesh mesh)
         {
             Array.Clear(K, 0, K.Length);
@@ -156,7 +176,10 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             //Debug.WriteLine("K:\n" + FormatComplexMatrix(K));
         }
 
-        /// <summary>Eq (1.1.12)</summary>
+        /// <summary>
+        /// Integrates the boundary impedance contributions from the complete
+        /// electrode model to form the Robin mass matrix M.
+        /// </summary>
         private void BuildRobinMassMatrix(FEMMesh mesh)
         {
             Array.Clear(M, 0, M.Length);
@@ -173,7 +196,10 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             //Debug.WriteLine("M:\n" + FormatComplexMatrix(M));
         }
 
-        /// <summary>Eq (1.1.12)</summary>
+        /// <summary>
+        /// Builds the coupling matrix that links node potentials with
+        /// electrode potentials through the contact impedance terms.
+        /// </summary>
         private void BuildCouplingMatrix(FEMMesh mesh)
         {
             Array.Clear(A_coup, 0, A_coup.Length);
@@ -190,7 +216,10 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             //Debug.WriteLine("A_coup:\n" + FormatComplexMatrix(A_coup));
         }
 
-        /// <summary>Eq (1.1.15)</summary>
+        /// <summary>
+        /// Populates the diagonal electrode matrix D that stores the
+        /// aggregate contact admittance for each electrode pad.
+        /// </summary>
         private void BuildElectrodeMatrix(FEMMesh mesh)
         {
             Array.Clear(D, 0, D.Length);
@@ -202,7 +231,10 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             //Debug.WriteLine("D:\n" + FormatComplexMatrix(D));
         }
 
-        /// <summary>Eq (1.1.16)</summary>
+        /// <summary>
+        /// Assembles the saddle-point block system combining K, M, A_coup, and
+        /// D in the canonical CEM ordering.
+        /// </summary>
         private void BuildSystemMatrix()
         {
             int N = N_phi, Lloc = L;
@@ -222,7 +254,10 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
            // Debug.WriteLine("SystemMatrix:\n" + FormatComplexMatrix(SystemMatrix));
         }
 
-        /// <summary>rhs = [0; I] </summary>
+        /// <summary>
+        /// Builds the right-hand side vector with nodal entries set to zero
+        /// and electrode entries equal to the prescribed currents.
+        /// </summary>
         private void BuildRhsVector(List<FEMElectrode> electrodes)
         {
             Array.Clear(SystemRHS, 0, SystemRHS.Length);
@@ -236,7 +271,10 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
 
         #region Grounding
 
-        /// <summary>Sec 1.1.3</summary>
+        /// <summary>
+        /// Removes the ground electrode degree of freedom to obtain a full-rank
+        /// linear system as described in Sec. 1.1.3.
+        /// </summary>
         private (Complex[,], Complex[]) ApplyGrounding(Complex[,] A, Complex[] b, int groundId)
         {
             int full = N_phi + L;
@@ -259,7 +297,10 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             return (Ar, br);
         }
 
-        /// <summary>reinsert U_ground=0</summary>
+        /// <summary>
+        /// Reconstructs the full solution vector by reinserting the grounded
+        /// electrode with zero potential.
+        /// </summary>
         private Complex[] ReconstructFullSolution(double[] solRed, int groundId)
         {
             int full = N_phi + L;
@@ -296,12 +337,18 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             return R;
         }
 
+        /// <summary>
+        /// Formats a complex matrix for debugging output using a compact string representation.
+        /// </summary>
         private static string FormatComplexMatrix(Complex[,] M)
         {
             var s = ""; int r = M.GetLength(0), c = M.GetLength(1);
             for (int i = 0; i < r; i++) { for (int j = 0; j < c; j++) s += M[i, j].ToString("0.###") + " "; s += "\n"; }
             return s;
         }
+        /// <summary>
+        /// Formats a complex vector for debugging output.
+        /// </summary>
         private static string FormatComplexVector(Complex[] v)
         { var s = ""; for (int i = 0; i < v.Length; i++) s += v[i].ToString("0.###") + "\n"; return s; }
         #endregion

--- a/Utility/Classes/Solvers/GraphBasedSolver/GraphBasedOperators.cs
+++ b/Utility/Classes/Solvers/GraphBasedSolver/GraphBasedOperators.cs
@@ -16,6 +16,12 @@ namespace Utility.Classes.Solvers.GraphBasedSolver
         private readonly Graph _graph;
         private readonly Dictionary<int, int> _vidx;   // graph GlobalId -> 0..N-1
 
+        /// <summary>
+        /// Creates a new operator suite bound to the provided graph and
+        /// numeric solver.
+        /// </summary>
+        /// <param name="graph">Graph representation of the domain.</param>
+        /// <param name="solver">Linear solver used for CEM systems.</param>
         public GraphBasedOperators(Graph graph, INumericSolver solver)
         {
             _graph = graph ?? throw new ArgumentNullException(nameof(graph));
@@ -29,6 +35,10 @@ namespace Utility.Classes.Solvers.GraphBasedSolver
         public int NodeCount => _graph.NodeCount;
         public int EdgeCount => _graph.EdgeCount;
 
+        /// <summary>
+        /// Assembles the weighted graph Laplacian using the supplied edge
+        /// conductances.
+        /// </summary>
         private double[,] BuildLaplacian(double[] w)
         {
             int N = _graph.NodeCount;
@@ -46,13 +56,20 @@ namespace Utility.Classes.Solvers.GraphBasedSolver
             return K;
         }
 
+        /// <summary>
+        /// Selects a grounded electrode, falling back to the first electrode
+        /// when none is explicitly marked.
+        /// </summary>
         private static int PickGround(IReadOnlyList<FEMElectrode> el)
         {
             int g = el.ToList().FindIndex(e => e.IsGround);
             return (g >= 0) ? g : 0;
         }
 
-        // FEM electrodes -> graph boundary nodes (nearest by (x,y))
+        /// <summary>
+        /// Maps each FEM electrode to the nearest boundary nodes in the graph
+        /// domain so that electrode potentials can be imposed.
+        /// </summary>
         private Dictionary<int, List<int>> MapElectrodesToGraphNodes(FEMMesh mesh)
         {
             var map = new Dictionary<int, List<int>>();
@@ -98,6 +115,10 @@ namespace Utility.Classes.Solvers.GraphBasedSolver
             return map;
         }
 
+        /// <summary>
+        /// Builds the graph-based CEM matrices for a given set of edge weights
+        /// and returns the electrode-to-node mapping used during assembly.
+        /// </summary>
         private void AssembleCEM(double[] w, FEMMesh mesh,
                                  out double[,] Kt, out double[,] A, out double[,] D,
                                  out int ground, out Dictionary<int, List<int>> emap)
@@ -126,6 +147,10 @@ namespace Utility.Classes.Solvers.GraphBasedSolver
             ground = PickGround(electrodes);
         }
 
+        /// <summary>
+        /// Solves the graph-based CEM system for a given edge-weight vector,
+        /// returning both nodal potentials and electrode voltages.
+        /// </summary>
         public (double[] phi, double[] U, Dictionary<int, List<int>> map) SolveCEM(double[] w, FEMMesh mesh)
         {
             AssembleCEM(w, mesh, out var Kt, out var A, out var D, out int g, out var map);
@@ -170,6 +195,10 @@ namespace Utility.Classes.Solvers.GraphBasedSolver
             return (phi, U, map);
         }
 
+        /// <summary>
+        /// Computes the grounded electrode response matrix Λ that maps drive
+        /// currents to electrode voltages on the graph model.
+        /// </summary>
         public double[,] ElectrodeResponse(double[] w, FEMMesh mesh)
         {
             var electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();

--- a/Utility/Classes/Solvers/GraphBasedSolver/GraphBasedSolver.cs
+++ b/Utility/Classes/Solvers/GraphBasedSolver/GraphBasedSolver.cs
@@ -22,6 +22,18 @@ namespace Utility.Classes.Solvers.GraphBasedSolver
 
         public double[] LatestElectrodePotentials { get; set; } = Array.Empty<double>();
 
+        /// <summary>
+        /// Initialises the graph-based solver by projecting the supplied FEM
+        /// mesh to a weighted graph and seeding the optimisation parameters for
+        /// the edge conductances.
+        /// </summary>
+        /// <param name="mesh">Source FEM mesh.</param>
+        /// <param name="solver">Linear solver used for the graph CEM system.</param>
+        /// <param name="lambdaW">Regularisation weight for baseline conductances.</param>
+        /// <param name="lambdaAlpha">Regularisation weight for scaling factors.</param>
+        /// <param name="stepW">Gradient step for conductance updates.</param>
+        /// <param name="stepAlpha">Gradient step for scaling updates.</param>
+        /// <param name="epsilon">Numerical floor for edge weights.</param>
         public GraphBasedSolver(FEMMesh mesh, INumericSolver solver, double lambdaW, double lambdaAlpha,
             double stepW, double stepAlpha, double epsilon)
         {
@@ -40,9 +52,19 @@ namespace Utility.Classes.Solvers.GraphBasedSolver
             _ops = new GraphBasedOperators(_graph, _numericSolver);
         }
 
+        /// <summary>
+        /// Exposes the operator bundle that assembles graph-based CEM systems.
+        /// </summary>
         public GraphBasedOperators GetOperators() => _ops;
+
+        /// <summary>
+        /// Provides access to the working graph representation.
+        /// </summary>
         public Graph GetGraph() => _graph;
 
+        /// <summary>
+        /// Returns the current physical edge weights w = α ∘ w̄.
+        /// </summary>
         public double[] CurrentEdgeWeights()
         {
             var w = new double[_graph.EdgeCount];

--- a/Utility/Classes/Solvers/ISolver.cs
+++ b/Utility/Classes/Solvers/ISolver.cs
@@ -4,9 +4,15 @@ using Utility.Classes.Discretizer;
 
 namespace Utility.Classes.Solvers
 {
+    /// <summary>
+    /// Defines the interface implemented by forward and adjoint PDE solvers
+    /// used during EIT reconstruction.
+    /// </summary>
     public interface ISolver
     {
+        /// <summary>Solves the forward problem for the provided discretization and boundary data.</summary>
         public PotentialDistribution SolveForward(IDiscretization discretization, BoundaryCondition boundaryCondition);
+        /// <summary>Solves the adjoint problem driven by the supplied electrode source.</summary>
         public PotentialDistribution SolveAdjoint(IDiscretization discretization, BoundaryCondition boundaryCondition, Complex[] adjointSource);
     }
 }

--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
@@ -34,6 +34,9 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
         private double SolutionTolerance = 1e-6;
         private int ConvergenceCheckFrequency = 100;
 
+        /// <summary>
+        /// Configures the LBM solver with iteration limits and convergence criteria.
+        /// </summary>
         public LatticeBoltzmannSolver(int maxIterationCount, double solutionTolerance, int convergenceCheckFrequency)
         {
             MaxIterationCount = maxIterationCount;
@@ -41,6 +44,9 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             ConvergenceCheckFrequency = convergenceCheckFrequency;
         }
 
+        /// <summary>
+        /// Solves the forward diffusion problem on the LBM grid using the configured parameters.
+        /// </summary>
         public PotentialDistribution SolveForward(IDiscretization discretization, BoundaryCondition boundaryCondition)
         {
             var lbmGrid = discretization as LBMGrid ?? throw new InvalidCastException();
@@ -49,6 +55,9 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             return RunForward(lbmGrid, bc);
         }
 
+        /// <summary>
+        /// Reuses the forward time stepping to solve the adjoint LBM problem driven by electrode sources.
+        /// </summary>
         public PotentialDistribution SolveAdjoint(IDiscretization discretization, BoundaryCondition boundaryCondition, Complex[] adjointSource)
         {
             var lbmGrid = discretization as LBMGrid ?? throw new InvalidCastException();

--- a/Utility/Classes/Solvers/ScalarField.cs
+++ b/Utility/Classes/Solvers/ScalarField.cs
@@ -10,19 +10,29 @@
         /// </summary>
         public abstract Dictionary<int, double> IdValuePairs { get; set; }
 
+        /// <summary>
+        /// Creates an empty scalar field.
+        /// </summary>
         public ScalarField()
         {
             IdValuePairs = new Dictionary<int, double>();
         }
 
+        /// <summary>
+        /// Creates a scalar field initialised with the provided mapping.
+        /// </summary>
         public ScalarField(Dictionary<int, double> idValuePairs)
         {
             IdValuePairs = idValuePairs;
         }
 
+        /// <summary>Retrieves the scalar value associated with the supplied identifier.</summary>
         public abstract double GetValue(int key);
+        /// <summary>Sets the scalar value associated with the supplied identifier.</summary>
         public abstract void SetValue(int key, double value);
+        /// <summary>Returns the full identifier-to-value mapping.</summary>
         public abstract Dictionary<int, double> Get();
+        /// <summary>Replaces the underlying identifier-to-value mapping.</summary>
         public abstract void Set(Dictionary<int, double> idValuePairs);
     }
 }

--- a/Utility/Classes/Solvers/VectorField.cs
+++ b/Utility/Classes/Solvers/VectorField.cs
@@ -11,6 +11,9 @@
         /// </summary>
         public IReadOnlyDictionary<int, (double X, double Y)> Data { get; }
 
+        /// <summary>
+        /// Creates a vector field backed by the provided data dictionary.
+        /// </summary>
         public VectorField(IReadOnlyDictionary<int, (double X, double Y)> data)
         {
             Data = data;


### PR DESCRIPTION
## Summary
- add XML documentation to conductivity-aware W2 metric helpers
- describe solver infrastructure across FEM, graph, and LBM implementations
- document reconstruction parameter DTOs and mesh noise utility

## Testing
- not run (comment-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d95ba3cbd083338b9b6cfca7783bc9