### PR TITLE
Parallelize FEM inverse steps with OMP helper

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -1,6 +1,7 @@
 ﻿using DataAccessLayer;
 using System.Diagnostics;
 using System.Numerics;
+using System.Threading.Tasks;
 using Utility.Classes;
 using Utility.Classes.Application;
 using Utility.Classes.Factories;
@@ -12,6 +13,7 @@ using Utility.Classes.Models;
 using Utility.Classes.ReconstructionParameters;
 using Utility.Classes.Solvers.FiniteElementSolver;
 using Utility.Classes.Solvers.LatticeBoltzmannSolver;
+using Utility.Classes.Reconstruction.ErrorMetrics;
 
 namespace BusinessLayer
 {
@@ -34,6 +36,8 @@ namespace BusinessLayer
         private InitialDistributionTypes _initialDistributionType = InitialDistributionTypes.SlightlyDiffering;
         private bool _useOmpParallelization = false;
         private bool _useCudaParallelization = false;
+        private NumericSolver _numericSolverChoice = NumericSolver.LU;
+        private ErrorMetric _errorMetricChoice = ErrorMetric.L2;
 
         private ConductivityDistribution? _originalSigma = null;
         private ConductivityDistribution? _initialSigma = null;
@@ -70,7 +74,8 @@ namespace BusinessLayer
             {
                 _discretization = discretization;
 
-                _numericSolver = NumericSolverFactory.Create(parameters.NumericSolver);
+                _numericSolverChoice = parameters.NumericSolver;
+                _numericSolver = NumericSolverFactory.Create(_numericSolverChoice);
                 _useOmpParallelization = parameters.UseOmpParallelization;
                 _useCudaParallelization = parameters.UseCudaAcceleration;
 
@@ -93,7 +98,8 @@ namespace BusinessLayer
                                                                                       _useOmpParallelization,
                                                                                       _useCudaParallelization);
                 _regularizer = RegularisationFactory.Create(parameters.RegularizationTechnique, _discretization);
-                _errorMetric = ErrorMetricFactory.Create(parameters.ErrorMetric);
+                _errorMetricChoice = parameters.ErrorMetric;
+                _errorMetric = ErrorMetricFactory.Create(_errorMetricChoice);
                 _initialDistributionType = parameters.InitialDistributionType;
                 var initSigma = _initialSigma ?? ConductivityDistributionFactory.CreateInitialDistribution(discretization, _initialDistributionType);
                 _numericOptimizer = NumericOptimizerFactory.Create(parameters.NumericOptimizer, initSigma);
@@ -253,66 +259,25 @@ namespace BusinessLayer
             return lbmSolver.CUDASolveForward(lbmGrid, boundaryConditions);
         }
 
-        public ReconstructionFrame InverseSolveStepFem(FEMMesh mesh, FEMBoundaryCondition bc, double[] currentMeasurement, double _)
+        public ReconstructionFrame InverseSolveStepFem(FEMMesh mesh, FEMBoundaryCondition bc, double[] currentMeasurement, double gradientStepSize)
         {
             if (_differentialEquationSolver == null)
                 throw new NullReferenceException("Differential equation solver is null, check calling code!");
 
-            if(_errorMetric == null)
+            if (_errorMetric == null)
                 throw new NullReferenceException("Error metric is null, check calling code!");
 
             if (_regularizer == null)
                 throw new NullReferenceException("Regularizer is null, check calling code!");
 
-            Workspace.UpdateCurrentGlobalFemElectrodes(mesh);
-            Workspace.UpdateCurrentGlobalFemElements(mesh);
-            Workspace.SetCurrentGlobalFemBoundaryCondition(bc);
-            var electrodes = Workspace.GetCurrentGlobalFemElectrodes();
-            var elements = Workspace.GetCurrentGlobalFemElements();
-
-            // Solve Forward to extract simulated potentials
-            PotentialDistribution phi = _differentialEquationSolver.Solve(mesh, bc, null);
-
-            // Extract simulated potentials
-            double[] simulatedPotentials = mesh.GetElectrodePotentials();
-
-            // Error metric based gradeint expression for the adjoint equation
-            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, currentMeasurement, simulatedPotentials);
-
-            // Create the new adjoint source array
-            Complex[] adjointSource = new Complex[adjSrc.Length];
-            for (int k = 0; k < adjSrc.Length; k++)
-                adjointSource[k] = adjSrc[k];
-
-            // Solve the adjoint equation with the new boundary condition
-            var adjointBoundaryCondition = new FEMBoundaryCondition(electrodes);
-            Workspace.SetCurrentGlobalFemBoundaryCondition(adjointBoundaryCondition);
-            PotentialDistribution mu = _differentialEquationSolver.Solve(mesh, adjointBoundaryCondition, adjointSource);
-
-            // Gradient expression for the conductivity field
-            var phiGradient = FiniteElementOperators.CalculateElementWiseGradient(mesh, phi);
-            var muGradient = FiniteElementOperators.CalculateElementWiseGradient(mesh, mu);
-
-            ConductivityDistribution dataGrad = new ConductivityDistribution(
-                elements.ToDictionary(
-                    el => el.Id,
-                    el => {
-                        // compute ∇φ, ∇μ on this element
-                        var gPhi = phiGradient.GetVector(el.Id);
-                        var gMu = muGradient.GetVector(el.Id);
-                        return -(gMu.X * gPhi.X + gMu.Y * gPhi.Y) * el.Area;
-                    }
-                )
-            );
-
-            ConductivityDistribution sigma = mesh.GetConductivityDistribution();
-
-            // Calculate the regularization field
-            double regTerm = _regularizer.EvaluateTerm(mesh, sigma);
-            ConductivityDistribution regularization = _regularizer.EvaluateGradient(mesh, sigma);
-
-            // Returning the partial results from the inverse calculations
-            return new ReconstructionFrame(dataGrad, phi, mu, regularization);
+            return ComputeFemInverseStep(mesh,
+                                         bc,
+                                         currentMeasurement,
+                                         gradientStepSize,
+                                         _differentialEquationSolver,
+                                         _errorMetric,
+                                         _regularizer,
+                                         updateWorkspace: true);
         }
 
         public ReconstructionFrame InverseSolveStepLbm(LBMGrid mesh, LBMBoundaryCondition bc, double[] currentMeasurement)
