### PR TITLE
Stabilize Wasserstein error metric adjoint for custom FEM geometries

### DIFF
--- a/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
@@ -94,7 +94,15 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             public double Sum { get; }
         }
 
-        internal sealed record EdgeInfo(int Index, int U, int V, double Length, int ElementU, int ElementV, double Sigma, double Cost);
+        internal sealed record EdgeInfo(int Index,
+                                        int U,
+                                        int V,
+                                        double PhysicalLength,
+                                        double NormalizedLength,
+                                        int ElementU,
+                                        int ElementV,
+                                        double Sigma,
+                                        double Cost);
 
         private sealed record DirectedEdge(int EdgeIndex, int From, int To, double Cost);
 
@@ -132,6 +140,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             public required Dictionary<int, double> GradientCostTerm;
             public required double[] Measured;
             public required double[] Simulated;
+            public required double SpatialScale;
 
             public ConductivityDistribution? Gradient;
         }
@@ -197,11 +206,12 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             // Determine electrode spatial positions.
             var electrodePositions = GetElectrodePositions(fem);
             var electrodeNodes = MapElectrodesToGraphNodes(fem, electrodePositions);
+            double spatialScale = ComputeSpatialScale(electrodePositions);
 
             // Build both geometric and conductivity-aware cost matrices.
-            var geodesics = ComputeSoftDistancesAndOccupancies(fem, electrodeNodes);
+            var geodesics = ComputeSoftDistancesAndOccupancies(fem, electrodeNodes, spatialScale);
             var costConductive = BuildCostMatrix(geodesics.Distances);
-            var costGeometric = BuildGeometricCost(electrodePositions);
+            var costGeometric = BuildGeometricCost(electrodePositions, spatialScale);
 
             bool physicsOnly = _config.UsePhysicsAwareOnly || _config.Alpha >= 1.0 - 1e-12;
             double alpha = physicsOnly ? 1.0 : Math.Clamp(_config.Alpha, 0.0, 1.0);
@@ -220,21 +230,26 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 value = 0.5 * ((1.0 - alpha) * 2.0 * geoTerm + alpha * 2.0 * physTerm);
             }
 
+            double scaleSquared = spatialScale * spatialScale;
+            value *= scaleSquared; // undo geometric normalisation to keep physical units
+
             // Average Kantorovich potentials according to the blend.
-            var gMu = BlendPotentials(alpha, otPhysics.SourcePotential, otGeo?.SourcePotential);
+            var alphaPhysics = ScalePotentials(otPhysics.SourcePotential, scaleSquared);
+            double[]? alphaGeo = otGeo != null ? ScalePotentials(otGeo.SourcePotential, scaleSquared) : null;
+            var gMu = BlendPotentials(alpha, alphaPhysics, alphaGeo);
 
             // R^T g_μ for the adjoint RHS (Eq. (1) VJP).
             var adjointSource = ApplyNormalizationVjp(simNorm, gMu);
             // OT physics-cost correction (Eq. (5)-(7)).
-            var costTerm = ComputeCostGradient(fem, geodesics, otPhysics.Plan);
+            var costTerm = ComputeCostGradient(fem, geodesics, otPhysics.Plan, spatialScale);
             _last = new EvaluationCache
             {
                 Mu = mu,
                 Nu = nu,
                 GammaPhysics = otPhysics.Plan,
                 GammaGeo = otGeo?.Plan,
-                AlphaPhysics = otPhysics.SourcePotential,
-                AlphaGeo = otGeo?.SourcePotential,
+                AlphaPhysics = alphaPhysics,
+                AlphaGeo = alphaGeo,
                 SimNormalization = simNorm,
                 Geodesics = geodesics,
                 GMu = gMu,
@@ -243,6 +258,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 GradientCostTerm = costTerm,
                 Measured = (double[])measured.Clone(),
                 Simulated = (double[])simulated.Clone(),
+                SpatialScale = spatialScale,
                 Gradient = null
             };
 
@@ -318,7 +334,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                       throw new InvalidOperationException("Forward potential distribution is missing on the FEM mesh.");
 
             var adjointTerm = ComputeAdjointConductivityGradient(fem, phi, adjointPotential);
