### PR TITLE
Refactor reconstruction export workflow into service layer

### DIFF
--- a/DataAccessLayer/DataAccessLayer.csproj
+++ b/DataAccessLayer/DataAccessLayer.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="System.IO.Ports" Version="9.0.5" />
     <PackageReference Include="Unity" Version="5.11.10" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DataAccessLayer/IReconstructionExportRepository.cs
+++ b/DataAccessLayer/IReconstructionExportRepository.cs
@@ -1,0 +1,18 @@
+using Utility.Exports;
+using Utility.Rendering;
+using Utility.Classes;
+using Utility.Classes.Discretizer;
+
+namespace DataAccessLayer;
+
+public interface IReconstructionExportRepository
+{
+    DataExportResult ExportReconstructionData(ReconstructionExportRequest request);
+}
+
+public sealed record ReconstructionExportRequest(IDiscretization Discretization,
+                                                  IReadOnlyList<ReconstructionFrame> Frames,
+                                                  IReadOnlyList<ReconstructionResult> Results,
+                                                  ReconstructionFrame RenderFrame,
+                                                  PotentialDisplayMode DisplayMode,
+                                                  string TargetDirectory);

--- a/DataAccessLayer/ReconstructionExportRepository.cs
+++ b/DataAccessLayer/ReconstructionExportRepository.cs
@@ -1,0 +1,601 @@
+using SkiaSharp;
+using System.Globalization;
+using System.Text;
+using Utility.Classes;
+using Utility.Classes.Measurement;
+using Utility.Exports;
+using Utility.Rendering;
+
+namespace DataAccessLayer;
+
+public sealed class ReconstructionExportRepository : IReconstructionExportRepository
+{
+    public DataExportResult ExportReconstructionData(ReconstructionExportRequest request)
+    {
+        try
+        {
+            Directory.CreateDirectory(request.TargetDirectory);
+
+            var snapshots = CreateIterationSnapshots(request.Results);
+            if (snapshots.Count == 0)
+                return DataExportResult.CreateFailure("No Results", "No reconstruction iterations were recorded.");
+
+            var firstSnapshot = snapshots.First();
+            var latestSnapshot = snapshots.Last();
+
+            SaveDistributionSnapshot(request.TargetDirectory,
+                                     "original_distribution.png",
+                                     request.Discretization,
+                                     GetFrameForResult(latestSnapshot.Result, request.RenderFrame),
+                                     latestSnapshot.Result,
+                                     ReconstructionVideoRenderer.DistributionSnapshotType.Original,
+                                     "Original Conductivity Distribution",
+                                     CreateRangeMetadata(latestSnapshot.Result.OriginalConductivityDistribution),
+                                     request.DisplayMode);
+
+            var initialMetadata = CreateRangeMetadata(firstSnapshot.Result.InitialConductivitiyDistribution);
+            double initialResidual = CalculateResidual(firstSnapshot.Result.InitialConductivitiyDistribution,
+                                                       firstSnapshot.Result.OriginalConductivityDistribution);
+            initialMetadata.Add(("Residual L2", FormatDouble(initialResidual)));
+
+            var initialMetrics = ComputeInitialDistributionMetrics(firstSnapshot.Result);
+            if (initialMetrics.HasValue)
+            {
+                initialMetadata.Add(("MAE", FormatDouble(initialMetrics.Value.Mae)));
+                initialMetadata.Add(("RMSE", FormatDouble(initialMetrics.Value.Rmse)));
+            }
+
+            SaveDistributionSnapshot(request.TargetDirectory,
+                                     "initial_distribution.png",
+                                     request.Discretization,
+                                     GetFrameForResult(firstSnapshot.Result, request.RenderFrame),
+                                     firstSnapshot.Result,
+                                     ReconstructionVideoRenderer.DistributionSnapshotType.Initial,
+                                     "Initial Conductivity Distribution",
+                                     initialMetadata,
+                                     request.DisplayMode);
+
+            var finalMetadata = CreateRangeMetadata(latestSnapshot.Result.ReconstructedConductivityDistribution);
+            finalMetadata.Insert(0, ("Iteration", latestSnapshot.Iteration.ToString(CultureInfo.InvariantCulture)));
+            finalMetadata.Add(("Residual L2", FormatDouble(latestSnapshot.Residual)));
+            if (latestSnapshot.Metrics.HasValue)
+            {
+                var metrics = latestSnapshot.Metrics.Value;
+                finalMetadata.Add(("MAE", FormatDouble(metrics.Mae)));
+                finalMetadata.Add(("RMSE", FormatDouble(metrics.Rmse)));
+                finalMetadata.Add(("SSIM", FormatDouble(metrics.Ssim)));
+            }
+            finalMetadata.Add(("Correlation", FormatDouble(latestSnapshot.Correlation)));
+
+            SaveDistributionSnapshot(request.TargetDirectory,
+                                     "reconstructed_distribution_latest.png",
+                                     request.Discretization,
+                                     GetFrameForResult(latestSnapshot.Result, request.RenderFrame),
+                                     latestSnapshot.Result,
+                                     ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
+                                     "Latest Reconstructed Conductivity",
+                                     finalMetadata,
+                                     request.DisplayMode);
+
+            SaveBestMetricSnapshots(request.TargetDirectory,
+                                     request.Discretization,
+                                     request.RenderFrame,
+                                     snapshots,
+                                     request.DisplayMode);
+
+            WriteIterationMetricsCsv(request.TargetDirectory, snapshots);
+            WriteGradientMetricsCsv(request.TargetDirectory, request.Frames);
+
+            return DataExportResult.CreateSuccess(request.TargetDirectory);
+        }
+        catch (Exception ex)
+        {
+            return DataExportResult.CreateFailure("Export Failed", ex.Message);
+        }
+    }
+
+    private static List<ReconstructionIterationSnapshot> CreateIterationSnapshots(IReadOnlyList<ReconstructionResult> results)
+    {
+        var snapshots = new List<ReconstructionIterationSnapshot>(results.Count);
+        for (int i = 0; i < results.Count; i++)
+        {
+            var result = results[i];
+            var metrics = ComputeDistributionMetrics(result, CancellationToken.None);
+            double residualValue = CalculateResidual(result.ReconstructedConductivityDistribution,
+                                                     result.OriginalConductivityDistribution);
+            double correlationValue = CalculateCorrelation(result.ReconstructedConductivityDistribution,
+                                                           result.OriginalConductivityDistribution);
+            snapshots.Add(new ReconstructionIterationSnapshot(i + 1, result, metrics, residualValue, correlationValue));
+        }
+
+        return snapshots;
+    }
+
+    private static void SaveBestMetricSnapshots(string directory,
+                                                IDiscretization discretization,
+                                                ReconstructionFrame fallbackFrame,
+                                                IReadOnlyList<ReconstructionIterationSnapshot> snapshots,
+                                                PotentialDisplayMode mode)
+    {
+        var metricSnapshots = snapshots.Where(s => s.Metrics.HasValue).ToList();
+
+        if (metricSnapshots.Count > 0)
+        {
+            var maeSnapshot = metricSnapshots
+                .Where(s => !double.IsNaN(s.Metrics!.Value.Mae))
+                .OrderBy(s => s.Metrics!.Value.Mae)
+                .FirstOrDefault();
+
+            if (maeSnapshot.Result != null)
+            {
+                var metrics = maeSnapshot.Metrics!.Value;
+                var metadata = new List<(string, string)>
+                {
+                    ("Iteration", maeSnapshot.Iteration.ToString(CultureInfo.InvariantCulture)),
+                    ("MAE", FormatDouble(metrics.Mae)),
+                    ("RMSE", FormatDouble(metrics.Rmse)),
+                    ("SSIM", FormatDouble(metrics.Ssim)),
+                    ("Residual L2", FormatDouble(maeSnapshot.Residual)),
+                    ("Correlation", FormatDouble(maeSnapshot.Correlation))
+                };
+
+                SaveDistributionSnapshot(directory,
+                                         "best_mae_distribution.png",
+                                         discretization,
+                                         GetFrameForResult(maeSnapshot.Result, fallbackFrame),
+                                         maeSnapshot.Result,
+                                         ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
+                                         "Reconstruction – Min MAE",
+                                         metadata,
+                                         mode);
+            }
+
+            var ssimSnapshot = metricSnapshots
+                .Where(s => !double.IsNaN(s.Metrics!.Value.Ssim))
+                .OrderBy(s => s.Metrics!.Value.Ssim)
+                .FirstOrDefault();
+
+            if (ssimSnapshot.Result != null)
+            {
+                var metrics = ssimSnapshot.Metrics!.Value;
+                var metadata = new List<(string, string)>
+                {
+                    ("Iteration", ssimSnapshot.Iteration.ToString(CultureInfo.InvariantCulture)),
+                    ("SSIM", FormatDouble(metrics.Ssim)),
+                    ("MAE", FormatDouble(metrics.Mae)),
+                    ("RMSE", FormatDouble(metrics.Rmse)),
+                    ("Residual L2", FormatDouble(ssimSnapshot.Residual)),
+                    ("Correlation", FormatDouble(ssimSnapshot.Correlation))
+                };
+
+                SaveDistributionSnapshot(directory,
+                                         "best_ssim_distribution.png",
+                                         discretization,
+                                         GetFrameForResult(ssimSnapshot.Result, fallbackFrame),
+                                         ssimSnapshot.Result,
+                                         ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
+                                         "Reconstruction – Min SSIM",
+                                         metadata,
+                                         mode);
+            }
+        }
+
+        var residualSnapshot = snapshots
+            .OrderBy(s => s.Residual)
+            .FirstOrDefault();
+
+        if (residualSnapshot.Result != null)
+        {
+            var metadata = new List<(string, string)>
+            {
+                ("Iteration", residualSnapshot.Iteration.ToString(CultureInfo.InvariantCulture)),
+                ("Residual L2", FormatDouble(residualSnapshot.Residual)),
+                ("Correlation", FormatDouble(residualSnapshot.Correlation))
+            };
+
+            if (residualSnapshot.Metrics.HasValue)
+            {
+                var metrics = residualSnapshot.Metrics.Value;
+                metadata.Add(("MAE", FormatDouble(metrics.Mae)));
+                metadata.Add(("RMSE", FormatDouble(metrics.Rmse)));
+                metadata.Add(("SSIM", FormatDouble(metrics.Ssim)));
+            }
+
+            SaveDistributionSnapshot(directory,
+                                     "best_residual_distribution.png",
+                                     discretization,
+                                     GetFrameForResult(residualSnapshot.Result, fallbackFrame),
+                                     residualSnapshot.Result,
+                                     ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
+                                     "Reconstruction – Min Residual",
+                                     metadata,
+                                     mode);
+        }
+
+        var correlationSnapshot = snapshots
+            .Where(s => !double.IsNaN(s.Correlation))
+            .OrderBy(s => s.Correlation)
+            .FirstOrDefault();
+
+        if (correlationSnapshot.Result != null)
+        {
+            var metadata = new List<(string, string)>
+            {
+                ("Iteration", correlationSnapshot.Iteration.ToString(CultureInfo.InvariantCulture)),
+                ("Correlation", FormatDouble(correlationSnapshot.Correlation)),
+                ("Residual L2", FormatDouble(correlationSnapshot.Residual))
+            };
+
+            if (correlationSnapshot.Metrics.HasValue)
+            {
+                var metrics = correlationSnapshot.Metrics.Value;
+                metadata.Add(("MAE", FormatDouble(metrics.Mae)));
+                metadata.Add(("RMSE", FormatDouble(metrics.Rmse)));
+                metadata.Add(("SSIM", FormatDouble(metrics.Ssim)));
+            }
+
+            SaveDistributionSnapshot(directory,
+                                     "best_correlation_distribution.png",
+                                     discretization,
+                                     GetFrameForResult(correlationSnapshot.Result, fallbackFrame),
+                                     correlationSnapshot.Result,
+                                     ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
+                                     "Reconstruction – Min Correlation",
+                                     metadata,
+                                     mode);
+        }
+    }
+
+    private static void WriteIterationMetricsCsv(string directory,
+                                                 IReadOnlyList<ReconstructionIterationSnapshot> snapshots)
+    {
+        string path = Path.Combine(directory, "iteration_metrics.csv");
+        using var writer = new StreamWriter(path, false, Encoding.UTF8);
+        writer.WriteLine("Iteration,Residual,RMSE,MAE,MAPE,PSNR,SSIM,Correlation,RMSEImprovement,MAEImprovement");
+
+        foreach (var snapshot in snapshots)
+        {
+            var metrics = snapshot.Metrics;
+            string residual = FormatCsvValue(snapshot.Residual);
+            string rmse = metrics.HasValue ? FormatCsvValue(metrics.Value.Rmse) : string.Empty;
+            string mae = metrics.HasValue ? FormatCsvValue(metrics.Value.Mae) : string.Empty;
+            string mape = metrics.HasValue ? FormatCsvValue(metrics.Value.Mape) : string.Empty;
+            string psnr = metrics.HasValue ? FormatCsvValue(metrics.Value.Psnr) : string.Empty;
+            string ssim = metrics.HasValue ? FormatCsvValue(metrics.Value.Ssim) : string.Empty;
+            string correlation = FormatCsvValue(snapshot.Correlation);
+            string rmseImprovement = metrics.HasValue ? FormatCsvValue(metrics.Value.RmseImprovement) : string.Empty;
+            string maeImprovement = metrics.HasValue ? FormatCsvValue(metrics.Value.MaeImprovement) : string.Empty;
+
+            writer.WriteLine(string.Join(',',
+                snapshot.Iteration.ToString(CultureInfo.InvariantCulture),
+                residual,
+                rmse,
+                mae,
+                mape,
+                psnr,
+                ssim,
+                correlation,
+                rmseImprovement,
+                maeImprovement));
+        }
+    }
+
+    private static void WriteGradientMetricsCsv(string directory, IReadOnlyList<ReconstructionFrame> frames)
+    {
+        string path = Path.Combine(directory, "gradient_metrics.csv");
+        using var writer = new StreamWriter(path, false, Encoding.UTF8);
+        writer.WriteLine("Frame,GradientNorm,GradientAngleDegrees");
+
+        Dictionary<int, double>? previous = null;
+
+        for (int i = 0; i < frames.Count; i++)
+        {
+            var gradient = frames[i].ConductivityGradient.Conductivities;
+            double norm = 0.0;
+            foreach (var kv in gradient)
+            {
+                norm += kv.Value * kv.Value;
+            }
+            norm = Math.Sqrt(norm);
+
+            double? angle = null;
+            if (previous != null && previous.Count > 0 && gradient.Count > 0)
+            {
+                angle = ComputeGradientAngle(previous, gradient);
+                if (double.IsNaN(angle.Value))
+                    angle = null;
+            }
+
+            string angleValue = angle.HasValue ? FormatCsvValue(angle.Value) : string.Empty;
+            writer.WriteLine(string.Join(',',
+                (i + 1).ToString(CultureInfo.InvariantCulture),
+                FormatCsvValue(norm),
+                angleValue));
+
+            previous = new Dictionary<int, double>(gradient);
+        }
+    }
+
+    private static ReconstructionFrame GetFrameForResult(ReconstructionResult result, ReconstructionFrame fallback)
+        => result.Frames.LastOrDefault() ?? fallback;
+
+    private static List<(string Label, string Value)> CreateRangeMetadata(ConductivityDistribution distribution)
+    {
+        var stats = ComputeStatistics(distribution.Conductivities);
+        return new List<(string, string)>
+        {
+            ("Minimum σ", FormatNullableDouble(stats.Min)),
+            ("Maximum σ", FormatNullableDouble(stats.Max)),
+            ("Mean σ", FormatNullableDouble(stats.Mean))
+        };
+    }
+
+    private static string FormatCsvValue(double value)
+    {
+        if (double.IsNaN(value))
+            return string.Empty;
+        if (double.IsPositiveInfinity(value))
+            return "Infinity";
+        if (double.IsNegativeInfinity(value))
+            return "-Infinity";
+        return value.ToString("G17", CultureInfo.InvariantCulture);
+    }
+
+    private static string FormatDouble(double value, string format = "F3")
+        => value.ToString(format, CultureInfo.InvariantCulture);
+
+    private static string FormatNullableDouble(double? value, string format = "F3")
+        => value.HasValue ? FormatDouble(value.Value, format) : "—";
+
+    private static (double? Min, double? Max, double? Mean) ComputeStatistics(IReadOnlyDictionary<int, double> values)
+    {
+        if (values == null || values.Count == 0)
+            return (null, null, null);
+
+        double min = double.PositiveInfinity;
+        double max = double.NegativeInfinity;
+        double sum = 0.0;
+        int count = 0;
+
+        foreach (var value in values.Values)
+        {
+            if (double.IsNaN(value) || double.IsInfinity(value))
+                continue;
+
+            if (value < min)
+                min = value;
+            if (value > max)
+                max = value;
+
+            sum += value;
+            count++;
+        }
+
+        if (count == 0)
+            return (null, null, null);
+
+        double mean = sum / count;
+        return (min, max, mean);
+    }
+
+    private static double CalculateResidual(ConductivityDistribution reconstructed, ConductivityDistribution original)
+    {
+        double sum = 0.0;
+        foreach (var kv in reconstructed.Conductivities)
+        {
+            original.Conductivities.TryGetValue(kv.Key, out double origVal);
+            double diff = kv.Value - origVal;
+            sum += diff * diff;
+        }
+        return Math.Sqrt(sum);
+    }
+
+    private static double CalculateCorrelation(ConductivityDistribution reconstructed, ConductivityDistribution original)
+    {
+        if (reconstructed.Conductivities.Count == 0)
+            return 0.0;
+
+        double sumReconstructed = 0.0;
+        double sumOriginal = 0.0;
+        foreach (var kv in reconstructed.Conductivities)
+        {
+            sumReconstructed += kv.Value;
+            original.Conductivities.TryGetValue(kv.Key, out double origVal);
+            sumOriginal += origVal;
+        }
+
+        int count = reconstructed.Conductivities.Count;
+        double meanReconstructed = sumReconstructed / count;
+        double meanOriginal = sumOriginal / count;
+
+        double numerator = 0.0;
+        double sumSqReconstructed = 0.0;
+        double sumSqOriginal = 0.0;
+        foreach (var kv in reconstructed.Conductivities)
+        {
+            original.Conductivities.TryGetValue(kv.Key, out double origVal);
+            double centeredReconstructed = kv.Value - meanReconstructed;
+            double centeredOriginal = origVal - meanOriginal;
+            numerator += centeredReconstructed * centeredOriginal;
+            sumSqReconstructed += centeredReconstructed * centeredReconstructed;
+            sumSqOriginal += centeredOriginal * centeredOriginal;
+        }
+
+        double denominator = Math.Sqrt(sumSqReconstructed) * Math.Sqrt(sumSqOriginal);
+        if (denominator <= 1e-12)
+            return double.NaN;
+
+        double correlation = numerator / denominator;
+        return double.IsNaN(correlation) ? double.NaN : correlation;
+    }
+
+    private static DistributionMetrics? ComputeInitialDistributionMetrics(ReconstructionResult snapshot)
+    {
+        var initialResult = new ReconstructionResult(snapshot.OriginalConductivityDistribution,
+                                                     snapshot.InitialConductivitiyDistribution,
+                                                     snapshot.InitialConductivitiyDistribution,
+                                                     snapshot.Frames);
+        return ComputeDistributionMetrics(initialResult, CancellationToken.None);
+    }
+
+    private static DistributionMetrics? ComputeDistributionMetrics(ReconstructionResult result, CancellationToken token)
+    {
+        var reconstructed = result.ReconstructedConductivityDistribution.Conductivities;
+        if (reconstructed.Count == 0)
+            return null;
+
+        var original = result.OriginalConductivityDistribution.Conductivities;
+        var initial = result.InitialConductivitiyDistribution.Conductivities;
+
+        int count = reconstructed.Count;
+        double[] recon = new double[count];
+        double[] orig = new double[count];
+        double[] init = new double[count];
+
+        double sumSq = 0.0;
+        double sumAbs = 0.0;
+        double sumPct = 0.0;
+        double maxAbs = 0.0;
+
+        int index = 0;
+        foreach (var kv in reconstructed)
+        {
+            token.ThrowIfCancellationRequested();
+
+            double r = kv.Value;
+            original.TryGetValue(kv.Key, out double o);
+            initial.TryGetValue(kv.Key, out double i);
+
+            recon[index] = r;
+            orig[index] = o;
+            init[index] = i;
+
+            double diff = r - o;
+            sumSq += diff * diff;
+            sumAbs += Math.Abs(diff);
+            sumPct += Math.Abs(diff) / Math.Max(Math.Abs(o), 1e-6);
+
+            maxAbs = Math.Max(maxAbs, Math.Abs(o));
+            maxAbs = Math.Max(maxAbs, Math.Abs(r));
+            index++;
+        }
+
+        double mse = sumSq / Math.Max(count, 1);
+        double rmse = Math.Sqrt(mse);
+        double mae = sumAbs / Math.Max(count, 1);
+        double mape = sumPct / Math.Max(count, 1);
+
+        double psnr;
+        if (mse <= 1e-12)
+        {
+            psnr = double.PositiveInfinity;
+        }
+        else
+        {
+            double peak = maxAbs <= 1e-12 ? 1.0 : maxAbs;
+            psnr = 20.0 * Math.Log10(peak / Math.Sqrt(mse));
+        }
+
+        double initialRmse = 0.0;
+        double initialMae = 0.0;
+        for (int i = 0; i < count; i++)
+        {
+            double diff = init[i] - orig[i];
+            initialRmse += diff * diff;
+            initialMae += Math.Abs(diff);
+        }
+
+        initialRmse = Math.Sqrt(initialRmse / Math.Max(count, 1));
+        initialMae /= Math.Max(count, 1);
+
+        double rmseImprovement = initialRmse - rmse;
+        double maeImprovement = initialMae - mae;
+
+        double ssim = CalculateSsim(recon, orig);
+
+        return new DistributionMetrics(rmse,
+                                       mae,
+                                       mape,
+                                       psnr,
+                                       ssim,
+                                       rmseImprovement,
+                                       maeImprovement);
+    }
+
+    private static double CalculateSsim(double[] recon, double[] orig)
+    {
+        if (recon.Length == 0 || orig.Length == 0)
+            return double.NaN;
+
+        double meanRecon = recon.Average();
+        double meanOrig = orig.Average();
+
+        double varianceRecon = 0.0;
+        double varianceOrig = 0.0;
+        double covariance = 0.0;
+
+        for (int i = 0; i < recon.Length; i++)
+        {
+            double centeredRecon = recon[i] - meanRecon;
+            double centeredOrig = orig[i] - meanOrig;
+            varianceRecon += centeredRecon * centeredRecon;
+            varianceOrig += centeredOrig * centeredOrig;
+            covariance += centeredRecon * centeredOrig;
+        }
+
+        varianceRecon /= recon.Length;
+        varianceOrig /= orig.Length;
+        covariance /= recon.Length;
+
+        const double c1 = 0.01 * 0.01;
+        const double c2 = 0.03 * 0.03;
+
+        double numerator = (2 * meanRecon * meanOrig + c1) * (2 * covariance + c2);
+        double denominator = (meanRecon * meanRecon + meanOrig * meanOrig + c1) * (varianceRecon + varianceOrig + c2);
+
+        return denominator <= 0.0 ? double.NaN : numerator / denominator;
+    }
+
+    private static double ComputeGradientAngle(Dictionary<int, double> previous, Dictionary<int, double> current)
+    {
+        double dot = 0.0;
+        double prevNorm = 0.0;
+        double currNorm = 0.0;
+
+        foreach (var kv in current)
+        {
+            double value = kv.Value;
+            currNorm += value * value;
+            if (previous.TryGetValue(kv.Key, out double prevValue))
+                dot += prevValue * value;
+        }
+
+        foreach (var kv in previous)
+        {
+            double value = kv.Value;
+            prevNorm += value * value;
+        }
+
+        double denom = Math.Sqrt(prevNorm) * Math.Sqrt(currNorm);
+        if (denom <= 1e-12)
+            return double.NaN;
+
+        double cosTheta = dot / denom;
+        cosTheta = Math.Clamp(cosTheta, -1.0, 1.0);
+        return Math.Acos(cosTheta) * (180.0 / Math.PI);
+    }
+
+    private readonly record struct DistributionMetrics(double Rmse,
+                                                        double Mae,
+                                                        double Mape,
+                                                        double Psnr,
+                                                        double Ssim,
+                                                        double RmseImprovement,
+                                                        double MaeImprovement);
+
+    private readonly record struct ReconstructionIterationSnapshot(int Iteration,
+                                                                    ReconstructionResult Result,
+                                                                    DistributionMetrics? Metrics,
+                                                                    double Residual,
+                                                                    double Correlation);
+}

