### PR TITLE
Add BFGS quasi-Newton optimizer

### DIFF
--- a/Utility/Classes/Factories/NumericalOptimizerFactory.cs
+++ b/Utility/Classes/Factories/NumericalOptimizerFactory.cs
@@ -21,6 +21,7 @@ namespace Utility.Classes.Factories
             NumericOptimizer.HomotopyContinuation => CreateHomotopyContinuationOptimizer(sigmaPrior ?? throw new NullReferenceException()),
             NumericOptimizer.SimulatedAnnealing => CreateSimulatedAnnealingOptimizer(),
             NumericOptimizer.ParticleSwarm => CreateParticleSwarmOptimizer(),
+            NumericOptimizer.BFGS => CreateBfgsOptimizer(),
             _ => throw new NotSupportedException()
         };
 
@@ -81,11 +82,20 @@ namespace Utility.Classes.Factories
 
             return optimizer;
         }
-        private static ParticleSwarmOptimizer CreateParticleSwarmOptimizer() 
+        private static ParticleSwarmOptimizer CreateParticleSwarmOptimizer()
         {
             var optimizer = new ParticleSwarmOptimizer();
 
             Workspace.AddLogMessage("NumericOptimizerFactory","Created Particle Swarm Numeric Optimizer object.");
+
+            return optimizer;
+        }
+
+        private static BfgsOptimizer CreateBfgsOptimizer()
+        {
+            var optimizer = new BfgsOptimizer();
+
+            Workspace.AddLogMessage("NumericOptimizerFactory","Created BFGS Numeric Optimizer object.");
 
             return optimizer;
         }

--- a/Utility/Classes/ReconstructionParameters/NumericOptimizer.cs
+++ b/Utility/Classes/ReconstructionParameters/NumericOptimizer.cs
@@ -9,7 +9,8 @@
         GlobalTunneling = 5,
         HomotopyContinuation = 6,
         SimulatedAnnealing = 7,
-        ParticleSwarm = 8
+        ParticleSwarm = 8,
+        BFGS = 9
     };
 
     /// <summary>
@@ -115,6 +116,239 @@
                 next[id] = nextValue;
             }
             return new ConductivityDistribution(next);
