### PR TITLE
Keep imported FEM electrodes on the boundary and show low conductivities

### DIFF
--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -753,7 +753,308 @@ namespace DataAccessLayer
             var potentials = mesh.Vertices.ToDictionary(v => v.GlobalId, v => v.Potential);
             mesh.SetPotentialDistribution(new PotentialDistribution(potentials));
 
+            TryAugmentFemMeshFromMatlabJson(mesh, filePath);
+
             return mesh;
+        }
+
+        private static void TryAugmentFemMeshFromMatlabJson(FEMMesh mesh, string stlFilePath)
+        {
+            if (mesh is null)
+                throw new ArgumentNullException(nameof(mesh));
+
+            string? jsonPath = Path.ChangeExtension(stlFilePath, ".json");
+            if (string.IsNullOrEmpty(jsonPath) || !File.Exists(jsonPath))
+                return;
+
+            MatlabImportDefinition? import;
+            try
+            {
+                var json = File.ReadAllText(jsonPath);
+                import = JsonSerializer.Deserialize<MatlabImportDefinition>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+            }
+            catch
+            {
+                return;
+            }
+
+            if (import == null)
+                return;
+
+            const double CoordinateTolerance = 2e-2;
+
+            mesh.Metadata.Parameters ??= new Dictionary<string, string>();
+            mesh.Metadata.Parameters["matlabJson"] = Path.GetFileName(jsonPath);
+            mesh.Metadata.Parameters["electrodeCoordinateTolerance"] = CoordinateTolerance.ToString(CultureInfo.InvariantCulture);
+
+            if (!string.IsNullOrWhiteSpace(import.ModelType))
+                mesh.Metadata.Parameters["matlabModelType"] = import.ModelType!;
+            if (!string.IsNullOrWhiteSpace(import.EidorsVersion))
+                mesh.Metadata.Parameters["eidorsVersion"] = import.EidorsVersion!;
+
+            if (import.DrivePatternPairs != null && import.DrivePatternPairs.Count > 0)
+            {
+                try
+                {
+                    mesh.Metadata.Parameters["drivePatternPairs"] = JsonSerializer.Serialize(import.DrivePatternPairs);
+                }
+                catch
+                {
+                }
+            }
+
+            if (import.DrivePatternPairAmps != null && import.DrivePatternPairAmps.Count > 0)
+            {
+                try
+                {
+                    mesh.Metadata.Parameters["drivePatternPairAmps"] = JsonSerializer.Serialize(import.DrivePatternPairAmps);
+                }
+                catch
+                {
+                }
+            }
+
+            var vertices = mesh.Vertices;
+            var electrodes = new List<FEMElectrode>();
+            var reassignedElectrodes = new List<int>();
+
+            double meshMinX = vertices.Min(v => v.X);
+            double meshMaxX = vertices.Max(v => v.X);
+            double meshMinY = vertices.Min(v => v.Y);
+            double meshMaxY = vertices.Max(v => v.Y);
+            double meshRangeX = meshMaxX - meshMinX;
+            double meshRangeY = meshMaxY - meshMinY;
+
+            double electrodeMinX = double.PositiveInfinity;
+            double electrodeMaxX = double.NegativeInfinity;
+            double electrodeMinY = double.PositiveInfinity;
+            double electrodeMaxY = double.NegativeInfinity;
+            bool haveElectrodeBounds = false;
+
+            if (import.ElectrodeVertexCoordinates != null && import.ElectrodeVertexCoordinates.Count > 0)
+            {
+                foreach (var coords in import.ElectrodeVertexCoordinates)
+                {
+                    if (coords == null || coords.Length < 2)
+                        continue;
+
+                    double x = coords[0];
+                    double y = coords[1];
+
+                    if (!double.IsFinite(x) || !double.IsFinite(y))
+                        continue;
+
+                    electrodeMinX = Math.Min(electrodeMinX, x);
+                    electrodeMaxX = Math.Max(electrodeMaxX, x);
+                    electrodeMinY = Math.Min(electrodeMinY, y);
+                    electrodeMaxY = Math.Max(electrodeMaxY, y);
+                    haveElectrodeBounds = true;
+                }
+            }
+
+            static double NormalizeCoordinate(double value, double min, double max)
+            {
+                double range = max - min;
+                if (range <= 1e-12)
+                    return 0.5;
+                double normalized = (value - min) / range;
+                return Math.Clamp(normalized, 0.0, 1.0);
+            }
+
+            foreach (var vertex in vertices)
+            {
+                vertex.IsElectrode = false;
+                vertex.ElectrodeId = -1;
+            }
+
+            if (import.ElectrodeVertexCoordinates != null && import.ElectrodeVertexCoordinates.Count > 0)
+            {
+                for (int i = 0; i < import.ElectrodeVertexCoordinates.Count; i++)
+                {
+                    var coords = import.ElectrodeVertexCoordinates[i];
+                    if (coords == null || coords.Length < 2)
+                        continue;
+
+                    double targetX = coords[0];
+                    double targetY = coords[1];
+
+                    if (haveElectrodeBounds)
+                    {
+                        double normalizedX = NormalizeCoordinate(targetX, electrodeMinX, electrodeMaxX);
+                        double normalizedY = NormalizeCoordinate(targetY, electrodeMinY, electrodeMaxY);
+
+                        double scaleX = meshRangeX <= 1e-12 ? 0.0 : meshRangeX;
+                        double scaleY = meshRangeY <= 1e-12 ? 0.0 : meshRangeY;
+
+                        targetX = meshMinX + normalizedX * scaleX;
+                        targetY = meshMinY + normalizedY * scaleY;
+                    }
+
+                    var vertex = FindNearestVertex(
+                        vertices,
+                        targetX,
+                        targetY,
+                        CoordinateTolerance,
+                        out bool withinTolerance,
+                        v => v.IsBoundary);
+                    if (vertex == null)
+                        continue;
+
+                    if (!withinTolerance)
+                        reassignedElectrodes.Add(i);
+
+                    var electrode = new FEMElectrode(i, vertex.GlobalId, 0.0,
+                        GetListValue(import.ElectrodeZContact, i, 0.0), 0.0,
+                        pointElectrode: true)
+                    {
+                        IsMeasuring = true
+                    };
+
+                    electrode.FEMVertexIds.Add(vertex.GlobalId);
+
+                    vertex.IsElectrode = true;
+                    vertex.ElectrodeId = electrode.Id;
+
+                    electrodes.Add(electrode);
+                }
+
+                if (electrodes.Count > 0)
+                    mesh.SetElectrodes(electrodes);
+            }
+
+            if (reassignedElectrodes.Count > 0)
+            {
+                mesh.Metadata.Parameters["electrodeReassignmentIndices"] = string.Join(",", reassignedElectrodes);
+            }
+
+            if (import.DrivePatternPairs != null && import.DrivePatternPairs.Count > 0 && electrodes.Count > 0)
+            {
+                var firstPair = import.DrivePatternPairs[0];
+                if (firstPair != null && firstPair.Length >= 2)
+                {
+                    int excitationId = firstPair[0];
+                    int groundId = firstPair[1];
+
+                    var firstAmps = import.DrivePatternPairAmps != null && import.DrivePatternPairAmps.Count > 0
+                        ? import.DrivePatternPairAmps[0]
+                        : null;
+
+                    if (excitationId >= 0 && excitationId < electrodes.Count)
+                    {
+                        var excitation = electrodes[excitationId];
+                        excitation.IsExcitation = true;
+                        excitation.IsMeasuring = false;
+                        excitation.Current = firstAmps != null && firstAmps.Length > 0 ? firstAmps[0] : excitation.Current;
+                    }
+
+                    if (groundId >= 0 && groundId < electrodes.Count)
+                    {
+                        var ground = electrodes[groundId];
+                        ground.IsGround = true;
+                        ground.IsMeasuring = false;
+                        ground.Current = firstAmps != null && firstAmps.Length > 1 ? firstAmps[1] : ground.Current;
+                    }
+                }
+            }
+
+            if (import.InhomogenousPhantomElemData != null && import.InhomogenousPhantomElemData.Count > 0)
+            {
+                var conductivity = new Dictionary<int, double>(mesh.ElementsTyped.Count);
+                for (int i = 0; i < mesh.ElementsTyped.Count; i++)
+                {
+                    double sigma = GetListValue(import.InhomogenousPhantomElemData, i, 1.0);
+                    var element = mesh.ElementsTyped[i];
+                    element.Conductivity = sigma;
+                    conductivity[element.Id] = sigma;
+                }
+
+                if (conductivity.Count == mesh.ElementsTyped.Count)
+                {
+                    mesh.SetConductivityDistribution(new ConductivityDistribution(conductivity));
+                }
+            }
+        }
+
+        private static FEMVertex? FindNearestVertex(
+            IReadOnlyList<FEMVertex> vertices,
+            double x,
+            double y,
+            double tolerance,
+            out bool withinTolerance,
+            Func<FEMVertex, bool>? predicate = null)
+        {
+            static (FEMVertex? Vertex, double DistanceSquared) FindNearest(
+                IReadOnlyList<FEMVertex> source,
+                double targetX,
+                double targetY,
+                Func<FEMVertex, bool>? filter)
+            {
+                FEMVertex? candidate = null;
+                double best = double.MaxValue;
+
+                foreach (var vertex in source)
+                {
+                    if (filter != null && !filter(vertex))
+                        continue;
+
+                    double dx = vertex.X - targetX;
+                    double dy = vertex.Y - targetY;
+                    double distance = dx * dx + dy * dy;
+
+                    if (distance < best)
+                    {
+                        best = distance;
+                        candidate = vertex;
+                    }
+                }
+
+                return (candidate, best);
+            }
+
+            var (best, bestDistance) = FindNearest(vertices, x, y, predicate);
+
+            if (best == null && predicate != null)
+            {
+                (best, bestDistance) = FindNearest(vertices, x, y, null);
+            }
+
+            if (best == null)
+            {
+                withinTolerance = false;
+                return null;
+            }
+
+            if (tolerance <= 0.0)
+            {
+                withinTolerance = true;
+                return best;
+            }
+
+            withinTolerance = bestDistance <= tolerance * tolerance;
+
+            return best;
+        }
+
+        private static double GetListValue(IReadOnlyList<double>? values, int index, double fallback)
+        {
+            if (values == null || index < 0 || index >= values.Count)
+                return fallback;
+            return values[index];
+        }
+
+        private sealed class MatlabImportDefinition
+        {
+            public string? StlPath { get; set; }
+            public string? ModelType { get; set; }
+            public string? EidorsVersion { get; set; }
+            public List<double[]>? ElectrodeVertexCoordinates { get; set; }
+            public List<double>? ElectrodeZContact { get; set; }
+            public List<int[]>? DrivePatternPairs { get; set; }
+            public List<double[]>? DrivePatternPairAmps { get; set; }
+            public List<double>? InhomogenousPhantomElemData { get; set; }
         }
 
         private static FEMMesh LoadFemMeshFromAsciiStl(string filePath)
