### PR TITLE
Create unified light/dark theme and add showcase page

### DIFF
--- a/ElectricalImpedanceTomography/App.xaml
+++ b/ElectricalImpedanceTomography/App.xaml
@@ -6,9 +6,7 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
-                <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
-                <ResourceDictionary Source="Resources/Styles/PanelStyles.xaml" />
+                <ResourceDictionary Source="Resources/Styles/Theme.xaml" />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/ElectricalImpedanceTomography/AppShell.xaml
+++ b/ElectricalImpedanceTomography/AppShell.xaml
@@ -7,17 +7,22 @@
     xmlns:views="clr-namespace:ElectricalImpedanceTomography.Views"
     Title="ElectricalImpedanceTomography">
 
-    <ShellContent Title="Home" Route="MainPage">
-        <views:MainPage />
-    </ShellContent>
-    <ShellContent Title="DAQ" Route="DAQPage">
-        <views:DAQPage />
-    </ShellContent>
-    <ShellContent Title="Meshgin" Route="MeshingPage">
-        <views:MeshingPage />
-    </ShellContent>
-    <ShellContent Title="Reconstruction" Route="ReconstructionPage">
-        <views:ReconstructionPage />
-    </ShellContent>
-    
+    <TabBar>
+        <ShellContent Title="Theme" Route="ThemeGalleryPage">
+            <views:ThemeGalleryPage />
+        </ShellContent>
+        <ShellContent Title="Home" Route="MainPage">
+            <views:MainPage />
+        </ShellContent>
+        <ShellContent Title="DAQ" Route="DAQPage">
+            <views:DAQPage />
+        </ShellContent>
+        <ShellContent Title="Meshing" Route="MeshingPage">
+            <views:MeshingPage />
+        </ShellContent>
+        <ShellContent Title="Reconstruction" Route="ReconstructionPage">
+            <views:ReconstructionPage />
+        </ShellContent>
+    </TabBar>
+
 </Shell>

--- a/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
+++ b/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
@@ -86,6 +86,9 @@
           <Compile Update="Views\VideoExportProgressPopup.xaml.cs">
             <DependentUpon>VideoExportProgressPopup.xaml</DependentUpon>
           </Compile>
+          <Compile Update="Views\ThemeGalleryPage.xaml.cs">
+            <DependentUpon>ThemeGalleryPage.xaml</DependentUpon>
+          </Compile>
         </ItemGroup>
 
         <ItemGroup>
@@ -114,6 +117,9 @@
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
           <MauiXaml Update="Views\VideoExportProgressPopup.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\ThemeGalleryPage.xaml">
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
         </ItemGroup>