+        }
+    }
+
+    /// <summary>
+    /// BFGS quasi-Newton optimizer. Maintains an inverse Hessian approximation H⁻¹
+    /// and applies σ_{k+1} = σ_k - α H⁻¹ ∇J.
+    /// </summary>
+    public sealed class BfgsOptimizer : INumericOptimizer
+    {
+        private const double _minConductivity = 1e-6;
+        private const double _maxConductivity = 10.0;
+        private const double _updateEpsilon = 1e-12;
+
+        private List<int>? _elementOrder;
+        private double[,]? _inverseHessian;
+        private double[]? _lastSigmaVector;
+        private double[]? _lastGradientVector;
+
+        public ConductivityDistribution OptimizationStep(
+            ConductivityDistribution currentSigma,
+            ConductivityDistribution totalGradient,
+            double stepSize)
+        {
+            EnsureStructure(currentSigma);
+
+            if (_elementOrder == null || _inverseHessian == null)
+            {
+                return new ConductivityDistribution(currentSigma.Conductivities);
+            }
+
+            var sigmaVector = BuildVector(currentSigma);
+            var gradientVector = BuildVector(totalGradient);
+
+            UpdateInverseHessianApproximation(sigmaVector, gradientVector);
+
+            var searchDirection = MultiplyMatrixVector(_inverseHessian, gradientVector);
+            var next = new Dictionary<int, double>(currentSigma.Conductivities.Count);
+
+            for (int i = 0; i < _elementOrder.Count; i++)
+            {
+                int id = _elementOrder[i];
+                double conductivity = sigmaVector[i];
+
+                double rawStep = -stepSize * searchDirection[i];
+                double candidate = conductivity + rawStep;
+
+                candidate = NumericOptimizerGuards.ClipExcessiveGrowth(conductivity, candidate);
+                candidate = Math.Max(_minConductivity, Math.Min(_maxConductivity, candidate));
+
+                if (!double.IsFinite(candidate))
+                {
+                    candidate = conductivity;
+                }
+
+                next[id] = candidate;
+            }
+
+            _lastSigmaVector = sigmaVector;
+            _lastGradientVector = gradientVector;
+
+            return new ConductivityDistribution(next);
+        }
+
+        private void EnsureStructure(ConductivityDistribution sigma)
+        {
+            bool requiresReset = _elementOrder == null
+                || _elementOrder.Count != sigma.Conductivities.Count
+                || !_elementOrder.All(sigma.Conductivities.ContainsKey);
+
+            if (requiresReset)
+            {
+                _elementOrder = sigma.Conductivities.Keys.OrderBy(id => id).ToList();
+                ResetInverseHessian();
+                _lastSigmaVector = null;
+                _lastGradientVector = null;
+                return;
+            }
+
+            if (_inverseHessian == null || _inverseHessian.GetLength(0) != _elementOrder.Count)
+            {
+                ResetInverseHessian();
+            }
+        }
+
+        private void ResetInverseHessian()
+        {
+            if (_elementOrder == null)
+            {
+                _inverseHessian = null;
+                return;
+            }
+
+            int n = _elementOrder.Count;
+            _inverseHessian = new double[n, n];
+            for (int i = 0; i < n; i++)
+            {
+                _inverseHessian[i, i] = 1.0;
+            }
+        }
+
+        private double[] BuildVector(ConductivityDistribution distribution)
+        {
+            if (_elementOrder == null)
+            {
+                return Array.Empty<double>();
+            }
+
+            var vector = new double[_elementOrder.Count];
+            for (int i = 0; i < _elementOrder.Count; i++)
+            {
+                int id = _elementOrder[i];
+                vector[i] = distribution.GetConductivity(id);
+            }
+
+            return vector;
+        }
+
+        private void UpdateInverseHessianApproximation(double[] sigmaVector, double[] gradientVector)
+        {
+            if (_inverseHessian == null || _elementOrder == null)
+            {
+                return;
+            }
+
+            if (_lastSigmaVector == null || _lastGradientVector == null)
+            {
+                return;
+            }
+
+            var s = Subtract(sigmaVector, _lastSigmaVector);
+            var y = Subtract(gradientVector, _lastGradientVector);
+
+            double ys = Dot(y, s);
+            double yy = Dot(y, y);
+            double ss = Dot(s, s);
+
+            if (!double.IsFinite(ys) || !double.IsFinite(yy) || !double.IsFinite(ss))
+            {
+                ResetInverseHessian();
+                return;
+            }
+
+            if (ss < _updateEpsilon || yy < _updateEpsilon || Math.Abs(ys) < _updateEpsilon)
+            {
+                return;
+            }
+
+            if (ys <= 0)
+            {
+                ResetInverseHessian();
+                return;
+            }
+
+            double rho = 1.0 / ys;
+            var currentH = _inverseHessian;
+            var Hy = MultiplyMatrixVector(currentH, y);
+            double yHy = Dot(y, Hy);
+
+            if (!double.IsFinite(rho) || !double.IsFinite(yHy))
+            {
+                ResetInverseHessian();
+                return;
+            }
+
+            int n = _elementOrder.Count;
+            var updated = new double[n, n];
+
+            double scale = (1.0 + rho * yHy) * rho;
+
+            for (int i = 0; i < n; i++)
+            {
+                for (int j = 0; j < n; j++)
+                {
+                    double hij = currentH[i, j];
+                    double term1 = rho * Hy[i] * s[j];
+                    double term2 = rho * s[i] * Hy[j];
+                    double term3 = scale * s[i] * s[j];
+
+                    double candidate = hij - term1 - term2 + term3;
+                    if (!double.IsFinite(candidate))
+                    {
+                        candidate = hij;
+                    }
+
+                    updated[i, j] = candidate;
+                }
+            }
+
+            _inverseHessian = updated;
+        }
+
+        private static double[] Subtract(double[] first, double[] second)
+        {
+            int n = Math.Min(first.Length, second.Length);
+            var result = new double[n];
+            for (int i = 0; i < n; i++)
+            {
+                result[i] = first[i] - second[i];
+            }
+
+            return result;
+        }
+
+        private static double Dot(double[] first, double[] second)
+        {
+            int n = Math.Min(first.Length, second.Length);
+            double sum = 0.0;
+            for (int i = 0; i < n; i++)
+            {
+                sum += first[i] * second[i];
+            }
+
+            return sum;
+        }
+
+        private static double[] MultiplyMatrixVector(double[,] matrix, double[] vector)
+        {
+            int rows = matrix.GetLength(0);
+            int cols = matrix.GetLength(1);
+            var result = new double[rows];
+
+            for (int i = 0; i < rows; i++)
+            {
+                double sum = 0.0;
+                for (int j = 0; j < cols && j < vector.Length; j++)
+                {
+                    sum += matrix[i, j] * vector[j];
+                }
+
+                result[i] = sum;
+            }
+
+            return result;
         }
     }
 

