### PR TITLE
Fix W2 LP failure by balancing transport marginals

### DIFF
--- a/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
@@ -559,6 +559,20 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         {
             int m = mu.Length;
             int n = nu.Length;
+
+            if (m == 0 || n == 0)
+            {
+                sourcePotential = Array.Empty<double>();
+                targetPotential = Array.Empty<double>();
+                return new double[m, n];
+            }
+
+            double sumMu = mu.Sum();
+            double sumNu = nu.Sum();
+            double targetMass = 0.5 * (sumMu + sumNu);
+            var balancedMu = BalanceHistogram(mu, sumMu, targetMass);
+            var balancedNu = BalanceHistogram(nu, sumNu, targetMass);
+
             var solver = Solver.CreateSolver("GLOP") ?? throw new InvalidOperationException("OR-Tools GLOP solver unavailable.");
 
             var planVar = new Variable[m, n];
@@ -569,7 +583,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             var row = new Constraint[m];
             for (int i = 0; i < m; i++)
             {
-                row[i] = solver.MakeConstraint(mu[i], mu[i], $"row[{i}]");
+                row[i] = solver.MakeConstraint(balancedMu[i], balancedMu[i], $"row[{i}]");
                 for (int j = 0; j < n; j++)
                     row[i].SetCoefficient(planVar[i, j], 1.0);
             }
@@ -577,7 +591,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             var col = new Constraint[n];
             for (int j = 0; j < n; j++)
             {
-                col[j] = solver.MakeConstraint(nu[j], nu[j], $"col[{j}]");
+                col[j] = solver.MakeConstraint(balancedNu[j], balancedNu[j], $"col[{j}]");
                 for (int i = 0; i < m; i++)
                     col[j].SetCoefficient(planVar[i, j], 1.0);
             }
@@ -605,6 +619,63 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 targetPotential[j] = col[j].DualValue();
 
             return planMatrix;
+        }
+
+        private static double[] BalanceHistogram(double[] values, double originalMass, double targetMass)
+        {
+            if (values == null) throw new ArgumentNullException(nameof(values));
+            int length = values.Length;
+            if (length == 0)
+                return Array.Empty<double>();
+
+            var balanced = (double[])values.Clone();
+            EnsureHistogramMass(balanced, originalMass, targetMass);
+            return balanced;
+        }
+
+        private static void EnsureHistogramMass(double[] histogram, double originalMass, double targetMass)
+        {
+            if (histogram.Length == 0)
+                return;
+
+            double sum = originalMass;
+            if (!(sum > 0.0))
+                throw new InvalidOperationException("Histogram must have positive total mass.");
+
+            double effectiveTarget = targetMass;
+            if (!(effectiveTarget > 0.0))
+                effectiveTarget = sum;
+
+            double scale = effectiveTarget / sum;
+            double accum = 0.0;
+            for (int i = 0; i < histogram.Length; i++)
+            {
+                double scaled = histogram[i] * scale;
+                histogram[i] = scaled;
+                accum += scaled;
+            }
+
+            double correction = effectiveTarget - accum;
+            histogram[^1] += correction;
+
+            if (histogram[^1] < 0.0)
+            {
+                double deficit = -histogram[^1];
+                histogram[^1] = 0.0;
+                for (int i = histogram.Length - 2; i >= 0 && deficit > 0.0; i--)
+                {
+                    double available = Math.Min(histogram[i], deficit);
+                    histogram[i] -= available;
+                    deficit -= available;
+                }
+
+                if (deficit > 1e-12)
+                    throw new InvalidOperationException("Unable to balance histogram without negative entries.");
+
+                double finalSum = histogram.Sum();
+                double finalCorrection = effectiveTarget - finalSum;
+                histogram[^1] += finalCorrection;
+            }
         }
 
         /// <summary>

--- a/Utility/Tests/ConductivityAwareW2MetricTests.cs
+++ b/Utility/Tests/ConductivityAwareW2MetricTests.cs
@@ -68,6 +68,59 @@ namespace Utility.Tests
         }
 
         [Fact]
+        public void OptimalTransportPrimalBalancesFloatingPointMismatch()
+        {
+            double[,] cost =
+            {
+                { 0.0, 1.0, 2.0 },
+                { 1.0, 0.0, 1.0 },
+                { 2.0, 1.0, 0.0 }
+            };
+
+            double[] mu =
+            {
+                0.20000000000000004,
+                0.29999999999999993,
+                0.50000000000000011
+            };
+
+            double[] nu =
+            {
+                0.25,
+                0.35,
+                0.4000000001
+            };
+
+            double muTotal = mu.Sum();
+            double nuTotal = nu.Sum();
+            double expectedMass = 0.5 * (muTotal + nuTotal);
+            var plan = ConductivityAwareW2Metric.SolveOptimalTransportPrimal(cost, mu, nu);
+
+            for (int i = 0; i < mu.Length; i++)
+            {
+                double row = 0.0;
+                for (int j = 0; j < nu.Length; j++)
+                    row += plan[i, j];
+                Assert.Equal(expectedMass * mu[i] / muTotal, row, 9);
+            }
+
+            for (int j = 0; j < nu.Length; j++)
+            {
+                double col = 0.0;
+                for (int i = 0; i < mu.Length; i++)
+                    col += plan[i, j];
+                Assert.Equal(expectedMass * nu[j] / nuTotal, col, 9);
+            }
+
+            double total = 0.0;
+            for (int i = 0; i < mu.Length; i++)
+                for (int j = 0; j < nu.Length; j++)
+                    total += plan[i, j];
+
+            Assert.Equal(expectedMass, total, 12);
+        }
+
+        [Fact]
         public void SoftGeodesicConvergesToShortestPathForSmallTau()
         {
             var mesh = TinyFEM();


### PR DESCRIPTION
## Summary
- balance the simulated and measured histograms before calling the W2 LP solver so the row and column marginals agree despite rounding
- guard the LP setup when no electrodes are present and keep the histogram mass non-negative when rebalancing
- add a unit test covering floating-point marginal mismatches

## Testing
- `dotnet test` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee8a2bfbec8333a15634c1256e6467