--- a/ElectricalImpedanceTomography/Resources/Styles/Theme.xaml
+++ b/ElectricalImpedanceTomography/Resources/Styles/Theme.xaml
@@ -1,0 +1,366 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+
+  <!-- 1) COLOR TOKENS (Light/Dark in one place) -->
+  <AppThemeColor x:Key="ColorBg"
+                 Light="#F9FAFB"
+                 Dark="#0F172A" />
+  <AppThemeColor x:Key="ColorSurface"
+                 Light="#FFFFFF"
+                 Dark="#111827" />
+  <AppThemeColor x:Key="ColorCard"
+                 Light="#FFFFFF"
+                 Dark="#1F2937" />
+  <AppThemeColor x:Key="ColorCardAlt"
+                 Light="#F3F4F6"
+                 Dark="#0B1220" />
+  <AppThemeColor x:Key="ColorText"
+                 Light="#111827"
+                 Dark="#F1F5F9" />
+  <AppThemeColor x:Key="ColorTextMuted"
+                 Light="#6B7280"
+                 Dark="#94A3B8" />
+  <AppThemeColor x:Key="ColorPrimary"
+                 Light="#2563EB"
+                 Dark="#38BDF8" />
+  <AppThemeColor x:Key="ColorPrimaryStrong"
+                 Light="#1D4ED8"
+                 Dark="#0EA5E9" />
+  <AppThemeColor x:Key="ColorAccent"
+                 Light="#10B981"
+                 Dark="#A78BFA" />
+  <AppThemeColor x:Key="ColorSuccess"
+                 Light="#16A34A"
+                 Dark="#22C55E" />
+  <AppThemeColor x:Key="ColorWarning"
+                 Light="#D97706"
+                 Dark="#F59E0B" />
+  <AppThemeColor x:Key="ColorDanger"
+                 Light="#DC2626"
+                 Dark="#EF4444" />
+  <AppThemeColor x:Key="ColorBorder"
+                 Light="#E5E7EB"
+                 Dark="#233044" />
+  <AppThemeColor x:Key="ColorDivider"
+                 Light="#E5E7EB"
+                 Dark="#1C2636" />
+  <AppThemeColor x:Key="ColorInput"
+                 Light="#FFFFFF"
+                 Dark="#0B1220" />
+  <AppThemeColor x:Key="ColorInputBorder"
+                 Light="#CBD5E1"
+                 Dark="#263246" />
+  <AppThemeColor x:Key="ColorSelection"
+                 Light="#2563EB22"
+                 Dark="#0EA5E933" />
+
+  <!-- Supporting brushes -->
+  <SolidColorBrush x:Key="BrushBg" Color="{DynamicResource ColorBg}" />
+  <SolidColorBrush x:Key="BrushSurface" Color="{DynamicResource ColorSurface}" />
+  <SolidColorBrush x:Key="BrushCard" Color="{DynamicResource ColorCard}" />
+  <SolidColorBrush x:Key="BrushCardAlt" Color="{DynamicResource ColorCardAlt}" />
+  <SolidColorBrush x:Key="BrushText" Color="{DynamicResource ColorText}" />
+  <SolidColorBrush x:Key="BrushTextMuted" Color="{DynamicResource ColorTextMuted}" />
+  <SolidColorBrush x:Key="BrushPrimary" Color="{DynamicResource ColorPrimary}" />
+  <SolidColorBrush x:Key="BrushPrimaryStrong" Color="{DynamicResource ColorPrimaryStrong}" />
+  <SolidColorBrush x:Key="BrushAccent" Color="{DynamicResource ColorAccent}" />
+  <SolidColorBrush x:Key="BrushSuccess" Color="{DynamicResource ColorSuccess}" />
+  <SolidColorBrush x:Key="BrushWarning" Color="{DynamicResource ColorWarning}" />
+  <SolidColorBrush x:Key="BrushDanger" Color="{DynamicResource ColorDanger}" />
+  <SolidColorBrush x:Key="BrushBorder" Color="{DynamicResource ColorBorder}" />
+  <SolidColorBrush x:Key="BrushDivider" Color="{DynamicResource ColorDivider}" />
+  <SolidColorBrush x:Key="BrushSelection" Color="{DynamicResource ColorSelection}" />
+
+  <!-- Gradients reused in legacy panels -->
+  <LinearGradientBrush x:Key="ConfigurationPanelBrush" StartPoint="0,0" EndPoint="0,1">
+    <GradientStop Color="{DynamicResource ColorCard}" Offset="0" />
+    <GradientStop Color="{DynamicResource ColorCardAlt}" Offset="1" />
+  </LinearGradientBrush>
+  <LinearGradientBrush x:Key="ControlPanelBrush" StartPoint="0,0" EndPoint="0,1">
+    <GradientStop Color="{DynamicResource ColorCard}" Offset="0" />
+    <GradientStop Color="{DynamicResource ColorCardAlt}" Offset="1" />
+  </LinearGradientBrush>
+  <LinearGradientBrush x:Key="PartialResultsBrush" StartPoint="0,0" EndPoint="0,1">
+    <GradientStop Color="{DynamicResource ColorCard}" Offset="0" />
+    <GradientStop Color="{DynamicResource ColorCardAlt}" Offset="1" />
+  </LinearGradientBrush>
+  <LinearGradientBrush x:Key="FullResultsBrush" StartPoint="0,0" EndPoint="0,1">
+    <GradientStop Color="{DynamicResource ColorCard}" Offset="0" />
+    <GradientStop Color="{DynamicResource ColorCardAlt}" Offset="1" />
+  </LinearGradientBrush>
+  <LinearGradientBrush x:Key="HistoryPanelBrush" StartPoint="0,0" EndPoint="0,1">
+    <GradientStop Color="{DynamicResource ColorCard}" Offset="0" />
+    <GradientStop Color="{DynamicResource ColorCardAlt}" Offset="1" />
+  </LinearGradientBrush>
+  <LinearGradientBrush x:Key="StatisticsPanelBrush" StartPoint="0,0" EndPoint="0,1">
+    <GradientStop Color="{DynamicResource ColorCard}" Offset="0" />
+    <GradientStop Color="{DynamicResource ColorCardAlt}" Offset="1" />
+  </LinearGradientBrush>
+
+  <!-- 2) TYPOGRAPHY -->
+  <Style TargetType="Label">
+    <Setter Property="TextColor" Value="{DynamicResource ColorText}" />
+    <Setter Property="FontSize" Value="14" />
+    <Setter Property="LineBreakMode" Value="WordWrap" />
+  </Style>
+
+  <Style x:Key="LabelMuted" TargetType="Label">
+    <Setter Property="TextColor" Value="{DynamicResource ColorTextMuted}" />
+  </Style>
+
+  <!-- 3) PAGES & SHELL -->
+  <Style TargetType="Page">
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorBg}" />
+    <Setter Property="Padding" Value="24" />
+  </Style>
+
+  
+  <Style TargetType="ContentPage">
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorBg}" />
+    <Setter Property="Padding" Value="24" />
+  </Style>
+
+  <Style TargetType="NavigationPage">
+    <Setter Property="BarBackgroundColor" Value="{DynamicResource ColorSurface}" />
+    <Setter Property="BarTextColor" Value="{DynamicResource ColorText}" />
+  </Style>
+
+  <Style TargetType="TabBar">
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorSurface}" />
+    <Setter Property="TitleColor" Value="{DynamicResource ColorText}" />
+    <Setter Property="UnselectedTabColor" Value="{DynamicResource ColorTextMuted}" />
+    <Setter Property="SelectedTabColor" Value="{DynamicResource ColorPrimary}" />
+  </Style>
+
+  <!-- 3) CARDS -->
+  <Style x:Key="Card" TargetType="Frame">
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorCard}" />
+    <Setter Property="BorderColor" Value="{DynamicResource ColorBorder}" />
+    <Setter Property="CornerRadius" Value="16" />
+    <Setter Property="HasShadow" Value="True" />
+    <Setter Property="Shadow">
+      <Setter.Value>
+        <Shadow Radius="18" Opacity="0.35" Offset="0,6">
+          <Shadow.Brush>
+            <SolidColorBrush Color="{DynamicResource ColorBorder}" />
+          </Shadow.Brush>
+        </Shadow>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="Padding" Value="20" />
+    <Setter Property="Margin" Value="0,12" />
+  </Style>
+
+  <Style x:Key="CardBorderStyle" TargetType="Border">
+    <Setter Property="StrokeShape" Value="RoundRectangle 16" />
+    <Setter Property="StrokeThickness" Value="1" />
+    <Setter Property="Stroke" Value="{DynamicResource BrushBorder}" />
+    <Setter Property="Background" Value="{DynamicResource BrushCard}" />
+    <Setter Property="Padding" Value="20" />
+    <Setter Property="Shadow">
+      <Setter.Value>
+        <Shadow Radius="18" Opacity="0.35" Offset="0,6">
+          <Shadow.Brush>
+            <SolidColorBrush Color="{DynamicResource ColorBorder}" />
+          </Shadow.Brush>
+        </Shadow>
+      </Setter.Value>
+    </Setter>
+  </Style>
+
+  <!-- Legacy panel aliases -->
+  <Style x:Key="PanelBorderStyle" TargetType="Border" BasedOn="{StaticResource CardBorderStyle}" />
+  <Style x:Key="PanelSectionBorderStyle" TargetType="Border">
+    <Setter Property="StrokeShape" Value="RoundRectangle 12" />
+    <Setter Property="StrokeThickness" Value="0" />
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorCardAlt}" />
+    <Setter Property="Padding" Value="12" />
+  </Style>
+  <Style x:Key="CanvasBorderStyle" TargetType="Border" BasedOn="{StaticResource CardBorderStyle}">
+    <Setter Property="Padding" Value="16" />
+  </Style>
+
+  <!-- 4) BUTTONS -->
+  <Style TargetType="Button">
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorPrimary}" />
+    <Setter Property="TextColor">
+      <Setter.Value>
+        <AppThemeBinding Light="{DynamicResource ColorSurface}" Dark="{DynamicResource ColorText}" />
+      </Setter.Value>
+    </Setter>
+    <Setter Property="CornerRadius" Value="12" />
+    <Setter Property="Padding" Value="16,12" />
+    <Setter Property="BorderColor" Value="{DynamicResource ColorPrimary}" />
+    <Setter Property="BorderWidth" Value="0" />
+    <Setter Property="FontAttributes" Value="Semibold" />
+    <Setter Property="MinimumHeightRequest" Value="44" />
+    <Setter Property="VisualStateManager.VisualStateGroups">
+      <VisualStateGroupList>
+        <VisualStateGroup x:Name="CommonStates">
+          <VisualState x:Name="Normal" />
+          <VisualState x:Name="PointerOver">
+            <VisualState.Setters>
+              <Setter Property="BackgroundColor" Value="{DynamicResource ColorPrimaryStrong}" />
+            </VisualState.Setters>
+          </VisualState>
+          <VisualState x:Name="Pressed">
+            <VisualState.Setters>
+              <Setter Property="BackgroundColor" Value="{DynamicResource ColorPrimaryStrong}" />
+              <Setter Property="Opacity" Value="0.85" />
+            </VisualState.Setters>
+          </VisualState>
+          <VisualState x:Name="Disabled">
+            <VisualState.Setters>
+              <Setter Property="Opacity" Value="0.45" />
+              <Setter Property="TextColor" Value="{DynamicResource ColorTextMuted}" />
+            </VisualState.Setters>
+          </VisualState>
+        </VisualStateGroup>
+      </VisualStateGroupList>
+    </Setter>
+  </Style>
+
+  <Style x:Key="GhostButton" TargetType="Button">
+    <Setter Property="BackgroundColor" Value="Transparent" />
+    <Setter Property="TextColor" Value="{DynamicResource ColorText}" />
+    <Setter Property="BorderColor" Value="{DynamicResource ColorBorder}" />
+    <Setter Property="BorderWidth" Value="1" />
+    <Setter Property="CornerRadius" Value="12" />
+    <Setter Property="Padding" Value="16,12" />
+    <Setter Property="VisualStateManager.VisualStateGroups">
+      <VisualStateGroupList>
+        <VisualStateGroup x:Name="CommonStates">
+          <VisualState x:Name="PointerOver">
+            <VisualState.Setters>
+              <Setter Property="BackgroundColor" Value="{DynamicResource ColorSelection}" />
+            </VisualState.Setters>
+          </VisualState>
+          <VisualState x:Name="Pressed">
+            <VisualState.Setters>
+              <Setter Property="BackgroundColor" Value="{DynamicResource ColorSelection}" />
+              <Setter Property="Opacity" Value="0.9" />
+            </VisualState.Setters>
+          </VisualState>
+          <VisualState x:Name="Disabled">
+            <VisualState.Setters>
+              <Setter Property="TextColor" Value="{DynamicResource ColorTextMuted}" />
+              <Setter Property="Opacity" Value="0.45" />
+            </VisualState.Setters>
+          </VisualState>
+        </VisualStateGroup>
+      </VisualStateGroupList>
+    </Setter>
+  </Style>
+
+  <!-- 5) INPUTS -->
+  <Style TargetType="Entry">
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorInput}" />
+    <Setter Property="TextColor" Value="{DynamicResource ColorText}" />
+    <Setter Property="PlaceholderColor" Value="{DynamicResource ColorTextMuted}" />
+    <Setter Property="BorderColor" Value="{DynamicResource ColorInputBorder}" />
+    <Setter Property="BorderWidth" Value="1" />
+    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="HeightRequest" Value="44" />
+    <Setter Property="VisualStateManager.VisualStateGroups">
+      <VisualStateGroupList>
+        <VisualStateGroup x:Name="CommonStates">
+          <VisualState x:Name="Focused">
+            <VisualState.Setters>
+              <Setter Property="BorderColor" Value="{DynamicResource ColorPrimary}" />
+              <Setter Property="BorderWidth" Value="2" />
+            </VisualState.Setters>
+          </VisualState>
+          <VisualState x:Name="Disabled">
+            <VisualState.Setters>
+              <Setter Property="TextColor" Value="{DynamicResource ColorTextMuted}" />
+              <Setter Property="Opacity" Value="0.6" />
+            </VisualState.Setters>
+          </VisualState>
+        </VisualStateGroup>
+      </VisualStateGroupList>
+    </Setter>
+  </Style>
+
+  <Style TargetType="Editor">
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorInput}" />
+    <Setter Property="TextColor" Value="{DynamicResource ColorText}" />
+    <Setter Property="PlaceholderColor" Value="{DynamicResource ColorTextMuted}" />
+    <Setter Property="BorderColor" Value="{DynamicResource ColorInputBorder}" />
+    <Setter Property="BorderWidth" Value="1" />
+    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="HeightRequest" Value="120" />
+    <Setter Property="VisualStateManager.VisualStateGroups">
+      <VisualStateGroupList>
+        <VisualStateGroup x:Name="CommonStates">
+          <VisualState x:Name="Focused">
+            <VisualState.Setters>
+              <Setter Property="BorderColor" Value="{DynamicResource ColorPrimary}" />
+              <Setter Property="BorderWidth" Value="2" />
+            </VisualState.Setters>
+          </VisualState>
+        </VisualStateGroup>
+      </VisualStateGroupList>
+    </Setter>
+  </Style>
+
+  <Style TargetType="Picker">
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorInput}" />
+    <Setter Property="TextColor" Value="{DynamicResource ColorText}" />
+    <Setter Property="TitleColor" Value="{DynamicResource ColorTextMuted}" />
+    <Setter Property="BorderColor" Value="{DynamicResource ColorInputBorder}" />
+    <Setter Property="BorderWidth" Value="1" />
+    <Setter Property="CornerRadius" Value="10" />
+    <Setter Property="HeightRequest" Value="44" />
+  </Style>
+
+  <!-- 6) LISTS -->
+  <Style TargetType="CollectionView">
+    <Setter Property="SelectionBackgroundColor" Value="{DynamicResource ColorSelection}" />
+  </Style>
+
+  <Style TargetType="ListView">
+    <Setter Property="SelectionMode" Value="Single" />
+    <Setter Property="SelectionBackgroundColor" Value="{DynamicResource ColorSelection}" />
+  </Style>
+
+  <!-- 7) CONSOLE / LOG -->
+  <Style x:Key="ConsoleFrame" TargetType="Frame" BasedOn="{StaticResource Card}">
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorCardAlt}" />
+  </Style>
+  <Style x:Key="LogError" TargetType="Label" BasedOn="{StaticResource Label}">
+    <Setter Property="TextColor" Value="{DynamicResource ColorDanger}" />
+    <Setter Property="FontFamily" Value="Consolas" />
+  </Style>
+  <Style x:Key="LogInfo" TargetType="Label" BasedOn="{StaticResource Label}">
+    <Setter Property="TextColor" Value="{DynamicResource ColorTextMuted}" />
+    <Setter Property="FontFamily" Value="Consolas" />
+  </Style>
+  <Style x:Key="LogTimestamp" TargetType="Label" BasedOn="{StaticResource LabelMuted}">
+    <Setter Property="FontFamily" Value="Consolas" />
+    <Setter Property="FontAttributes" Value="Italic" />
+  </Style>
+
+  <!-- 8) DIVIDER -->
+  <Style x:Key="Divider" TargetType="BoxView">
+    <Setter Property="HeightRequest" Value="1" />
+    <Setter Property="Color" Value="{DynamicResource ColorDivider}" />
+    <Setter Property="Opacity" Value="1" />
+    <Setter Property="HorizontalOptions" Value="Fill" />
+  </Style>
+
+  <!-- 9) BADGES / STATUS CHIPS -->
+  <Style x:Key="SuccessBadge" TargetType="Frame" BasedOn="{StaticResource Card}">
+    <Setter Property="Padding" Value="12,6" />
+    <Setter Property="CornerRadius" Value="20" />
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorSuccess}" />
+    <Setter Property="HasShadow" Value="False" />
+  </Style>
+  <Style x:Key="WarningBadge" TargetType="Frame" BasedOn="{StaticResource SuccessBadge}">
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorWarning}" />
+  </Style>
+  <Style x:Key="DangerBadge" TargetType="Frame" BasedOn="{StaticResource SuccessBadge}">
+    <Setter Property="BackgroundColor" Value="{DynamicResource ColorDanger}" />
+  </Style>
+
+</ResourceDictionary>