--- a/Utility/Tests/NumericOptimizerTests.cs
+++ b/Utility/Tests/NumericOptimizerTests.cs
@@ -9,7 +9,7 @@ namespace Utility.Tests
         [Fact]
         public void GradientBased_Clamps_And_Steps()
         {
-            var opt = new GradientBasedOptimizer(); // min=1e-6, max=10.0  
+            var opt = new GradientBasedOptimizer(); // min=1e-6, max=10.0
             var σk = TestData.Sigma((0, 9.9), (1, 1.0), (2, 1e-7));
             var g = TestData.Grad((0, -10.0), (1, 2.0), (2, 10.0)); // negative grad increases value
 
@@ -20,6 +20,27 @@ namespace Utility.Tests
             Assert.Equal(10.0, σnext.GetConductivity(0), 12);
             Assert.Equal(0.6, σnext.GetConductivity(1), 12);
             Assert.Equal(1e-6, σnext.GetConductivity(2), 12);
+        }
+
+        [Fact]
+        public void Bfgs_Adjusts_Step_Length_From_Curvature()
+        {
+            var opt = new BfgsOptimizer();
+            const double optimum = 1.0;
+            const double curvature = 4.0;
+
+            var σ0 = TestData.Sigma((0, 5.0));
+            var g0 = QuadraticGradient(σ0, optimum, curvature);
+            var σ1 = opt.OptimizationStep(σ0, g0, 0.1);
+
+            var g1 = QuadraticGradient(σ1, optimum, curvature);
+            var σ2 = opt.OptimizationStep(σ1, g1, 0.1);
+
+            double firstRatio = Math.Abs((σ0.GetConductivity(0) - σ1.GetConductivity(0)) / (0.1 * g0.GetConductivity(0)));
+            double secondRatio = Math.Abs((σ1.GetConductivity(0) - σ2.GetConductivity(0)) / (0.1 * g1.GetConductivity(0)));
+
+            Assert.InRange(firstRatio, 0.99, 1.01); // identity inverse Hessian on first step
+            Assert.InRange(secondRatio, 0.24, 0.26); // approximates 1 / curvature after update
         }
 
         [Fact]
@@ -126,6 +147,16 @@ namespace Utility.Tests
             var σ1 = opt.OptimizationStep(σ0, g, 0.0);
             Assert.Equal(1.0, σ1.GetConductivity(0), 12);
             Assert.Equal(2.0, σ1.GetConductivity(1), 12);
+        }
+
+        private static ConductivityDistribution QuadraticGradient(
+            ConductivityDistribution sigma,
+            double optimum,
+            double curvature)
+        {
+            double value = sigma.GetConductivity(0);
+            double gradient = curvature * (value - optimum);
+            return TestData.Grad((0, gradient));
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a BFGS quasi-Newton optimizer that maintains an inverse Hessian approximation
- expose the new optimizer through the numeric optimizer factory and enumeration
- cover the optimizer with a curvature-sensitive unit test

## Testing
- `dotnet test Utility/Utility.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f562e8caa083338aed657797dc3d93