--- a/DataAccessLayer/Settings.cs
+++ b/DataAccessLayer/Settings.cs
@@ -9,7 +9,8 @@ namespace DataAccessLayer
             return Utility.Composition.Settings.ApplyContainerRegistration()
                 .RegisterType<IDAQRepository, DAQRepository>()
                 .RegisterType<IMeshRepository, MeshRepository>()
-                .RegisterType<IReconstructionRepository, ReconstructionRepository>();
+                .RegisterType<IReconstructionRepository, ReconstructionRepository>()
+                .RegisterType<IReconstructionExportRepository, ReconstructionExportRepository>();
 
         }
     }

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -1,6 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using ElectricalImpedanceTomography.Helpers;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Storage;
 using ServiceLayer;
@@ -13,6 +12,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -23,6 +23,8 @@ using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Factories;
 using Utility.Classes.Measurement;
 using Utility.Classes.ReconstructionParameters;
+using Utility.Exports;
+using Utility.Rendering;
 
 using Workspace = Utility.Classes.Application.Workspace;
 using Timer = System.Timers.Timer;
@@ -32,6 +34,7 @@ namespace ElectricalImpedanceTomography.ViewModels
     public partial class ReconstructionPageViewModel : BaseReconstructionPageViewModel
     {
         private readonly IReconstructionService _reconstructionService;
+        private readonly IReconstructionExportService _exportService;
 
         private readonly Stopwatch _reconstructionStopwatch = new();
         private readonly Timer _elapsedTimer;
@@ -193,9 +196,11 @@ namespace ElectricalImpedanceTomography.ViewModels
             UpdateVideoExportPhase();
         }
 