@@ -871,6 +1172,8 @@ namespace DataAccessLayer
                 });
             }
 
+            MarkBoundaryVertices(femVertices, triangles);
+
             var femElements = new List<FEMElement>(triangles.Count);
             for (int i = 0; i < triangles.Count; i++)
             {
@@ -887,6 +1190,89 @@ namespace DataAccessLayer
 
             var mesh = new FEMMesh(femVertices, femElements);
             return mesh;
+        }
+
+        private static void MarkBoundaryVertices(
+            List<FEMVertex> vertices,
+            List<(int A, int B, int C)> triangles)
+        {
+            if (vertices.Count == 0 || triangles.Count == 0)
+                return;
+
+            var edgeUses = new Dictionary<(int Min, int Max), BoundaryEdgeInfo>();
+
+            void RegisterEdge(int from, int to)
+            {
+                var key = from < to ? (from, to) : (to, from);
+                if (!edgeUses.TryGetValue(key, out var info))
+                {
+                    info = new BoundaryEdgeInfo();
+                    edgeUses[key] = info;
+                }
+
+                info.Count++;
+                if (info.Count == 1)
+                {
+                    info.Orientation = (from, to);
+                }
+            }
+
+            foreach (var (a, b, c) in triangles)
+            {
+                RegisterEdge(a, b);
+                RegisterEdge(b, c);
+                RegisterEdge(c, a);
+            }
+
+            var boundaryVertexIndices = new HashSet<int>();
+
+            foreach (var kvp in edgeUses)
+            {
+                var info = kvp.Value;
+                if (info.Count == 1)
+                {
+                    boundaryVertexIndices.Add(info.Orientation.From);
+                    boundaryVertexIndices.Add(info.Orientation.To);
+                }
+            }
+
+            if (boundaryVertexIndices.Count == 0)
+                return;
+
+            foreach (int idx in boundaryVertexIndices)
+            {
+                if (idx >= 0 && idx < vertices.Count)
+                {
+                    var vertex = vertices[idx];
+                    vertex.IsBoundary = true;
+                }
+            }
+
+            var boundaryVertices = boundaryVertexIndices
+                .Where(i => i >= 0 && i < vertices.Count)
+                .Select(i => vertices[i])
+                .ToList();
+
+            if (boundaryVertices.Count == 0)
+                return;
+
+            double cx = boundaryVertices.Average(v => v.X);
+            double cy = boundaryVertices.Average(v => v.Y);
+
+            var ordered = boundaryVertices
+                .OrderBy(v => Math.Atan2(v.Y - cy, v.X - cx))
+                .ToList();
+
+            for (int i = 0; i < ordered.Count; i++)
+            {
+                ordered[i].BoundaryId = i + 1;
+            }
+        }
+
+        private sealed class BoundaryEdgeInfo
+        {
+            public int Count { get; set; }
+            public (int From, int To) Orientation { get; set; }
         }
 
         private static bool IsAsciiStl(Stream stream)

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -86,16 +86,48 @@ public partial class MeshingPage : ContentPage
             : (Color.FromArgb("#D4EFE7"), Color.FromArgb("#C2E3DA"));
     }
 
