### PR TITLE
Handle non-finite electrode data in FEM Wasserstein metrics

### DIFF
--- a/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
@@ -342,21 +342,33 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             double[] sigmoid = new double[raw.Length];
             double[] normalized = new double[raw.Length];
 
-            double min = raw[0];
+            double min = double.PositiveInfinity;
             int minIdx = 0;
-            for (int i = 1; i < raw.Length; i++)
+            for (int i = 0; i < raw.Length; i++)
             {
-                if (raw[i] < min)
+                double value = raw[i];
+                if (!double.IsFinite(value))
+                    continue;
+                if (value < min)
                 {
-                    min = raw[i];
+                    min = value;
                     minIdx = i;
                 }
+            }
+
+            if (!double.IsFinite(min))
+            {
+                min = 0.0;
+                minIdx = 0;
             }
 
             double sum = 0.0;
             for (int i = 0; i < raw.Length; i++)
             {
-                double val = raw[i] - min;
+                double rawVal = raw[i];
+                if (!double.IsFinite(rawVal))
+                    rawVal = min;
+                double val = rawVal - min;
                 shifted[i] = val;
                 double kx = kappa * val;
                 double sp = Softplus(kx) / kappa;

--- a/Utility/Classes/ReconstructionParameters/ErrorMetric.cs
+++ b/Utility/Classes/ReconstructionParameters/ErrorMetric.cs
@@ -120,6 +120,13 @@ namespace Utility.Classes.ReconstructionParameters
             double[] a = (double[])mPred.Clone();
             double[] b = (double[])dObs.Clone();
 
+            for (int i = 0; i < a.Length; i++)
+                if (!double.IsFinite(a[i]))
+                    a[i] = 0.0;
+            for (int j = 0; j < b.Length; j++)
+                if (!double.IsFinite(b[j]))
+                    b[j] = 0.0;
+
             double minA = a.Length > 0 ? a.Min() : 0.0;
             double minB = b.Length > 0 ? b.Min() : 0.0;
             if (minA < 0) for (int i = 0; i < a.Length; i++) a[i] -= minA;
@@ -239,7 +246,7 @@ namespace Utility.Classes.ReconstructionParameters
             // also provide measurements.
             var include = new List<int>();
             for (int i = 0; i < measured.Length; i++)
-                if (!double.IsNaN(measured[i]))
+                if (double.IsFinite(measured[i]))
                     include.Add(i);
 
             var (aRaw, aLoc, aMap) = BuildDistribution(simulated, all, coord, include);
@@ -267,7 +274,7 @@ namespace Utility.Classes.ReconstructionParameters
             foreach (int i in include)
             {
                 double v = raw[i];
-                if (double.IsNaN(v))
+                if (!double.IsFinite(v))
                     continue;
 
                 var e = electrodes[i];

--- a/Utility/Tests/ConductivityAwareW2MetricTests.cs
+++ b/Utility/Tests/ConductivityAwareW2MetricTests.cs
@@ -42,6 +42,19 @@ namespace Utility.Tests
         }
 
         [Fact]
+        public void NormalizeIgnoresNonFiniteEntries()
+        {
+            double[] raw = { double.NaN, double.PositiveInfinity, -1.0, 0.0 };
+            double kappa = 4.0;
+            double epsilon = 1e-6;
+
+            var cache = ConductivityAwareW2Metric.Normalize(raw, kappa, epsilon);
+
+            Assert.All(cache.Normalized, v => Assert.True(double.IsFinite(v)));
+            Assert.Equal(1.0, cache.Normalized.Sum(), 8);
+        }
+
+        [Fact]
         public void OptimalTransportPrimalMatchesMarginals()
         {
             double[,] cost =

--- a/Utility/Tests/ErrorMetricTests.cs
+++ b/Utility/Tests/ErrorMetricTests.cs
@@ -77,6 +77,25 @@ namespace Utility.Tests
         }
 
         [Fact]
+        public void Wasserstein2_FEM_Allows_More_Boundary_Vertices_Than_Electrodes()
+        {
+            var mesh = MeshFactory.CreateCircularFEMMesh(layers: 2, boundaryFEMVertexCount: 64, electrodeCount: 16);
+
+            var electrodes = mesh.GetElectrodes();
+            Assert.Equal(16, electrodes.Count);
+
+            var meas = new double[electrodes.Count];
+            var sim = new double[electrodes.Count];
+            meas[0] = 1.0;
+            sim[1] = 1.0;
+
+            var metric = new Wasserstein2ErrorMetric();
+            double value = metric.Evaluate(mesh, meas, sim);
+
+            Assert.True(value >= 0.0);
+        }
+
+        [Fact]
         public void ErrorMetricFactory_Returns_ConductivityAwareW2Metric()
         {
             var metric = ErrorMetricFactory.Create(ErrorMetric.ConductivityAwareW2);


### PR DESCRIPTION
## Summary
- sanitize Wasserstein-2 input distributions by ignoring non-finite electrode values
- make the conductivity-aware Wasserstein normalization robust to NaN/Infinity masses
- add regression coverage for FEM meshes with extra boundary vertices and non-finite inputs

## Testing
- dotnet test Utility/Utility.csproj *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ee8a2bfbec8333a15634c1256e6467