@@ -374,6 +339,164 @@ namespace BusinessLayer
 
             return new ReconstructionFrame(dataGrad, phi, mu, new ConductivityDistribution([]));
         }
+
+        private ReconstructionFrame ComputeFemInverseStep(FEMMesh mesh,
+                                                          FEMBoundaryCondition bc,
+                                                          double[] currentMeasurement,
+                                                          double gradientStepSize,
+                                                          IDifferentialEquationSolver solver,
+                                                          IErrorMetric errorMetric,
+                                                          IRegularizer regularizer,
+                                                          bool updateWorkspace)
+        {
+            if (solver == null)
+                throw new ArgumentNullException(nameof(solver));
+            if (errorMetric == null)
+                throw new ArgumentNullException(nameof(errorMetric));
+            if (regularizer == null)
+                throw new ArgumentNullException(nameof(regularizer));
+
+            _ = gradientStepSize; // Currently unused but preserved for API compatibility.
+
+            List<FEMElectrode> electrodes;
+            List<FEMElement> elements;
+
+            if (updateWorkspace)
+            {
+                Workspace.UpdateCurrentGlobalFemElectrodes(mesh);
+                Workspace.UpdateCurrentGlobalFemElements(mesh);
+                Workspace.SetCurrentGlobalFemBoundaryCondition(bc);
+
+                electrodes = Workspace.GetCurrentGlobalFemElectrodes();
+                elements = Workspace.GetCurrentGlobalFemElements();
+            }
+            else
+            {
+                electrodes = new List<FEMElectrode>(bc.GetElectrodes());
+                elements = mesh.GetElements().Cast<FEMElement>().ToList();
+            }
+
+            PotentialDistribution phi = solver.Solve(mesh, bc, null);
+            double[] simulatedPotentials = mesh.GetElectrodePotentials();
+
+            var adjSrc = errorMetric.EvaluateAdjointSource(mesh, currentMeasurement, simulatedPotentials);
+            Complex[] adjointSource = new Complex[adjSrc.Length];
+            for (int k = 0; k < adjSrc.Length; k++)
+                adjointSource[k] = adjSrc[k];
+
+            var adjointBoundaryCondition = new FEMBoundaryCondition(new List<FEMElectrode>(electrodes));
+            if (updateWorkspace)
+                Workspace.SetCurrentGlobalFemBoundaryCondition(adjointBoundaryCondition);
+
+            PotentialDistribution mu = solver.Solve(mesh, adjointBoundaryCondition, adjointSource);
+
+            var phiGradient = FiniteElementOperators.CalculateElementWiseGradient(mesh, phi);
+            var muGradient = FiniteElementOperators.CalculateElementWiseGradient(mesh, mu);
+
+            ConductivityDistribution dataGrad = new ConductivityDistribution(
+                elements.ToDictionary(
+                    el => el.Id,
+                    el =>
+                    {
+                        var gPhi = phiGradient.GetVector(el.Id);
+                        var gMu = muGradient.GetVector(el.Id);
+                        return -(gMu.X * gPhi.X + gMu.Y * gPhi.Y) * el.Area;
+                    })
+            );
+
+            ConductivityDistribution sigma = mesh.GetConductivityDistribution();
+
+            _ = regularizer.EvaluateTerm(mesh, sigma);
+            ConductivityDistribution regularization = regularizer.EvaluateGradient(mesh, sigma);
+
+            return new ReconstructionFrame(dataGrad, phi, mu, regularization);
+        }
+
+        private (Dictionary<int, double> Gradient, ReconstructionFrame[] Frames) ComputeFemInverseStepsOmp(
+            FEMMesh mesh,
+            IReadOnlyList<double[]> measurementFrames,
+            int electrodeCount)
+        {
+            if (measurementFrames == null)
+                throw new ArgumentNullException(nameof(measurementFrames));
+            if (measurementFrames.Count == 0)
+                throw new ArgumentException("Measurement frame list cannot be empty.", nameof(measurementFrames));
+            if (_regularizer == null)
+                throw new InvalidOperationException("Regularizer must be initialised before running parallel FEM inverse steps.");
+
+            var elementList = mesh.GetElements().Cast<FEMElement>().ToList();
+            var gradientAccumulator = elementList.ToDictionary(el => el.Id, _ => 0.0);
+            var frames = new ReconstructionFrame[electrodeCount];
+
+            Parallel.For(0, electrodeCount, exc =>
+            {
+                var localMesh = (FEMMesh)mesh.DeepCopy();
+                var localElectrodes = localMesh.GetElectrodes().Cast<FEMElectrode>().ToList();
+
+                foreach (var el in localElectrodes)
+                {
+                    el.Current = 0.0;
+                    el.IsExcitation = false;
+                    el.IsGround = false;
+                    el.IsMeasuring = true;
+                    el.Potential = 0.0;
+                }
+
+                int localExcitationIndex = exc % localElectrodes.Count;
+                int localGroundIndex = (exc + 1) % localElectrodes.Count;
+                localElectrodes[localExcitationIndex].IsExcitation = true;
+                localElectrodes[localExcitationIndex].IsMeasuring = false;
+                localElectrodes[localExcitationIndex].Current = 1.0;
+                localElectrodes[localGroundIndex].IsGround = true;
+                localElectrodes[localGroundIndex].IsMeasuring = false;
+                localElectrodes[localGroundIndex].Current = -1.0;
+
+                var localBc = new FEMBoundaryCondition(localElectrodes);
+                var localSolver = new FiniteElementDESolver(localMesh, CreateNumericSolverInstance(), _useOmpParallelization);
+                var localErrorMetric = CreateErrorMetricInstance();
+
+                int measurementIndex = exc % measurementFrames.Count;
+                var frame = ComputeFemInverseStep(localMesh,
+                                                  localBc,
+                                                  measurementFrames[measurementIndex],
+                                                  1.0,
+                                                  localSolver,
+                                                  localErrorMetric,
+                                                  _regularizer,
+                                                  updateWorkspace: false);
+
+                frames[exc] = frame;
+            });
+
+            foreach (var frame in frames)
+            {
+                if (frame == null)
+                    continue;
+
+                foreach (var kvp in frame.ConductivityGradient.Conductivities)
+                    gradientAccumulator[kvp.Key] += kvp.Value;
+            }
+
+            return (gradientAccumulator, frames);
+        }
+
+        private INumericSolver CreateNumericSolverInstance() => _numericSolverChoice switch
+        {
+            NumericSolver.LU => new LuDecompositionSolver(),
+            NumericSolver.SVD => new SVDSolver(),
+            NumericSolver.tSVD => new tSVDSolver(),
+            NumericSolver.GMRES => new GmresSolver(),
+            _ => throw new NotSupportedException($"Numeric solver {_numericSolverChoice} is not supported for parallel execution.")
+        };
+
+        private IErrorMetric CreateErrorMetricInstance() => _errorMetricChoice switch
+        {
+            ErrorMetric.L2 => new L2ErrorMetric(),
+            ErrorMetric.Wasserstein2 => new Wasserstein2ErrorMetric(),
+            ErrorMetric.ConductivityAwareW2 => new ConductivityAwareW2Metric(),
+            ErrorMetric.EnergyBasedWasserstein2 => new EnergyBasedWasserstein2Metric(),
+            _ => throw new NotSupportedException($"Error metric {_errorMetricChoice} is not supported for parallel execution.")
+        };
 
         public ReconstructionFrame InverseSolveStepLbmCuda(LBMGrid mesh, LBMBoundaryCondition bc, double[] currentMeasurement)
         {
@@ -441,50 +564,61 @@ namespace BusinessLayer
             // --- Iterative reconstruction loop -----------------------------------------
             for (int iter = 0; iter < maxIterationCount && !_stopRequested; iter++)
             {
-                // Initialise an accumulator for the gradient contributions of
-                // all electrode pairs.
-                Dictionary<int, double> totalGrad = elements.ToDictionary(el => el.Id, _ => 0.0);
+                Dictionary<int, double> totalGrad;
 
-                for (int exc = 0; exc < electrodeCount; exc++)
+                if (_useOmpParallelization)
                 {
-                    // Reset electrode roles before applying a new excitation
-                    // pattern.  The excitation amplitude is set to unity for
-                    // simplicity; the measurement data already includes this
-                    // amplitude.
-                    foreach (var el in electrodes)
+                    var (parallelGradient, parallelFrames) = ComputeFemInverseStepsOmp(mesh, measurementFrames, electrodeCount);
+                    totalGrad = parallelGradient;
+                    frames.AddRange(parallelFrames);
+                }
+                else
+                {
+                    // Initialise an accumulator for the gradient contributions of
+                    // all electrode pairs.
+                    totalGrad = elements.ToDictionary(el => el.Id, _ => 0.0);
+
+                    for (int exc = 0; exc < electrodeCount; exc++)
                     {
-                        el.Current = 0.0;
-                        el.IsExcitation = false;
-                        el.IsGround = false;
-                        el.IsMeasuring = true;
-                        el.Potential = 0.0;
+                        // Reset electrode roles before applying a new excitation
+                        // pattern.  The excitation amplitude is set to unity for
+                        // simplicity; the measurement data already includes this
+                        // amplitude.
+                        foreach (var el in electrodes)
+                        {
+                            el.Current = 0.0;
+                            el.IsExcitation = false;
+                            el.IsGround = false;
+                            el.IsMeasuring = true;
+                            el.Potential = 0.0;
+                        }
+
+                        electrodes[exc % electrodeCount].IsExcitation = true;
+                        electrodes[exc % electrodeCount].IsMeasuring = false;
+                        electrodes[exc % electrodeCount].Current = 1.0;
+                        electrodes[(exc + 1) % electrodeCount].IsGround = true;
+                        electrodes[(exc + 1) % electrodeCount].IsMeasuring = false;
+                        electrodes[(exc + 1) % electrodeCount].Current = -1.0;
+
+                        // Boundary condition reflecting the just configured
+                        // electrode setup.
+                        var bc = new FEMBoundaryCondition(electrodes);
+                        Workspace.SetCurrentGlobalFemBoundaryCondition(bc);
+
+                        // Measurement corresponding to this excitation pattern.
+                        double[] dObs = measurementFrames[exc];
+
+                        // Perform forward/adjoint solve and obtain the gradient
+                        // contribution for this electrode pair.  The gradient step
+                        // size is set to unity so the returned gradient represents
+                        // ∇J_data without any scaling.
+                        var frame = InverseSolveStepFem(mesh, bc, dObs, 1.0);
+
+                        frames.Add(frame);
+
+                        foreach (var kvp in frame.ConductivityGradient.Conductivities)
+                            totalGrad[kvp.Key] += kvp.Value;
                     }
-
-                    electrodes[exc % electrodeCount].IsExcitation = true;
-                    electrodes[exc % electrodeCount].IsMeasuring = false;
-                    electrodes[exc % electrodeCount].Current = 1.0;
-                    electrodes[(exc + 1) % electrodeCount].IsGround = true;
-                    electrodes[(exc + 1) % electrodeCount].IsMeasuring = false;
-                    electrodes[(exc + 1) % electrodeCount].Current = -1.0;
-
-                    // Boundary condition reflecting the just configured
-                    // electrode setup.
-                    var bc = new FEMBoundaryCondition(electrodes);
-                    Workspace.SetCurrentGlobalFemBoundaryCondition(bc);
-
-                    // Measurement corresponding to this excitation pattern.
-                    double[] dObs = measurementFrames[exc];
-
-                    // Perform forward/adjoint solve and obtain the gradient
-                    // contribution for this electrode pair.  The gradient step
-                    // size is set to unity so the returned gradient represents
-                    // ∇J_data without any scaling.
-                    var frame = InverseSolveStepFem(mesh, bc, dObs, 1.0);
-
-                    frames.Add(frame);
-
-                    foreach (var kvp in frame.ConductivityGradient.Conductivities)
-                        totalGrad[kvp.Key] += kvp.Value;
                 }
 
                 // Add regularisation gradient to the accumulated data


### PR DESCRIPTION
## Summary
- cache the selected numeric solver and error metric so that parallel workers can create thread-safe instances
- add reusable helpers that run FEM inverse solves and aggregate gradient contributions across excitations in parallel when OMP is enabled
- update the FEM reconstruction loop to dispatch either the sequential or parallel path based on the UI flag while preserving gradient accumulation semantics

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e7d4c0c1b083338be6b3065fa8c177