-            var costTerm = _last.GradientCostTerm ?? ComputeCostGradient(fem, _last.Geodesics, _last.GammaPhysics);
+            var costTerm = _last.GradientCostTerm ?? ComputeCostGradient(fem, _last.Geodesics, _last.GammaPhysics, _last.SpatialScale);
 
             _last.GradientAdjointTerm = adjointTerm;
 
@@ -502,7 +518,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         /// </summary>
         /// <param name="electrodePositions">Electrode centroid coordinates.</param>
         /// <returns>Squared Euclidean distance matrix.</returns>
-        private static double[,] BuildGeometricCost(IReadOnlyList<(double x, double y)> electrodePositions)
+        private static double[,] BuildGeometricCost(IReadOnlyList<(double x, double y)> electrodePositions, double spatialScale)
         {
             int m = electrodePositions.Count;
             var cost = new double[m, m];
@@ -513,7 +529,8 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                     double dx = electrodePositions[i].x - electrodePositions[j].x;
                     double dy = electrodePositions[i].y - electrodePositions[j].y;
                     double d = Math.Sqrt(dx * dx + dy * dy);
-                    cost[i, j] = d * d;
+                    double normalized = d / spatialScale;
+                    cost[i, j] = normalized * normalized;
                 }
             }
             return cost;
@@ -651,6 +668,14 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return result;
         }
 
+        private static double[] ScalePotentials(double[] sourcePotential, double scaleSquared)
+        {
+            var scaled = (double[])sourcePotential.Clone();
+            for (int i = 0; i < scaled.Length; i++)
+                scaled[i] *= scaleSquared;
+            return scaled;
+        }
+
         private static IReadOnlyList<(double x, double y)> GetElectrodePositions(FEMMesh mesh)
         {
             var vertices = mesh.GetVertices().ToDictionary(v => v.GlobalId);
@@ -696,8 +721,10 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         /// </summary>
         internal SoftGeodesicResult DebugComputeSoftGeodesics(FEMMesh mesh)
         {
-            var nodes = DebugElectrodeNodeMapping(mesh);
-            return ComputeSoftDistancesAndOccupancies(mesh, nodes);
+            var positions = GetElectrodePositions(mesh);
+            double scale = ComputeSpatialScale(positions);
+            var nodes = MapElectrodesToGraphNodes(mesh, positions);
+            return ComputeSoftDistancesAndOccupancies(mesh, nodes, scale);
         }
 
         /// <summary>
@@ -740,6 +767,36 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         }
 
         /// <summary>
+        /// Estimates a characteristic length scale from electrode positions so that
+        /// geometries with vastly different units yield comparable adjoint magnitudes.
+        /// </summary>
+        /// <param name="positions">Electrode centroid coordinates.</param>
+        /// <returns>Maximum pairwise electrode distance (fallbacks to 1 when degenerate).</returns>
+        private static double ComputeSpatialScale(IReadOnlyList<(double x, double y)> positions)
+        {
+            if (positions == null || positions.Count < 2)
+                return 1.0;
+
+            double maxDistance = 0.0;
+            for (int i = 0; i < positions.Count; i++)
+            {
+                for (int j = i + 1; j < positions.Count; j++)
+                {
+                    double dx = positions[i].x - positions[j].x;
+                    double dy = positions[i].y - positions[j].y;
+                    double dist = Math.Sqrt(dx * dx + dy * dy);
+                    if (dist > maxDistance)
+                        maxDistance = dist;
+                }
+            }
+
+            if (maxDistance <= 0.0 || double.IsNaN(maxDistance) || double.IsInfinity(maxDistance))
+                return 1.0;
+
+            return maxDistance;
+        }
+
+        /// <summary>
         /// Runs the conductivity-aware soft geodesic solver for every
         /// electrode pair and stores the resulting distances and edge
         /// occupancies.  The occupancies enable efficient reuse during
@@ -748,7 +805,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         /// <param name="mesh">Finite-element mesh providing the conductivity graph.</param>
         /// <param name="electrodeNodes">Indices of graph nodes attached to electrodes.</param>
         /// <returns>Distances and edge metadata for subsequent computations.</returns>
