### PR TITLE
Add Matlab export button and service support

### DIFF
--- a/BusinessLayer/DAQPersistence.cs
+++ b/BusinessLayer/DAQPersistence.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using DataAccessLayer;
+using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
@@ -28,6 +29,8 @@ namespace BusinessLayer
         public void DeleteEITMeasurement(string name, DateTime savedAt) => _daqRepository.DeleteEITMeasurement(name, savedAt);        
         public void SaveFEMMesh(FEMMesh mesh, string name) => _meshRepository.SaveFEMMesh(mesh, name);        
         public void SaveLBMGrid(LBMGrid grid, string name) => _meshRepository.SaveLBMGrid(grid, name);
+        public MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern)
+            => _meshRepository.ExportFemMeshForMatlab(mesh, name, drivePattern);
         public FEMMesh LoadFEMMesh(string filePath) => _meshRepository.LoadFEMMesh(filePath);
         public LBMGrid LoadLBMGrid(string filePath) => _meshRepository.LoadLBMGrid(filePath);
         public IEnumerable<DiscretizationInfo> GetDiscretizationInfos() => _meshRepository.GetDiscretizationInfos();

--- a/BusinessLayer/IDAQPersistence.cs
+++ b/BusinessLayer/IDAQPersistence.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
@@ -22,6 +23,7 @@ namespace BusinessLayer
         LBMGrid LoadLBMGrid(string filePath);
         IEnumerable<DiscretizationInfo> GetDiscretizationInfos();
         void DeleteMesh(string filePath);
+        MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern);
         bool ConnectHardware();
         bool DisconnectHardware();
         bool ChangeHardwarePort(string portName);

--- a/DataAccessLayer/IMeshRepository.cs
+++ b/DataAccessLayer/IMeshRepository.cs
@@ -1,6 +1,8 @@
+using Utility.Classes;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Classes.Measurement;
 
 namespace DataAccessLayer
 {
@@ -12,5 +14,6 @@ namespace DataAccessLayer
         LBMGrid LoadLBMGrid(string filePath);
         IEnumerable<DiscretizationInfo> GetDiscretizationInfos();
         void DeleteMesh(string filePath);
+        MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern);
     }
 }

--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -1,10 +1,12 @@
 using System.Globalization;
+using System.Text.Json;
 using System.Xml.Linq;
 using Utility.Classes;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Factories;
+using Utility.Classes.Measurement;
 
 namespace DataAccessLayer
 {
@@ -42,6 +44,55 @@ namespace DataAccessLayer
             var timestamp = DateTime.UtcNow;
             var doc = BuildLbmDocument(grid, name);
             SaveDocument(doc, name, "lbm", timestamp);
+        }
+
+        public MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern)
+        {
+            if (mesh == null) throw new ArgumentNullException(nameof(mesh));
+            if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name required.", nameof(name));
+
+            var timestamp = DateTime.UtcNow;
+            string stlPath = SaveFemMeshAsStl(mesh, name, "matlab", timestamp);
+
+            var electrodes = mesh.ElectrodesTyped.OrderBy(e => e.Id).ToList();
+            var electrodeVertices = new List<int>();
+            foreach (var electrode in electrodes)
+            {
+                if (electrode == null)
+                    continue;
+
+                if (electrode.FEMVertexIds != null && electrode.FEMVertexIds.Count > 0)
+                    electrodeVertices.AddRange(electrode.FEMVertexIds);
+                else if (electrode.MeshId >= 0)
+                    electrodeVertices.Add(electrode.MeshId);
+            }
+
+            var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
+            var drivePatternPairs = new List<int[]>();
+            if (electrodes.Count > 0)
+            {
+                int cycleLength = Math.Max(1, strategy.GetCycleLength(electrodes.Count));
+                for (int step = 0; step < cycleLength; step++)
+                {
+                    var pair = strategy.GetElectrodePair(electrodes.Count, step);
+                    drivePatternPairs.Add(new[] { pair.Excitation, pair.Ground });
+                }
+            }
+
+            var export = new
+            {
+                stlPath,
+                electrodeVertices,
+                drivePatternPairs
+            };
+
+            string jsonFile = Path.ChangeExtension(stlPath, ".json")
+                ?? throw new InvalidOperationException("Unable to determine Matlab export JSON path.");
+
+            var json = JsonSerializer.Serialize(export, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(jsonFile, json);
+
+            return new MatlabExportResult(stlPath, jsonFile);
         }
 
         public IEnumerable<DiscretizationInfo> GetDiscretizationInfos()
@@ -267,7 +318,7 @@ namespace DataAccessLayer
             doc.Save(file);
         }
 