-    private SKColor ColorForValue(double val, double max)
+    private static readonly SKColor LowerHighlight = SKColor.Parse("#1E88E5");
+    private static readonly SKColor NeutralHighlight = SKColor.Parse("#F5F5F5");
+    private static readonly SKColor UpperHighlight = SKColor.Parse("#E53935");
+
+    private SKColor ColorForValue(double val, double min, double max)
     {
-        double range = max - 1;
-        if (range <= 0)
-            return new SKColor(0, 0, 255);
-        double t = (val - 1) / range;
+        const double baseline = 1.0;
+
+        double clampedMin = Math.Min(min, baseline);
+        double clampedMax = Math.Max(max, baseline);
+
+        double lowerRange = baseline - clampedMin;
+        double upperRange = clampedMax - baseline;
+
+        if (lowerRange < 1e-9 && upperRange < 1e-9)
+            return NeutralHighlight;
+
+        if (val <= baseline && lowerRange > 1e-9)
+        {
+            double t = (baseline - val) / lowerRange;
+            t = Math.Clamp(t, 0.0, 1.0);
+            return LerpColor(NeutralHighlight, LowerHighlight, t);
+        }
+
+        if (val >= baseline && upperRange > 1e-9)
+        {
+            double t = (val - baseline) / upperRange;
+            t = Math.Clamp(t, 0.0, 1.0);
+            return LerpColor(NeutralHighlight, UpperHighlight, t);
+        }
+
+        return NeutralHighlight;
+    }
+
+    private static SKColor LerpColor(SKColor from, SKColor to, double t)
+    {
         t = Math.Clamp(t, 0.0, 1.0);
-        byte r = (byte)(255 * t);
-        byte b = (byte)(255 * (1 - t));
-        return new SKColor(r, 0, b);
+        byte r = (byte)Math.Round(from.Red + (to.Red - from.Red) * t);
+        byte g = (byte)Math.Round(from.Green + (to.Green - from.Green) * t);
+        byte b = (byte)Math.Round(from.Blue + (to.Blue - from.Blue) * t);
+        byte a = (byte)Math.Round(from.Alpha + (to.Alpha - from.Alpha) * t);
+        return new SKColor(r, g, b, a);
     }
 
     private static async Task ShrinkViewAsync(VisualElement element)