-        private SoftGeodesicResult ComputeSoftDistancesAndOccupancies(FEMMesh mesh, int[] electrodeNodes)
+        private SoftGeodesicResult ComputeSoftDistancesAndOccupancies(FEMMesh mesh, int[] electrodeNodes, double spatialScale)
         {
             // Build graph data from the discretization.
             var graph = mesh.ToGraph();
@@ -770,17 +827,26 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 if (u == v) continue;
                 double dx = e.Vertices[0].X - e.Vertices[1].X;
                 double dy = e.Vertices[0].Y - e.Vertices[1].Y;
-                double length = Math.Sqrt(dx * dx + dy * dy);
-                if (length <= 0.0)
-                    length = 1e-12;
+                double lengthPhysical = Math.Sqrt(dx * dx + dy * dy);
+                if (lengthPhysical <= 0.0)
+                    lengthPhysical = 1e-12;
+                double lengthNormalized = lengthPhysical / spatialScale;
 
                 double sigU = sigmaField.TryGetValue(e.Vertices[0].GlobalId, out var sU) ? sU : 1.0;
                 double sigV = sigmaField.TryGetValue(e.Vertices[1].GlobalId, out var sV) ? sV : 1.0;
                 double sigmaEdge = 0.5 * (Math.Clamp(sigU, _config.SigmaFloor, _config.SigmaCeiling) +
                                           Math.Clamp(sigV, _config.SigmaFloor, _config.SigmaCeiling));
-                double cost = length * Math.Pow(sigmaEdge, -_config.Beta);
+                double cost = lengthNormalized * Math.Pow(sigmaEdge, -_config.Beta);
 
-                edges.Add(new EdgeInfo(ei, u, v, length, e.Vertices[0].GlobalId, e.Vertices[1].GlobalId, sigmaEdge, cost));
+                edges.Add(new EdgeInfo(ei,
+                                       u,
+                                       v,
+                                       lengthPhysical,
+                                       lengthNormalized,
+                                       e.Vertices[0].GlobalId,
+                                       e.Vertices[1].GlobalId,
+                                       sigmaEdge,
+                                       cost));
                 adjacency[u].Add(new DirectedEdge(ei, u, v, cost));
                 adjacency[v].Add(new DirectedEdge(ei, v, u, cost));
             }
@@ -1003,7 +1069,10 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         /// <param name="geodesics">Soft geodesic cache.</param>
         /// <param name="gamma">Optimal transport plan Γ.</param>
         /// <returns>Element-indexed gradient contribution.</returns>
-        private Dictionary<int, double> ComputeCostGradient(FEMMesh mesh, SoftGeodesicResult geodesics, double[,] gamma)
+        private Dictionary<int, double> ComputeCostGradient(FEMMesh mesh,
+                                                             SoftGeodesicResult geodesics,
+                                                             double[,] gamma,
+                                                             double spatialScale)
         {
             var gradient = new Dictionary<int, double>();
 
@@ -1029,13 +1098,17 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                     if (occupancy == 0.0) continue;
                     var edge = geodesics.EdgeInfos[ei];
                     double sigma = Math.Max(edge.Sigma, 1e-12);
-                    double factor = -_config.Beta * edge.Length * Math.Pow(sigma, -_config.Beta - 1);
+                    double factor = -_config.Beta * edge.NormalizedLength * Math.Pow(sigma, -_config.Beta - 1);
                     double contribution = 0.5 * gammaWeight * distance * occupancy * factor;
 
                     gradient[edge.ElementU] += contribution;
                     gradient[edge.ElementV] += contribution;
                 }
             }
+
+            double scaleSquared = spatialScale * spatialScale;
+            foreach (var key in gradient.Keys.ToList())
+                gradient[key] *= scaleSquared;
 
             return gradient;
         }


### PR DESCRIPTION
## Summary
- normalize the electrode geometry scale before solving the W2 optimal transport problem and rescale the metric and adjoint outputs to physical units
- propagate the spatial scale through cached data and cost-gradient assembly so custom FEM meshes yield stable adjoint sources

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd413a055883338a94f4e0e0cf9e2c