-        public ReconstructionPageViewModel(IReconstructionService reconstructionService)
+        public ReconstructionPageViewModel(IReconstructionService reconstructionService,
+                                           IReconstructionExportService exportService)
         {
             _reconstructionService = reconstructionService;
+            _exportService = exportService;
 
             _elapsedTimer = new Timer(200)
             {
@@ -1148,6 +1153,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             public double MaeImprovement { get; }
         }
 
+
         private readonly struct MeasurementMetrics
         {
             public MeasurementMetrics(double rmse, double mae, double mape, double? misfit)
@@ -1604,6 +1610,24 @@ namespace ElectricalImpedanceTomography.ViewModels
                 return VideoExportResult.CreateFailure("Export Failed", ex.Message);
             }
         }
+
+        public Task<DataExportResult> ExportReconstructionDataAsync(PotentialDisplayMode mode)
+        {
+            string rootDirectory = FileSystem.Current.AppDataDirectory;
+            return _exportService.ExportAsync(rootDirectory, mode);
+        }
+
+        private static DistributionMetrics? ComputeInitialDistributionMetrics(ReconstructionResult snapshot)
+        {
+            var initialResult = new ReconstructionResult(snapshot.OriginalConductivityDistribution,
+                                                         snapshot.InitialConductivitiyDistribution,
+                                                         snapshot.InitialConductivitiyDistribution,
+                                                         snapshot.Frames);
+            return ComputeDistributionMetrics(initialResult, CancellationToken.None);
+        }
+
+        private static ReconstructionFrame GetFrameForResult(ReconstructionResult result, ReconstructionFrame fallback)
+            => result.Frames.LastOrDefault() ?? fallback;
 
         public void BeginVideoExportProgress()
         {

--- a/ElectricalImpedanceTomography/Views/ExportOptionsPopup.xaml
+++ b/ElectricalImpedanceTomography/Views/ExportOptionsPopup.xaml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<toolkit:Popup
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:toolkit="clr-namespace:CommunityToolkit.Maui.Views;assembly=CommunityToolkit.Maui"
+    x:Class="ElectricalImpedanceTomography.Views.ExportOptionsPopup"
+    CanBeDismissedByTappingOutsideOfPopup="True"
+    Color="Transparent">
+
+    <Border
+        StrokeShape="RoundRectangle 18"
+        StrokeThickness="0"
+        Padding="24"
+        WidthRequest="360"
+        BackgroundColor="{AppThemeBinding Light=#F8FAFC, Dark=#111827}">
+        <Border.Shadow>
+            <Shadow
+                Brush="{AppThemeBinding Light=#1F2937, Dark=#000000}"
+                Radius="20"
+                Opacity="0.25" />
+        </Border.Shadow>
+
+        <VerticalStackLayout Spacing="18">
+            <Label
+                Text="Export Reconstruction"
+                FontSize="20"
+                FontAttributes="Bold"
+                HorizontalOptions="Center"
+                TextColor="{AppThemeBinding Light=#0F172A, Dark=#E2E8F0}" />
+
+            <Label
+                Text="Choose the export format for your reconstruction data."
+                FontSize="14"
+                TextColor="{AppThemeBinding Light=#334155, Dark=#CBD5F5}"
+                LineBreakMode="WordWrap" />
+
+            <VerticalStackLayout Spacing="12">
+                <Button
+                    Text="Export Video"
+                    Clicked="OnExportVideoClicked"
+                    BackgroundColor="{AppThemeBinding Light=#2563EB, Dark=#1D4ED8}"
+                    TextColor="White"
+                    CornerRadius="10"
+                    Padding="18,10"
+                    FontAttributes="Bold" />
+                <Button
+                    Text="Export CSV Bundle"
+                    Clicked="OnExportCsvClicked"
+                    BackgroundColor="{AppThemeBinding Light=#10B981, Dark=#047857}"
+                    TextColor="White"
+                    CornerRadius="10"
+                    Padding="18,10"
+                    FontAttributes="Bold" />
+            </VerticalStackLayout>
+
+            <Button
+                Text="Cancel"
+                Clicked="OnCancelClicked"
+                BackgroundColor="{AppThemeBinding Light=#E2E8F0, Dark=#1F2A3A}"
+                TextColor="{AppThemeBinding Light=#1E293B, Dark=#E2E8F0}"
+                CornerRadius="10"
+                Padding="18,10" />
+        </VerticalStackLayout>
+    </Border>
+</toolkit:Popup>

--- a/ElectricalImpedanceTomography/Views/ExportOptionsPopup.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ExportOptionsPopup.xaml.cs
@@ -1,0 +1,27 @@
+using System;
+using CommunityToolkit.Maui.Views;
+
+namespace ElectricalImpedanceTomography.Views;
+
+public partial class ExportOptionsPopup : Popup
+{
+    public ExportOptionsPopup()
+    {
+        InitializeComponent();
+    }
+
+    private void OnExportVideoClicked(object? sender, EventArgs e)
+        => Close(ExportMode.Video);
+
+    private void OnExportCsvClicked(object? sender, EventArgs e)
+        => Close(ExportMode.Csv);
+
+    private void OnCancelClicked(object? sender, EventArgs e)
+        => Close(null);
+}
+
+public enum ExportMode
+{
+    Video,
+    Csv
+}

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -310,12 +310,12 @@
                         </Picker>
                         <Border Grid.Column="7" Grid.Row="1"  Background="Transparent" Stroke="Transparent">
                             <Button x:Name="ExportVideoButton"
-                                    Text="Export Video"
+                                    Text="Export"
                                     Margin="10"
                                     BackgroundColor="#3A7CA5"
                                     TextColor="White"
                                     FontAttributes="Bold"
-                                    Clicked="OnExportVideoClicked"
+                                    Clicked="OnExportClicked"
                                     IsEnabled="False"/>
                         </Border>
                         <Slider x:Name="PlaybackSlider"

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -1,18 +1,20 @@
 using CommunityToolkit.Maui.Views;
 using ElectricalImpedanceTomography.Extensions;
-using ElectricalImpedanceTomography.Helpers;
 using ElectricalImpedanceTomography.ViewModels;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
 using SkiaSharp.Views.Maui.Controls;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Rendering;
 
 using Workspace = Utility.Classes.Application.Workspace;
 
@@ -1359,12 +1361,30 @@ public partial class ReconstructionPage : ContentPage
         return Math.Sqrt(sum);
     }
 
