### PR TITLE
Sanitize Wasserstein error metrics to prevent NaN conductivities

### DIFF
--- a/Utility/Classes/Reconstruction/ErrorMetrics/EnergyBasedWasserstein2Metric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/EnergyBasedWasserstein2Metric.cs
@@ -30,6 +30,14 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         /// Small numerical tolerance to avoid division by zero and handle degenerate cases
         /// </summary>
         private const double Tiny = 1e-12;
+
+        private static double Sanitize(double value) => double.IsFinite(value) ? value : 0.0;
+
+        private static void SanitizeInPlace(double[] values)
+        {
+            for (int i = 0; i < values.Length; i++)
+                values[i] = Sanitize(values[i]);
+        }
         
         /// <summary>
         /// Cache for the last computation to avoid redundant calculations when 
@@ -147,11 +155,12 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             // min_{P} sum_{i,j} cost[i,j] * P[i,j]
             // subject to: sum_j P[i,j] = mu[i], sum_i P[i,j] = nu[j], P[i,j] >= 0
             var transport = SolveOptimalTransport(cost, mu.Values, nu.Values);
-            double loss = transport.Objective;
+            double loss = Sanitize(transport.Objective);
 
             // === ADJOINT SOURCE COMPUTATION ===
             // Extract Kantorovich potential (dual variable alpha) from transport solution
             var sourcePotential = (double[])transport.Alpha.Clone();
+            SanitizeInPlace(sourcePotential);
             
             // Compute weighted mean of potential (needed for gauge fixing)
             double weightedMean = 0.0;
@@ -162,7 +171,9 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             double invMass = 1.0 / mu.TotalMass;
             var sourceGradient = new double[sourcePotential.Length];
             for (int i = 0; i < sourceGradient.Length; i++)
-                sourceGradient[i] = (sourcePotential[i] - weightedMean) * invMass;
+                sourceGradient[i] = Sanitize((sourcePotential[i] - weightedMean) * invMass);
+
+            SanitizeInPlace(sourceGradient);
 
             // Map back to full electrode array (including NaN entries)
             var adjointFull = new double[measured.Length];
@@ -489,7 +500,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
 
                 // === ELEMENT STIFFNESS ASSEMBLY ===
                 // Sum contributions from all finite elements
-                // Each element contributes: sigma * area * grad_phi_i · grad_phi_j
+                // Each element contributes: sigma * area * grad_phi_i  grad_phi_j
                 foreach (var element in mesh.ElementsTyped.Cast<FEMElement>())
                 {
                     double sigma = element.Conductivity;  // Local conductivity

--- a/Utility/Classes/ReconstructionParameters/ErrorMetric.cs
+++ b/Utility/Classes/ReconstructionParameters/ErrorMetric.cs
@@ -110,6 +110,16 @@ namespace Utility.Classes.ReconstructionParameters
         /// corresponding support coordinates.  The masses are shifted to be
         /// nonnegative, normalized to unit sum, and the primal LP is solved.
         /// </summary>
+        private static double Sanitize(double value) => double.IsFinite(value) ? value : 0.0;
+
+        private static void SanitizeInPlace(double[] values)
+        {
+            for (int i = 0; i < values.Length; i++)
+            {
+                values[i] = Sanitize(values[i]);
+            }
+        }
+
         public static OTResult w2_misfit_and_grad(double[] mPred, double[] dObs,
             (double x, double y)[] x, (double x, double y)[] y)
         {
@@ -182,7 +192,7 @@ namespace Utility.Classes.ReconstructionParameters
                 for (int j = 0; j < n; j++)
                     P[i, j] = plan[i, j].SolutionValue();
 
-            double cost = 0.5 * obj.Value();
+            double cost = Sanitize(0.5 * obj.Value());
 
             // Dual potentials from row/column constraints
             double[] phi = new double[m];
@@ -199,7 +209,10 @@ namespace Utility.Classes.ReconstructionParameters
 
             // Chain rule back to raw (unnormalized) masses
             double[] gradRaw = new double[m];
-            for (int i = 0; i < m; i++) gradRaw[i] = grad[i] / sumA;
+            for (int i = 0; i < m; i++)
+            {
+                gradRaw[i] = Sanitize(grad[i] / sumA);
+            }
 
             return new OTResult(cost, gradRaw, P, phi, psi);
         }
@@ -251,7 +264,11 @@ namespace Utility.Classes.ReconstructionParameters
             var res = w2_misfit_and_grad(aRaw, bRaw, aLoc, bLoc);
             var gradFull = new double[all.Count];
             foreach (var (srcIdx, electrodeIdx) in aMap)
-                gradFull[electrodeIdx] = res.Grad[srcIdx];
+            {
+                gradFull[electrodeIdx] = Sanitize(res.Grad[srcIdx]);
+            }
+
+            SanitizeInPlace(gradFull);
 
             return new OptimalTransportResult(measured, simulated, res.Cost, gradFull);
         }


### PR DESCRIPTION
## Summary
- guard the Wasserstein-2 error metric against non-finite LP results before returning the adjoint source
- sanitize the energy-based Wasserstein-2 metric so dual potentials and gradients cannot inject NaNs back into reconstructions

## Testing
- dotnet build (fails: dotnet not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ed81e327348333aedf18867b3d638c