@@ -130,9 +162,13 @@ public partial class MeshingPage : ContentPage
         var conductiveElements = grid.ElementsTyped
             .Where(el => !el.IsWall && !el.IsElectrode)
             .ToList();
-        double maxConductivity = conductiveElements.Count > 0
-            ? Math.Max(defaultConductivity, conductiveElements.Max(el => el.Conductivity))
-            : defaultConductivity;
+        double maxConductivity = defaultConductivity;
+        double minConductivity = defaultConductivity;
+        if (conductiveElements.Count > 0)
+        {
+            maxConductivity = Math.Max(defaultConductivity, conductiveElements.Max(el => el.Conductivity));
+            minConductivity = Math.Min(defaultConductivity, conductiveElements.Min(el => el.Conductivity));
+        }
 
         for (int y = 0; y < grid.Ny; y++)
         {
@@ -148,7 +184,7 @@ public partial class MeshingPage : ContentPage
                     fill = _lbmWall;
                 else if (Math.Abs(el.Conductivity - defaultConductivity) > 1e-6)
                 {
-                    _lbmGradientFill.Color = ColorForValue(el.Conductivity, maxConductivity);
+                    _lbmGradientFill.Color = ColorForValue(el.Conductivity, minConductivity, maxConductivity);
                     fill = _lbmGradientFill;
                 }
                 else
@@ -183,7 +219,13 @@ public partial class MeshingPage : ContentPage
         _marginY = pad + (availH - usedH) / 2f;
 
         var elements = mesh.ElementsTyped;
-        double max = Math.Max(1.0, elements.Max(el => el.Conductivity));
+        double max = 1.0;
+        double min = 1.0;
+        if (elements.Count > 0)
+        {
+            max = Math.Max(1.0, elements.Max(el => el.Conductivity));
+            min = Math.Min(1.0, elements.Min(el => el.Conductivity));
+        }
 
         using var path = new SKPath();
         foreach (var el in elements)
@@ -193,7 +235,7 @@ public partial class MeshingPage : ContentPage
             var p3 = ToCanvas(el.Vertices[2]);
             path.Reset();
             path.MoveTo(p1); path.LineTo(p2); path.LineTo(p3); path.Close();
-            _femFill.Color = ColorForValue(el.Conductivity, max);
+            _femFill.Color = ColorForValue(el.Conductivity, min, max);
             canvas.DrawPath(path, _femFill);
             canvas.DrawPath(path, _femStroke);
         }


### PR DESCRIPTION
## Summary
- normalize Matlab electrode coordinates against the STL mesh bounds so imported electrodes snap to the nearest boundary vertex and mark mesh boundaries from the STL facets
- relax the coordinate tolerance metadata and clear previous electrode flags before rebuilding electrodes from the Matlab JSON
- update meshing canvas color mapping to use a diverging scale so conductivities below 1.0 are still visible

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e7b45d8508833395e9d60f91d858a2