-    private async void OnExportVideoClicked(object sender, EventArgs e)
+    private async void OnExportClicked(object sender, EventArgs e)
     {
         await AnimateButtonAsync(sender);
 
         ExportVideoButton.IsEnabled = false;
 
+        var choice = await this.ShowPopupAsync(new ExportOptionsPopup());
+
+        switch (choice)
+        {
+            case ExportMode.Video:
+                await HandleVideoExportAsync();
+                break;
+            case ExportMode.Csv:
+                await HandleCsvExportAsync();
+                break;
+            default:
+                UpdateExportButtonState();
+                break;
+        }
+    }
+
+    private async Task HandleVideoExportAsync()
+    {
         var popup = new VideoExportProgressPopup(_viewModel,
             PotentialDistributionCanvas.CanvasSize,
             PotentialColorbarCanvas.CanvasSize,
@@ -1387,6 +1407,33 @@ public partial class ReconstructionPage : ContentPage
             string title = failure.ErrorTitle ?? "Export Failed";
             string message = failure.ErrorMessage ?? "Unknown error.";
             await DisplayAlert(title, message, "OK");
+        }
+    }
+
+    private async Task HandleCsvExportAsync()
+    {
+        try
+        {
+            var exportResult = await _viewModel.ExportReconstructionDataAsync(_potMode);
+
+            UpdateExportButtonState();
+
+            if (exportResult.Success)
+            {
+                string message = $"Data saved to:\n{exportResult.DirectoryPath}";
+                await DisplayAlert("Export Complete", message, "OK");
+            }
+            else
+            {
+                string title = exportResult.ErrorTitle ?? "Export Failed";
+                string message = exportResult.ErrorMessage ?? "Unknown error.";
+                await DisplayAlert(title, message, "OK");
+            }
+        }
+        catch (Exception ex)
+        {
+            UpdateExportButtonState();
+            await DisplayAlert("Export Failed", ex.Message, "OK");
         }
     }
 

