### PR TITLE
Add electrode coordinates to Matlab mesh export JSON

### DIFF
--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -71,6 +71,7 @@ namespace DataAccessLayer
                 .OrderBy(e => e.Id)
                 .ToList();
             var electrodeVertices = new List<int>(electrodes.Count);
+            var electrodeVertexCoordinates = new List<double[]?>(electrodes.Count);
             var matlabElectrodeVertexIds = new List<int>(electrodes.Count);
             foreach (var electrode in electrodes)
             {
@@ -95,6 +96,15 @@ namespace DataAccessLayer
 
                 int globalId = vertexId ?? -1;
                 electrodeVertices.Add(globalId);
+
+                if (globalId >= 0 && vertexById.TryGetValue(globalId, out var coordinateVertex))
+                {
+                    electrodeVertexCoordinates.Add(new[] { coordinateVertex.X, coordinateVertex.Y });
+                }
+                else
+                {
+                    electrodeVertexCoordinates.Add(null);
+                }
 
                 if (globalId >= 0 && matlabIndexByVertexId.TryGetValue(globalId, out var matlabIndex))
                 {
@@ -125,6 +135,7 @@ namespace DataAccessLayer
                 stlPath = Path.GetFileName(stlPath),
                 modelType,
                 electrodeVertices,
+                electrodeVertexCoordinates,
                 matlabElectrodeVertexIds,
                 drivePatternPairs,
                 stlVertexOrder = matlabVertexOrder


### PR DESCRIPTION
## Summary
- include electrode vertex coordinates alongside ids in the Matlab mesh export JSON
- preserve existing electrode id ordering while storing coordinates when available

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d8867f408333bfe9ac20383297a9