### PR TITLE
Fix Matlab export vertex ordering

### DIFF
--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text.Json;
 using System.Xml.Linq;
@@ -54,7 +55,8 @@ namespace DataAccessLayer
             if (string.IsNullOrWhiteSpace(modelType)) throw new ArgumentException("Model type required.", nameof(modelType));
 
             var timestamp = DateTime.UtcNow;
-            string stlPath = SaveFemMeshAsStl(mesh, name, "matlab", timestamp);
+            var stlVertexOrder = new List<int>(mesh.Vertices.Count);
+            string stlPath = SaveFemMeshAsStl(mesh, name, "matlab", timestamp, stlVertexOrder);
 
             var vertexById = mesh.Vertices.ToDictionary(v => v.GlobalId);
             var electrodes = mesh.ElectrodesTyped
@@ -103,7 +105,8 @@ namespace DataAccessLayer
                 stlPath = Path.GetFileName(stlPath),
                 modelType,
                 electrodeVertices,
-                drivePatternPairs
+                drivePatternPairs,
+                stlVertexOrder
             };
 
             string jsonFile = Path.ChangeExtension(stlPath, ".json")
@@ -338,7 +341,7 @@ namespace DataAccessLayer
             doc.Save(file);
         }
 
-        private static string SaveFemMeshAsStl(FEMMesh mesh, string name, string suffix, DateTime timestamp)
+        private static string SaveFemMeshAsStl(FEMMesh mesh, string name, string suffix, DateTime timestamp, IList<int>? stlVertexOrder = null)
         {
             Directory.CreateDirectory(MeshDir);
             string safeName = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
@@ -352,7 +355,13 @@ namespace DataAccessLayer
 
             writer.WriteLine($"solid {safeName}");
 
-            foreach (var element in mesh.ElementsTyped)
+            var elements = mesh.ElementsTyped
+                .OrderBy(e => e.Id)
+                .ToList();
+
+            var seenVertices = stlVertexOrder != null ? new HashSet<int>() : null;
+
+            foreach (var element in elements)
             {
                 var a = element.Vertices[0];
                 var b = element.Vertices[1];
@@ -393,8 +402,13 @@ namespace DataAccessLayer
                 return (nx / length, ny / length, nz / length);
             }
 
-            static void WriteVertex(StreamWriter writer, FEMVertex vertex)
+            void WriteVertex(StreamWriter writer, FEMVertex vertex)
             {
+                if (stlVertexOrder != null && seenVertices != null && seenVertices.Add(vertex.GlobalId))
+                {
+                    stlVertexOrder.Add(vertex.GlobalId);
+                }
+
                 writer.WriteLine(string.Format(CultureInfo.InvariantCulture,
                     "      vertex {0:G17} {1:G17} 0", vertex.X, vertex.Y));
             }


### PR DESCRIPTION
## Summary
- capture the order of FEM vertices as they are written into the Matlab STL export
- include the recorded vertex order in the Matlab export JSON payload
- ensure elements are written in a deterministic order when generating STL files

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4bb90ae48833381c95880a8ede5d4