--- a/ElectricalImpedanceTomography/Views/VideoExportProgressPopup.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/VideoExportProgressPopup.xaml.cs
@@ -1,8 +1,8 @@
 using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Views;
-using ElectricalImpedanceTomography.Helpers;
 using ElectricalImpedanceTomography.ViewModels;
 using SkiaSharp;
+using Utility.Rendering;
 
 namespace ElectricalImpedanceTomography.Views;
 

--- a/ServiceLayer/IReconstructionExportService.cs
+++ b/ServiceLayer/IReconstructionExportService.cs
@@ -1,0 +1,11 @@
+using Utility.Exports;
+using Utility.Rendering;
+
+namespace ServiceLayer;
+
+public interface IReconstructionExportService
+{
+    Task<DataExportResult> ExportAsync(string rootDirectory,
+                                       PotentialDisplayMode displayMode,
+                                       CancellationToken cancellationToken = default);
+}

--- a/ServiceLayer/ReconstructionExportService.cs
+++ b/ServiceLayer/ReconstructionExportService.cs
@@ -1,0 +1,48 @@
+using DataAccessLayer;
+using Utility.Classes;
+using Utility.Exports;
+using Utility.Rendering;
+
+namespace ServiceLayer;
+
+public sealed class ReconstructionExportService : IReconstructionExportService
+{
+    private readonly IReconstructionExportRepository _repository;
+
+    public ReconstructionExportService(IReconstructionExportRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public Task<DataExportResult> ExportAsync(string rootDirectory,
+                                              PotentialDisplayMode displayMode,
+                                              CancellationToken cancellationToken = default)
+    {
+        var results = Workspace.GetReconstructionResults().ToList();
+        if (results.Count == 0)
+            return Task.FromResult(DataExportResult.CreateFailure("No Results", "There are no reconstruction results to export."));
+
+        var discretization = Workspace.GetDiscretization();
+        if (discretization == null)
+            return Task.FromResult(DataExportResult.CreateFailure("No Mesh", "Unable to determine the discretization for rendering."));
+
+        var frames = Workspace.GetReconstructionFrames().ToList();
+        if (frames.Count == 0)
+            frames = results.SelectMany(r => r.Frames).ToList();
+
+        var renderFrame = frames.LastOrDefault();
+        if (renderFrame == null)
+            return Task.FromResult(DataExportResult.CreateFailure("No Frames", "No reconstruction frames are available for export."));
+
+        string directory = Path.Combine(rootDirectory, $"reconstruction_export_{DateTime.Now:yyyyMMdd_HHmmss}");
+
+        var request = new ReconstructionExportRequest(discretization,
+                                                      frames,
+                                                      results,
+                                                      renderFrame,
+                                                      displayMode,
+                                                      directory);
+
+        return Task.Run(() => _repository.ExportReconstructionData(request), cancellationToken);
+    }
+}

--- a/ServiceLayer/Settings.cs
+++ b/ServiceLayer/Settings.cs
@@ -10,6 +10,7 @@ namespace ServiceLayer
             return BusinessLayer.Settings.ApplyContainerRegistration()
                 .RegisterType<IDAQService, DAQService>()
                 .RegisterType<IReconstructionService, ReconstructionService>()
+                .RegisterType<IReconstructionExportService, ReconstructionExportService>()
                 .RegisterType<ILogger, WorkspaceLogger>();
         }
     }