-        private static void SaveFemMeshAsStl(FEMMesh mesh, string name, string suffix, DateTime timestamp)
+        private static string SaveFemMeshAsStl(FEMMesh mesh, string name, string suffix, DateTime timestamp)
         {
             Directory.CreateDirectory(MeshDir);
             string safeName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
@@ -327,6 +378,8 @@ namespace DataAccessLayer
                 writer.WriteLine(string.Format(CultureInfo.InvariantCulture,
                     "      vertex {0:G17} {1:G17} 0", vertex.X, vertex.Y));
             }
+
+            return file;
         }
 
         private static XDocument BuildFemDocument(FEMMesh mesh, string name)

--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -7,6 +7,7 @@ using Utility.Classes.Factories;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Classes.Measurement;
 
 using Workspace = Utility.Classes.Application.Workspace;
 
@@ -28,6 +29,12 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         [ObservableProperty]
         private DiscretizationType selectedMeshType = DiscretizationType.FEM;
+
+        private static readonly DrivePattern[] DrivePatternValues = Enum.GetValues<DrivePattern>();
+        public IEnumerable<DrivePattern> DrivePatterns => DrivePatternValues;
+
+        [ObservableProperty]
+        private DrivePattern selectedDrivePattern = DrivePattern.Adjecent;
 
         private static readonly GeometryType[] GeometryTypeValues = Enum.GetValues<GeometryType>();
         public IEnumerable<GeometryType> GeometryTypes => GeometryTypeValues;
@@ -109,6 +116,11 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             Workspace.SetDiscretization(_currentDiscretization);
             Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
+
+            SelectedMeshType = _currentDiscretization is FEMMesh ? DiscretizationType.FEM : DiscretizationType.LBM;
+            OnPropertyChanged(nameof(IsFEM));
+            OnPropertyChanged(nameof(IsLBM));
+            OnPropertyChanged(nameof(SelectedDrivePattern));
         }
 
         public void LoadMeshFromWorkspace()
@@ -121,6 +133,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             OnPropertyChanged(nameof(SelectedMeshType));
             OnPropertyChanged(nameof(IsFEM));
             OnPropertyChanged(nameof(IsLBM));
+            OnPropertyChanged(nameof(SelectedDrivePattern));
         }
 
         public void PushState()
@@ -196,6 +209,18 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             Workspace.SetDiscretization(_currentDiscretization);
             Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
+        }
+
+        public MatlabExportResult? ExportCurrentMeshForMatlab()
+        {
+            if (_currentDiscretization is not FEMMesh fem)
+                return null;
+
+            string exportName = string.IsNullOrWhiteSpace(Name)
+                ? (string.IsNullOrWhiteSpace(fem.Metadata?.Name) ? "mesh" : fem.Metadata.Name)
+                : Name;
+
+            return _daqService.ExportFemMeshForMatlab(fem, exportName, SelectedDrivePattern);
         }
 
         private FEMMesh GenerateFEMMesh()

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -287,6 +287,21 @@
                         Background="{StaticResource ControlPanelBrush}">
                     <VerticalStackLayout Margin="5"
                                          Spacing="10">
