### PR TITLE
Add OpenMP-style parallel FEM assembly option

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -69,7 +69,7 @@ namespace BusinessLayer
                 _discretization = discretization;
 
                 _numericSolver = NumericSolverFactory.Create(parameters.NumericSolver);
-                _differentialEquationSolver = DifferentialEquationSolverFactory.Create(discretization, parameters.DifferentialEquationSolver, _numericSolver);
+                _differentialEquationSolver = DifferentialEquationSolverFactory.Create(discretization, parameters.DifferentialEquationSolver, _numericSolver, parameters.UseOmpParallelization);
                 _regularizer = RegularisationFactory.Create(parameters.RegularizationTechnique, _discretization);
                 _errorMetric = ErrorMetricFactory.Create(parameters.ErrorMetric);
                 _initialDistributionType = parameters.InitialDistributionType;

--- a/ElectricalImpedanceTomography/Controls/ReconstructionParametersControl.xaml
+++ b/ElectricalImpedanceTomography/Controls/ReconstructionParametersControl.xaml
@@ -17,7 +17,7 @@
         <Grid x:Name="LBMParametersGrid"
               Grid.Row="0"
               Grid.Column="0"
-              ColumnDefinitions="Auto,Auto,Auto,Auto,Auto"
+              ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto"
               ColumnSpacing="10"
               HeightRequest="100">
             <Picker Grid.Column="0"
@@ -49,6 +49,14 @@
                     ItemsSource="{Binding NumericOptimizerOptions}"
                     SelectedItem="{Binding ReconstructionParameters.NumericOptimizer}"
                     ItemDisplayBinding="{Binding ., Converter={StaticResource EnumDesc}}"/>
+            <HorizontalStackLayout Grid.Column="5"
+                                   VerticalOptions="Center"
+                                   Spacing="6">
+                <Label Text="Use OMP"
+                       VerticalOptions="Center"
+                       TextColor="{AppThemeBinding Light=Black, Dark=White}"/>
+                <Switch IsToggled="{Binding ReconstructionParameters.UseOmpParallelization}"/>
+            </HorizontalStackLayout>
         </Grid>
         <!-- FEM parameters -->
         <Grid x:Name="FEMParametersGrid"