--- a/ElectricalImpedanceTomography/Views/ThemeGalleryPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ThemeGalleryPage.xaml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="ElectricalImpedanceTomography.Views.ThemeGalleryPage"
+             Title="Theme">
+    <ScrollView>
+        <VerticalStackLayout Spacing="24">
+            <Label Text="Theme Showcase" FontSize="28" FontAttributes="Bold" />
+            <Label Style="{StaticResource LabelMuted}"
+                   Text="Demonstration of the minimalist light and dark dashboard theme." />
+
+            <Frame Style="{StaticResource Card}">
+                <VerticalStackLayout Spacing="16">
+                    <Label Text="Actions" FontSize="20" FontAttributes="Bold" />
+                    <StackLayout Orientation="Horizontal" Spacing="12">
+                        <Button Text="Primary Action" />
+                        <Button Text="Secondary" Style="{StaticResource GhostButton}" />
+                    </StackLayout>
+                    <StackLayout Orientation="Horizontal" Spacing="12">
+                        <Frame Style="{StaticResource SuccessBadge}">
+                            <Label Text="Success" TextColor="{DynamicResource ColorSurface}" />
+                        </Frame>
+                        <Frame Style="{StaticResource WarningBadge}">
+                            <Label Text="Warning" TextColor="{DynamicResource ColorSurface}" />
+                        </Frame>
+                        <Frame Style="{StaticResource DangerBadge}">
+                            <Label Text="Critical" TextColor="{DynamicResource ColorSurface}" />
+                        </Frame>
+                    </StackLayout>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame Style="{StaticResource Card}">
+                <VerticalStackLayout Spacing="16">
+                    <Label Text="Inputs" FontSize="20" FontAttributes="Bold" />
+                    <Entry Placeholder="Search or enter value" />
+                    <Picker Title="Select option">
+                        <Picker.ItemsSource>
+                            <x:Array Type="x:String">
+                                <x:String>Option A</x:String>
+                                <x:String>Option B</x:String>
+                                <x:String>Option C</x:String>
+                            </x:Array>
+                        </Picker.ItemsSource>
+                    </Picker>
+                    <Editor Placeholder="Provide additional context" AutoSize="TextChanges" />
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame Style="{StaticResource Card}">
+                <VerticalStackLayout Spacing="16">
+                    <Label Text="KPI Cards" FontSize="20" FontAttributes="Bold" />
+                    <Grid ColumnDefinitions="*,*,*" ColumnSpacing="16">
+                        <Frame Grid.Column="0" Style="{StaticResource Card}">
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="Active Users" />
+                                <Label Text="1,248" FontSize="24" FontAttributes="Bold" />
+                                <Label Style="{StaticResource LabelMuted}" Text="+12% vs last week" />
+                            </VerticalStackLayout>
+                        </Frame>
+                        <Frame Grid.Column="1" Style="{StaticResource Card}">
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="Conversion" />
+                                <Label Text="3.4%" FontSize="24" FontAttributes="Bold" />
+                                <Label Style="{StaticResource LabelMuted}" Text="Stable" />
+                            </VerticalStackLayout>
+                        </Frame>
+                        <Frame Grid.Column="2" Style="{StaticResource Card}">
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="Alerts" />
+                                <Label Text="5" FontSize="24" FontAttributes="Bold" />
+                                <Label Style="{StaticResource LabelMuted}" Text="3 critical" />
+                            </VerticalStackLayout>
+                        </Frame>
+                    </Grid>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame Style="{StaticResource ConsoleFrame}">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="System Console" FontSize="20" FontAttributes="Bold" />
+                    <StackLayout>
+                        <Label Style="{StaticResource LogInfo}" Text="[09:31:08] Connected to acquisition hardware." />
+                        <Label Style="{StaticResource LogInfo}" Text="[09:31:12] Meshing pipeline ready." />
+                        <Label Style="{StaticResource LogError}" Text="[09:31:18] Reconstruction timeout exceeded." />
+                    </StackLayout>
+                </VerticalStackLayout>
+            </Frame>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/ElectricalImpedanceTomography/Views/ThemeGalleryPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ThemeGalleryPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.Maui.Controls;
+
+namespace ElectricalImpedanceTomography.Views;
+
+public partial class ThemeGalleryPage : ContentPage
+{
+    public ThemeGalleryPage()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- add a single Theme.xaml resource dictionary with light/dark AppThemeColor tokens and control styles for cards, buttons, inputs, badges, and console views
- update App.xaml and AppShell to consume the new theme and expose a Theme tab alongside existing pages
- register a ThemeGalleryPage that showcases buttons, cards, inputs, and console layout using the semantic resources

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dad7bec3c48333bde560bdc1b263f3