+                        <HorizontalStackLayout Spacing="12"
+                                               HorizontalOptions="Center"
+                                               VerticalOptions="Center">
+                            <Label Text="Drive Pattern"
+                                   VerticalOptions="Center"
+                                   TextColor="{AppThemeBinding Light=#F7FBFF, Dark=White}"/>
+                            <Picker ItemsSource="{Binding DrivePatterns}"
+                                    SelectedItem="{Binding SelectedDrivePattern}"
+                                    WidthRequest="160"/>
+                            <Button Text="Matlab Export"
+                                    BackgroundColor="#3A7CA5"
+                                    Clicked="OnMatlabExportClicked"
+                                    IsEnabled="{Binding IsFEM}"/>
+                        </HorizontalStackLayout>
+
                         <Grid ColumnDefinitions="Auto, Auto"
                                HorizontalOptions="Center">
                             <Border Grid.Column="0" Stroke="Transparent">

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -657,4 +657,37 @@ public partial class MeshingPage : ContentPage
         _viewModel.InvokeMeshChanged();
         MeshCanvas.InvalidateSurface();
     }
+
+    private async void OnMatlabExportClicked(object sender, EventArgs e)
+    {
+        if (sender is VisualElement v) await ShrinkViewAsync(v);
+
+        if (_viewModel.GetCurrentMesh() is not FEMMesh)
+        {
+            await DisplayAlert("Matlab Export", "Matlab export is only available for FEM meshes.", "OK");
+            return;
+        }
+
+        var exportName = await DisplayPromptAsync("Matlab Export", "Export name", initialValue: _viewModel.Name);
+        if (string.IsNullOrWhiteSpace(exportName))
+            return;
+
+        _viewModel.Name = exportName;
+
+        try
+        {
+            var result = _viewModel.ExportCurrentMeshForMatlab();
+            if (result == null)
+            {
+                await DisplayAlert("Matlab Export", "No FEM mesh available for export.", "OK");
+                return;
+            }
+
+            await DisplayAlert("Matlab Export", $"STL saved to:\n{result.StlFilePath}\n\nJSON saved to:\n{result.JsonFilePath}", "OK");
+        }
+        catch (Exception ex)
+        {
+            await DisplayAlert("Matlab Export Failed", ex.Message, "OK");
+        }
+    }
 }

--- a/ServiceLayer/DAQService.cs
+++ b/ServiceLayer/DAQService.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using BusinessLayer;
 using System.Diagnostics;
+using Utility.Classes;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
@@ -160,6 +161,21 @@ namespace ServiceLayer
             try
             {
                 _daqPersistence.SaveLBMGrid(grid, name);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                Debug.WriteLine(ex.Message);
+                Console.WriteLine(ex.Message);
+                throw;
+            }
+        }
+
+        public MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern)
+        {
+            try
+            {
+                return _daqPersistence.ExportFemMeshForMatlab(mesh, name, drivePattern);
             }
             catch (Exception ex)
             {

--- a/ServiceLayer/IDAQService.cs
+++ b/ServiceLayer/IDAQService.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
@@ -22,6 +23,7 @@ namespace ServiceLayer
         LBMGrid LoadLBMGrid(string filePath);
         IEnumerable<DiscretizationInfo> GetDiscretizationInfos();
         void DeleteMesh(string filePath);
+        MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern);
         bool ConnectHardware();
         bool DisconnectHardware();
         bool ChangeHardwarePort(string portName);

--- a/Utility/Classes/MatlabExportResult.cs
+++ b/Utility/Classes/MatlabExportResult.cs
@@ -1,0 +1,4 @@
+namespace Utility.Classes
+{
+    public record MatlabExportResult(string StlFilePath, string JsonFilePath);
+}


### PR DESCRIPTION
## Summary
- add drive pattern picker and Matlab Export button to the meshing page UI
- wire the meshing view model to surface drive pattern selection and invoke a new export workflow
- extend the data/service layers to write STL and JSON artifacts for Matlab consumption

## Testing
- `dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dea71b24d8833391bb312d73854e9b