### PR TITLE
Fix gradient scaling for energy-based Wasserstein metric

### DIFF
--- a/Utility/Classes/Reconstruction/ErrorMetrics/EnergyBasedWasserstein2Metric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/EnergyBasedWasserstein2Metric.cs
@@ -83,16 +83,21 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             var transport = SolveOptimalTransport(cost, mu.Values, nu.Values);
             double loss = transport.Objective;
 
-            var alpha = (double[])transport.Alpha.Clone();
-            double mean = alpha.Average();
-            for (int i = 0; i < alpha.Length; i++)
-                alpha[i] -= mean;
+            var sourcePotential = (double[])transport.Alpha.Clone();
+            double weightedMean = 0.0;
+            for (int i = 0; i < sourcePotential.Length; i++)
+                weightedMean += sourcePotential[i] * mu.Values[i];
+
+            double invMass = 1.0 / mu.TotalMass;
+            var sourceGradient = new double[sourcePotential.Length];
+            for (int i = 0; i < sourceGradient.Length; i++)
+                sourceGradient[i] = (sourcePotential[i] - weightedMean) * invMass;
 
             var adjointFull = new double[measured.Length];
             for (int i = 0; i < include.Count; i++)
-                adjointFull[include[i]] = alpha[i];
+                adjointFull[include[i]] = sourceGradient[i];
 
-            return new CachedResult(measured, simulated, loss, adjointFull, include.ToArray(), alpha, transport.Plan);
+            return new CachedResult(measured, simulated, loss, adjointFull, include.ToArray(), sourcePotential, sourceGradient, transport.Plan);
         }
 
         private static Histogram NormalizeHistogram(double[] raw)
@@ -116,7 +121,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             for (int i = 0; i < values.Length; i++)
                 values[i] /= sum;
 
-            return new Histogram(values, false);
+            return new Histogram(values, false, sum);
         }
 
         private static double[] ExtractHistogram(double[] data, IReadOnlyList<int> include)
@@ -197,29 +202,32 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
 
         private readonly struct Histogram
         {
-            public Histogram(double[] values, bool degenerate)
+            public Histogram(double[] values, bool degenerate, double totalMass)
             {
                 Values = values;
                 IsDegenerate = degenerate;
+                TotalMass = totalMass;
             }
 
             public double[] Values { get; }
             public bool IsDegenerate { get; }
+            public double TotalMass { get; }
 
-            public static Histogram Degenerate(double[] values) => new(values, true);
+            public static Histogram Degenerate(double[] values) => new(values, true, 0.0);
         }
 
         private sealed class CachedResult
         {
             public CachedResult(double[] measured, double[] simulated, double cost, double[] adjoint,
-                                int[] included, double[] alpha, double[,] plan)
+                                int[] included, double[] sourcePotential, double[] sourceGradient, double[,] plan)
             {
                 Measured = measured;
                 Simulated = simulated;
                 Cost = cost;
                 Adjoint = adjoint;
                 Included = included;
-                Alpha = alpha;
+                SourcePotential = sourcePotential;
+                SourceGradient = sourceGradient;
                 Plan = plan;
             }
 
@@ -228,7 +236,8 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             public double Cost { get; }
             public double[] Adjoint { get; }
             public int[] Included { get; }
-            public double[] Alpha { get; }
+            public double[] SourcePotential { get; }
+            public double[] SourceGradient { get; }
             public double[,] Plan { get; }
 
             public bool Matches(double[] measured, double[] simulated)
@@ -237,7 +246,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             public static CachedResult Zero(double[] measured, double[] simulated)
             {
                 var zeros = new double[measured.Length];
-                return new CachedResult(measured, simulated, 0.0, zeros, Array.Empty<int>(), Array.Empty<double>(), new double[0, 0]);
+                return new CachedResult(measured, simulated, 0.0, zeros, Array.Empty<int>(), Array.Empty<double>(), Array.Empty<double>(), new double[0, 0]);
             }
         }
 

--- a/Utility/Tests/EnergyBasedWasserstein2MetricTests.cs
+++ b/Utility/Tests/EnergyBasedWasserstein2MetricTests.cs
@@ -39,7 +39,39 @@ namespace Utility.Tests
 
             var adjoint = metric.EvaluateAdjointSource(mesh, measured, simulated);
             Assert.Equal(measured.Length, adjoint.Length);
-            Assert.True(Math.Abs(adjoint.Sum()) < 1e-10);
+
+            double dot = 0.0;
+            for (int i = 0; i < simulated.Length; i++)
+            {
+                double mass = simulated[i];
+                if (!double.IsFinite(mass) || mass < 0.0)
+                    mass = 0.0;
+                dot += adjoint[i] * mass;
+            }
+
+            Assert.True(Math.Abs(dot) < 1e-10, "Adjoint must be orthogonal to the sanitized simulated histogram.");
+        }
+
+        [Fact]
+        public void EvaluateAdjoint_RespectsNormalizationScaling()
+        {
+            var mesh = TinyFEM();
+            var metric = new EnergyBasedWasserstein2Metric();
+
+            double[] measured = { 0.5, 0.5, 0.0, 0.0 };
+            double[] simulated = { 0.8, 0.2, 0.0, 0.0 };
+
+            metric.Evaluate(mesh, measured, simulated);
+            var adjoint = metric.EvaluateAdjointSource(mesh, measured, simulated);
+
+            double scale = 10.0;
+            double[] scaledSimulated = simulated.Select(v => v * scale).ToArray();
+
+            metric.Evaluate(mesh, measured, scaledSimulated);
+            var scaledAdjoint = metric.EvaluateAdjointSource(mesh, measured, scaledSimulated);
+
+            for (int i = 0; i < adjoint.Length; i++)
+                Assert.Equal(adjoint[i] / scale, scaledAdjoint[i], 6);
         }
 
         private static FEMMesh TinyFEM()


### PR DESCRIPTION
## Summary
- correct the energy-based Wasserstein-2 adjoint by mass-weighting the dual potentials and accounting for histogram normalization
- cache the recovered source potentials/gradients and track histogram mass used in the transport solve
- extend the metric tests to cover orthogonality and normalization-scaling behaviour

## Testing
- dotnet test *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2605be6648333896d2e2b9d723f75