--- a/Utility/Exports/DataExportResult.cs
+++ b/Utility/Exports/DataExportResult.cs
@@ -1,0 +1,13 @@
+namespace Utility.Exports;
+
+public sealed record DataExportResult(bool Success,
+                                      string? DirectoryPath,
+                                      string? ErrorTitle,
+                                      string? ErrorMessage)
+{
+    public static DataExportResult CreateSuccess(string directoryPath)
+        => new(true, directoryPath, null, null);
+
+    public static DataExportResult CreateFailure(string title, string message)
+        => new(false, null, title, message);
+}

--- a/Utility/Rendering/PotentialDisplayMode.cs
+++ b/Utility/Rendering/PotentialDisplayMode.cs
@@ -1,4 +1,4 @@
-namespace ElectricalImpedanceTomography.Helpers;
+namespace Utility.Rendering;
 
 public enum PotentialDisplayMode
 {

--- a/Utility/Rendering/ReconstructionVideoRenderer.cs
+++ b/Utility/Rendering/ReconstructionVideoRenderer.cs
@@ -9,7 +9,7 @@ using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Measurement;
 
-namespace ElectricalImpedanceTomography.Helpers;
+namespace Utility.Rendering;
 
 internal static class ReconstructionVideoRenderer
 {

--- a/Utility/Utility.csproj
+++ b/Utility/Utility.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />
     <PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add a reconstruction export repository and service to encapsulate CSV bundle generation
- relocate shared rendering helpers and result models into the Utility project for reuse across layers
- update the reconstruction page to call the new export service and register the new dependencies

## Testing
- `dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj` *(fails: dotnet CLI is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68efa665fdec8333abb8c1cd493302c6