--- a/Utility/Classes/Factories/DifferentialEquationSolverFactory.cs
+++ b/Utility/Classes/Factories/DifferentialEquationSolverFactory.cs
@@ -12,17 +12,17 @@ namespace Utility.Classes.Factories
     /// </summary>
     public static class DifferentialEquationSolverFactory
     {
-        public static IDifferentialEquationSolver Create(IDiscretization discretization, DifferentialEquationSolver des, INumericSolver numericSolver) => des switch
+        public static IDifferentialEquationSolver Create(IDiscretization discretization, DifferentialEquationSolver des, INumericSolver numericSolver, bool useOmpParallelization) => des switch
         {
-            DifferentialEquationSolver.FEM => CreateFiniteElementSolver((FEMMesh)discretization, numericSolver),
+            DifferentialEquationSolver.FEM => CreateFiniteElementSolver((FEMMesh)discretization, numericSolver, useOmpParallelization),
             DifferentialEquationSolver.LBM => CreateLatticeBoltzmannSolver(),
             DifferentialEquationSolver.Graph => CreateGraphBasedSolver((FEMMesh)discretization, numericSolver),
             _ => throw new NotSupportedException()
         };
 
-        private static FiniteElementDESolver CreateFiniteElementSolver(FEMMesh mesh, INumericSolver numericSolver)
+        private static FiniteElementDESolver CreateFiniteElementSolver(FEMMesh mesh, INumericSolver numericSolver, bool useOmpParallelization)
         {
-            var deSolver = new FiniteElementDESolver(mesh, numericSolver);
+            var deSolver = new FiniteElementDESolver(mesh, numericSolver, useOmpParallelization);
 
             Workspace.AddLogMessage("DifferentialEquationSolverFactory", "Created Finite Element solver object.");
 

--- a/Utility/Classes/ReconstructionParameters/DifferentialEquationSolver.cs
+++ b/Utility/Classes/ReconstructionParameters/DifferentialEquationSolver.cs
@@ -34,10 +34,10 @@ namespace Utility.Classes.ReconstructionParameters
         private readonly FiniteElementSolver _solver;
         private readonly FEMMesh _mesh;
 
-        public FiniteElementDESolver(FEMMesh mesh, INumericSolver numericSolver)
+        public FiniteElementDESolver(FEMMesh mesh, INumericSolver numericSolver, bool useOmpParallelization)
         {
             _mesh = mesh;
-            _solver = new FiniteElementSolver(mesh, numericSolver);
+            _solver = new FiniteElementSolver(mesh, numericSolver, useOmpParallelization);
         }
 
         /// <summary>

--- a/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
+++ b/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
@@ -25,6 +25,9 @@ namespace Utility.Classes.ReconstructionParameters
         private InitialDistributionTypes initialDistributionType = InitialDistributionTypes.Homogeneous;
 
         [ObservableProperty]
+        private bool useOmpParallelization = false;
+
+        [ObservableProperty]
         private MeasurementNoiseType measurementNoiseType = MeasurementNoiseType.None;
 
         [ObservableProperty]
@@ -50,6 +53,7 @@ namespace Utility.Classes.ReconstructionParameters
             MeasurementNoiseAmplitude = 0.0;
             DrivePattern = DrivePattern.Adjecent;
             Mesh = DiscretizationType.FEM;
+            UseOmpParallelization = false;
         }
 
         /// <summary>
@@ -64,7 +68,8 @@ namespace Utility.Classes.ReconstructionParameters
                                            InitialDistributionTypes initialDistributionType = InitialDistributionTypes.SlightlyDiffering,
                                            MeasurementNoiseType measurementNoiseType = MeasurementNoiseType.None,
                                            double measurementNoiseAmplitude = 0.0,
-                                           DrivePattern drivePattern = DrivePattern.Adjecent)
+                                           DrivePattern drivePattern = DrivePattern.Adjecent,
+                                           bool useOmpParallelization = false)
         {
             DifferentialEquationSolver = differentialEquationSolver;
             RegularizationTechnique = regularizationTechnique;
@@ -75,6 +80,7 @@ namespace Utility.Classes.ReconstructionParameters
             MeasurementNoiseType = measurementNoiseType;
             MeasurementNoiseAmplitude = measurementNoiseAmplitude;
             DrivePattern = drivePattern;
+            UseOmpParallelization = useOmpParallelization;
 
             Mesh = (differentialEquationSolver == DifferentialEquationSolver.FEM) ? DiscretizationType.FEM : DiscretizationType.LBM;
         }

--- a/Utility/Classes/Solvers/FiniteElementSolver/FiniteElementSolver.cs
+++ b/Utility/Classes/Solvers/FiniteElementSolver/FiniteElementSolver.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Numerics;
+using System.Linq;
+using System.Threading.Tasks;
 using Utility.Classes.Measurement;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
