### PR TITLE
Guard against degenerate FEM elements causing SVD failures

### DIFF
--- a/Utility/Classes/Discretizer/FiniteElementMesh/FEMElement.cs
+++ b/Utility/Classes/Discretizer/FiniteElementMesh/FEMElement.cs
@@ -1,4 +1,6 @@
-﻿namespace Utility.Classes.Discretizer.FiniteElementMesh
+﻿using System;
+
+namespace Utility.Classes.Discretizer.FiniteElementMesh
 {
     public sealed class FEMElement : DiscretizationElement
     {
@@ -61,6 +63,9 @@
             Area = 0.5 *  Math.Abs(V1.X * (V2.Y - V3.Y) +
                                     V2.X * (V3.Y - V1.Y) +
                                     V3.X * (V1.Y - V2.Y));
+
+            if (!double.IsFinite(Area) || Area <= 1e-12)
+                throw new InvalidOperationException($"Degenerate FEM element (Id={Id}) detected while computing area. Custom meshes must avoid overlapping or colinear vertices.");
         }
 
         // Calculate gradients of spahe functions beforehand

--- a/Utility/Classes/ReconstructionParameters/NumericSolver.cs
+++ b/Utility/Classes/ReconstructionParameters/NumericSolver.cs
@@ -1,4 +1,6 @@
-﻿using MathNet.Numerics.LinearAlgebra;
+﻿using System;
+using System.Linq;
+using MathNet.Numerics.LinearAlgebra;
 using MathNet.Numerics.LinearAlgebra.Double;
 
 namespace Utility.Classes.ReconstructionParameters
@@ -56,6 +58,10 @@ namespace Utility.Classes.ReconstructionParameters
     {
         public double[] SolveLinearSystem(double[,] A, double[] b)
         {
+            if (A.Cast<double>().Any(d => double.IsNaN(d) || double.IsInfinity(d)) ||
+                b.Any(d => double.IsNaN(d) || double.IsInfinity(d)))
+                throw new InvalidOperationException("SVD solver received non-finite entries. This typically indicates a degenerate FEM element (zero area) in the mesh assembly.");
+
             Matrix<double> matrixA = DenseMatrix.OfArray(A);
             Vector<double> vectorB = DenseVector.OfArray(b);
 
@@ -88,6 +94,10 @@ namespace Utility.Classes.ReconstructionParameters
 
         public double[] SolveLinearSystem(double[,] A, double[] b)
         {
+            if (A.Cast<double>().Any(d => double.IsNaN(d) || double.IsInfinity(d)) ||
+                b.Any(d => double.IsNaN(d) || double.IsInfinity(d)))
+                throw new InvalidOperationException("tSVD solver received non-finite entries. Check the FEM mesh for degenerate elements that yield NaN/Inf stiffness coefficients.");
+
             var M = DenseMatrix.OfArray(A);
             var y = DenseVector.OfArray(b);
             var svd = M.Svd(computeVectors: true);


### PR DESCRIPTION
## Summary
- detect degenerate (zero-area) FEM elements while initializing custom meshes to avoid propagating NaN values into the solver
- validate SVD-based numeric solvers for non-finite coefficients and emit actionable error messages tied to mesh quality issues

## Testing
- dotnet test ElectricalImpedanceTomography.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc52ed144c83339a28072987f44858