### PR TITLE
Add model type selection to Matlab mesh export

### DIFF
--- a/BusinessLayer/DAQPersistence.cs
+++ b/BusinessLayer/DAQPersistence.cs
@@ -29,8 +29,8 @@ namespace BusinessLayer
         public void DeleteEITMeasurement(string name, DateTime savedAt) => _daqRepository.DeleteEITMeasurement(name, savedAt);        
         public void SaveFEMMesh(FEMMesh mesh, string name) => _meshRepository.SaveFEMMesh(mesh, name);        
         public void SaveLBMGrid(LBMGrid grid, string name) => _meshRepository.SaveLBMGrid(grid, name);
-        public MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern)
-            => _meshRepository.ExportFemMeshForMatlab(mesh, name, drivePattern);
+        public MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern, string modelType)
+            => _meshRepository.ExportFemMeshForMatlab(mesh, name, drivePattern, modelType);
         public FEMMesh LoadFEMMesh(string filePath) => _meshRepository.LoadFEMMesh(filePath);
         public LBMGrid LoadLBMGrid(string filePath) => _meshRepository.LoadLBMGrid(filePath);
         public IEnumerable<DiscretizationInfo> GetDiscretizationInfos() => _meshRepository.GetDiscretizationInfos();

--- a/BusinessLayer/IDAQPersistence.cs
+++ b/BusinessLayer/IDAQPersistence.cs
@@ -23,7 +23,7 @@ namespace BusinessLayer
         LBMGrid LoadLBMGrid(string filePath);
         IEnumerable<DiscretizationInfo> GetDiscretizationInfos();
         void DeleteMesh(string filePath);
-        MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern);
+        MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern, string modelType);
         bool ConnectHardware();
         bool DisconnectHardware();
         bool ChangeHardwarePort(string portName);

--- a/DataAccessLayer/IMeshRepository.cs
+++ b/DataAccessLayer/IMeshRepository.cs
@@ -14,6 +14,6 @@ namespace DataAccessLayer
         LBMGrid LoadLBMGrid(string filePath);
         IEnumerable<DiscretizationInfo> GetDiscretizationInfos();
         void DeleteMesh(string filePath);
-        MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern);
+        MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern, string modelType);
     }
 }

--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -47,10 +47,11 @@ namespace DataAccessLayer
             SaveDocument(doc, name, "lbm", timestamp);
         }
 
-        public MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern)
+        public MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern, string modelType)
         {
             if (mesh == null) throw new ArgumentNullException(nameof(mesh));
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name required.", nameof(name));
+            if (string.IsNullOrWhiteSpace(modelType)) throw new ArgumentException("Model type required.", nameof(modelType));
 
             var timestamp = DateTime.UtcNow;
             string stlPath = SaveFemMeshAsStl(mesh, name, "matlab", timestamp);
@@ -100,6 +101,7 @@ namespace DataAccessLayer
             var export = new
             {
                 stlPath = Path.GetFileName(stlPath),
+                modelType,
                 electrodeVertices,
                 drivePatternPairs
             };

--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ServiceLayer;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Utility.Classes;
 using Utility.Classes.Factories;
@@ -35,6 +36,11 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         [ObservableProperty]
         private DrivePattern selectedDrivePattern = DrivePattern.Adjecent;
+
+        public IList<string> MatlabModelTypes { get; } = new List<string> { "c2c2" };
+
+        [ObservableProperty]
+        private string selectedMatlabModelType = "c2c2";
 
         private static readonly GeometryType[] GeometryTypeValues = Enum.GetValues<GeometryType>();
         public IEnumerable<GeometryType> GeometryTypes => GeometryTypeValues;
@@ -220,7 +226,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                 ? (string.IsNullOrWhiteSpace(fem.Metadata?.Generator) ? "mesh" : fem.Metadata.Generator)
                 : Name;
 
-            return _daqService.ExportFemMeshForMatlab(fem, exportName, SelectedDrivePattern);
+            return _daqService.ExportFemMeshForMatlab(fem, exportName, SelectedDrivePattern, SelectedMatlabModelType);
         }
 
         private FEMMesh GenerateFEMMesh()

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -674,6 +674,29 @@ public partial class MeshingPage : ContentPage
 
         _viewModel.Name = exportName;
 
+        var modelTypes = _viewModel.MatlabModelTypes;
+        if (modelTypes.Count == 0)
+        {
+            await DisplayAlert("Matlab Export", "No Matlab model types are configured.", "OK");
+            return;
+        }
+
+        string? selectedModelType;
+        if (modelTypes.Count == 1)
+        {
+            selectedModelType = modelTypes[0];
+        }
+        else
+        {
+            var title = $"Select Matlab model type (default: {_viewModel.SelectedMatlabModelType})";
+            selectedModelType = await DisplayActionSheet(title, "Cancel", null, modelTypes.ToArray());
+            if (string.IsNullOrWhiteSpace(selectedModelType) || string.Equals(selectedModelType, "Cancel", StringComparison.Ordinal))
+                return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(selectedModelType))
+            _viewModel.SelectedMatlabModelType = selectedModelType;
+
         try
         {
             var result = _viewModel.ExportCurrentMeshForMatlab();

--- a/ServiceLayer/DAQService.cs
+++ b/ServiceLayer/DAQService.cs
@@ -171,11 +171,11 @@ namespace ServiceLayer
             }
         }
 
-        public MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern)
+        public MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern, string modelType)
         {
             try
             {
-                return _daqPersistence.ExportFemMeshForMatlab(mesh, name, drivePattern);
+                return _daqPersistence.ExportFemMeshForMatlab(mesh, name, drivePattern, modelType);
             }
             catch (Exception ex)
             {

--- a/ServiceLayer/IDAQService.cs
+++ b/ServiceLayer/IDAQService.cs
@@ -23,7 +23,7 @@ namespace ServiceLayer
         LBMGrid LoadLBMGrid(string filePath);
         IEnumerable<DiscretizationInfo> GetDiscretizationInfos();
         void DeleteMesh(string filePath);
-        MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern);
+        MatlabExportResult ExportFemMeshForMatlab(FEMMesh mesh, string name, DrivePattern drivePattern, string modelType);
         bool ConnectHardware();
         bool DisconnectHardware();
         bool ChangeHardwarePort(string portName);


### PR DESCRIPTION
## Summary
- add a configurable Matlab model type selection to the meshing export workflow with a default of c2c2
- pass the selected model type through the service and data layers so it is persisted in the export metadata

## Testing
- ⚠️ `dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e41136c0e08333a5fc57f347e51cd8