@@ -20,6 +22,7 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
     public sealed class FiniteElementSolver : ISolver
     {
         private readonly INumericSolver _numericSolver;
+        private readonly bool _useOmp;
 
         public int N_phi { get; }
         public int L { get; }
@@ -37,11 +40,12 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
         /// <summary>
         /// Initialize solver with mesh sizes and numeric solver.
         /// </summary>
-        public FiniteElementSolver(FEMMesh mesh, INumericSolver numericSolver)
+        public FiniteElementSolver(FEMMesh mesh, INumericSolver numericSolver, bool useOmp)
         {
             N_phi = mesh.Vertices.Count;
             L = mesh.GetElectrodes().Count;
             _numericSolver = numericSolver ?? throw new ArgumentNullException(nameof(numericSolver));
+            _useOmp = useOmp;
 
             // allocate
             K = new Complex[N_phi, N_phi];
@@ -108,14 +112,28 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
         private PotentialDistribution Solve(FEMMesh mesh, List<FEMElectrode> electrodes)
         {
             // Build sub-blocks of the Saddle-Point System
-            BuildStiffnessMatrix(mesh);     // Eq (1.2.3)
-            BuildRobinMassMatrix(mesh);     // Eq (1.1.12)
-            BuildCouplingMatrix(mesh);      // Eq (1.1.12)
-            BuildElectrodeMatrix(mesh);     // Eq (1.1.15)
+            if (_useOmp)
+            {
+                BuildStiffnessMatrixOmp(mesh);     // Eq (1.2.3)
+                BuildRobinMassMatrixOmp(mesh);     // Eq (1.1.12)
+                BuildCouplingMatrixOmp(mesh);      // Eq (1.1.12)
+                BuildElectrodeMatrixOmp(mesh);     // Eq (1.1.15)
 
-            // Assemble saddle system S [α; U] = b  (Eq 1.1.16)
-            BuildSystemMatrix();
-            BuildRhsVector(electrodes);
+                // Assemble saddle system S [α; U] = b  (Eq 1.1.16)
+                BuildSystemMatrixOmp();
+                BuildRhsVectorOmp(electrodes);
+            }
+            else
+            {
+                BuildStiffnessMatrix(mesh);     // Eq (1.2.3)
+                BuildRobinMassMatrix(mesh);     // Eq (1.1.12)
+                BuildCouplingMatrix(mesh);      // Eq (1.1.12)
+                BuildElectrodeMatrix(mesh);     // Eq (1.1.15)
+
+                // Assemble saddle system S [α; U] = b  (Eq 1.1.16)
+                BuildSystemMatrix();
+                BuildRhsVector(electrodes);
+            }
 
             Debug.WriteLine("Assembled S and b");
 
@@ -176,6 +194,35 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             //Debug.WriteLine("K:\n" + FormatComplexMatrix(K));
         }
 
+        private void BuildStiffnessMatrixOmp(FEMMesh mesh)
+        {
+            Array.Clear(K, 0, K.Length);
+            ConductivityDistribution sigma = mesh.GetConductivityDistribution();
+            var elements = mesh.GetElements().Cast<FEMElement>().ToList();
+            var rowLocks = CreateLockArray(N_phi);
+
+            Parallel.ForEach(elements, elem =>
+            {
+                double area = elem.Area;
+                double sT = sigma.GetConductivity(elem.Id);
+                var grads = elem.GradPhi;
+                for (int i = 0; i < 3; i++)
+                {
+                    int row = elem.Vertices[i].GlobalId;
+                    for (int j = 0; j < 3; j++)
+                    {
+                        int col = elem.Vertices[j].GlobalId;
+                        double gdot = grads[i][0] * grads[j][0] + grads[i][1] * grads[j][1];
+                        double contribution = sT * area * gdot;
+                        lock (rowLocks[row])
+                        {
+                            K[row, col] += contribution;
+                        }
+                    }
+                }
+            });
+        }
+
         /// <summary>
         /// Integrates the boundary impedance contributions from the complete
         /// electrode model to form the Robin mass matrix M.
@@ -184,7 +231,7 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
         {
             Array.Clear(M, 0, M.Length);
             var electrodes = mesh.GetElectrodes().Cast<FEMElectrode>();
-            
+
             foreach (var el in electrodes)
             {
                 double invZ = 1.0 / el.ZContact;
@@ -194,6 +241,27 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
                     M[vid, vid] += invZ * h;
             }
             //Debug.WriteLine("M:\n" + FormatComplexMatrix(M));
+        }
+
+        private void BuildRobinMassMatrixOmp(FEMMesh mesh)
+        {
+            Array.Clear(M, 0, M.Length);
+            var electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
+            var rowLocks = CreateLockArray(N_phi);
+
+            Parallel.ForEach(electrodes, el =>
+            {
+                double invZ = 1.0 / el.ZContact;
+                double h = el.Length / el.FEMVertexIds.Count;
+
+                foreach (int vid in el.FEMVertexIds)
+                {
+                    lock (rowLocks[vid])
+                    {
+                        M[vid, vid] += invZ * h;
+                    }
+                }
+            });
         }
 
         /// <summary>
@@ -216,6 +284,27 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             //Debug.WriteLine("A_coup:\n" + FormatComplexMatrix(A_coup));
         }
 
+        private void BuildCouplingMatrixOmp(FEMMesh mesh)
+        {
+            Array.Clear(A_coup, 0, A_coup.Length);
+            var electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
+            var rowLocks = CreateLockArray(N_phi);
+
+            Parallel.ForEach(electrodes, el =>
+            {
+                double invZ = 1.0 / el.ZContact;
+                double h = el.Length / el.FEMVertexIds.Count;
+
+                foreach (int vid in el.FEMVertexIds)
+                {
+                    lock (rowLocks[vid])
+                    {
+                        A_coup[vid, el.Id] += invZ * h;
+                    }
+                }
+            });
+        }
+
         /// <summary>
         /// Populates the diagonal electrode matrix D that stores the
         /// aggregate contact admittance for each electrode pad.
@@ -229,6 +318,17 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
                 D[el.Id, el.Id] = el.Length / el.ZContact;
 
             //Debug.WriteLine("D:\n" + FormatComplexMatrix(D));
+        }
+
+        private void BuildElectrodeMatrixOmp(FEMMesh mesh)
+        {
+            Array.Clear(D, 0, D.Length);
+            var electrodes = mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
+
+            Parallel.ForEach(electrodes, el =>
+            {
+                D[el.Id, el.Id] = el.Length / el.ZContact;
+            });
         }
 
         /// <summary>
@@ -254,6 +354,29 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
            // Debug.WriteLine("SystemMatrix:\n" + FormatComplexMatrix(SystemMatrix));
         }
 
+        private void BuildSystemMatrixOmp()
+        {
+            int N = N_phi, Lloc = L;
+            Array.Clear(SystemMatrix, 0, SystemMatrix.Length);
+
+            Parallel.For(0, N, i =>
+            {
+                for (int j = 0; j < N; j++)
+                    SystemMatrix[i, j] = K[i, j] + M[i, j];
+
+                for (int ell = 0; ell < Lloc; ell++)
+                    SystemMatrix[i, N + ell] = -A_coup[i, ell];
+            });
+
+            Parallel.For(0, Lloc, ell =>
+            {
+                for (int i = 0; i < N; i++)
+                    SystemMatrix[N + ell, i] = -A_coup[i, ell];
+
+                SystemMatrix[N + ell, N + ell] = D[ell, ell];
+            });
+        }
+
         /// <summary>
         /// Builds the right-hand side vector with nodal entries set to zero
         /// and electrode entries equal to the prescribed currents.
@@ -266,6 +389,16 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
                 SystemRHS[N_phi + ell] = electrodes[ell].Current;
 
            // Debug.WriteLine("SystemRHS:\n" + FormatComplexVector(SystemRHS));
+        }
+
+        private void BuildRhsVectorOmp(List<FEMElectrode> electrodes)
+        {
+            Array.Clear(SystemRHS, 0, SystemRHS.Length);
+
+            Parallel.For(0, L, ell =>
+            {
+                SystemRHS[N_phi + ell] = electrodes[ell].Current;
+            });
         }
         #endregion
 
@@ -351,6 +484,15 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
         /// </summary>
         private static string FormatComplexVector(Complex[] v)
         { var s = ""; for (int i = 0; i < v.Length; i++) s += v[i].ToString("0.###") + "\n"; return s; }
+
+        private static object[] CreateLockArray(int length)
+        {
+            var locks = new object[length];
+            for (int i = 0; i < length; i++)
+                locks[i] = new object();
+
+            return locks;
+        }
         #endregion
     }
 }


### PR DESCRIPTION
## Summary
- add an OpenMP-inspired parallel code path for FEM assembly and RHS construction using task parallelism
- thread the OMP toggle through reconstruction parameters, solver factory wiring, and the reconstruction parameter UI

## Testing
- dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj *(fails: `dotnet` not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dae389f3948333844d4e03c6e4b998