### PR TITLE
Support multi-node FEM electrodes

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -76,6 +76,9 @@ namespace ElectricalImpedanceTomography.ViewModels
         private double electrodeSize = 0.3;
 
         [ObservableProperty]
+        private int femElectrodeNodeCount = 1;
+
+        [ObservableProperty]
         private string hoveredElementInfo = string.Empty;
 
         [ObservableProperty]
@@ -200,8 +203,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                 foreach (var el in _currentDiscretization.GetElectrodes())
                     el.ZContact = ElectrodeContactImpedance;
                 if (_currentDiscretization is FEMMesh fem)
-                    foreach (var el in fem.ElectrodesTyped)
-                        el.Length = ElectrodeSize;
+                    ApplyFemElectrodeLayout(fem);
             }
         }
 
@@ -233,16 +235,21 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             if (_customPerimeter != null && _customPerimeter.Count > 2)
             {
-                var mesh = MeshFactory.CreatePolygonFEMMesh(_customPerimeter, Layers, ElectrodeCount);
+                var mesh = MeshFactory.CreatePolygonFEMMesh(_customPerimeter, Layers, ElectrodeCount, FemElectrodeNodeCount, ElectrodeSize);
                 return mesh;
             }
 
             return SelectedGeometry switch
             {
-                GeometryType.Circular => MeshFactory.CreateCircularFEMMesh(Layers, BoundaryFEMVertexCount, ElectrodeCount),
-                GeometryType.Rectangular => MeshFactory.CreateRectangularFEMMesh(Nx, Ny, ElectrodeCount, Layers),
-                _ => MeshFactory.CreateCircularFEMMesh(Layers, BoundaryFEMVertexCount, ElectrodeCount)
+                GeometryType.Circular => MeshFactory.CreateCircularFEMMesh(Layers, BoundaryFEMVertexCount, ElectrodeCount, FemElectrodeNodeCount, ElectrodeSize),
+                GeometryType.Rectangular => MeshFactory.CreateRectangularFEMMesh(Nx, Ny, ElectrodeCount, Layers, FemElectrodeNodeCount, ElectrodeSize),
+                _ => MeshFactory.CreateCircularFEMMesh(Layers, BoundaryFEMVertexCount, ElectrodeCount, FemElectrodeNodeCount, ElectrodeSize)
             };
+        }
+
+        private void ApplyFemElectrodeLayout(FEMMesh mesh)
+        {
+            mesh.PlaceEquidistantElectrodes(ElectrodeCount, ElectrodeContactImpedance, ElectrodeSize, Math.Max(1, FemElectrodeNodeCount));
         }
 
         private LBMGrid GenerateLBMGrid()
@@ -304,17 +311,40 @@ namespace ElectricalImpedanceTomography.ViewModels
         public void RefreshFemElectrodes()
         {
             if (_currentDiscretization is not FEMMesh mesh) return;
-            var verts = mesh.Vertices.Where(v => v.IsElectrode).ToList();
-            var electrodes = new List<FEMElectrode>();
-            for (int i = 0; i < verts.Count; i++)
+
+            var templates = mesh.ElectrodesTyped.Cast<FEMElectrode>().ToList();
+            var updated = new List<FEMElectrode>(templates.Count);
+
+            foreach (var template in templates)
             {
-                var v = verts[i];
-                v.ElectrodeId = i;
-                var el = new FEMElectrode(i, v.GlobalId, 0.0, ElectrodeContactImpedance, 0.0);
-                el.FEMVertexIds.Add(v.GlobalId);
-                electrodes.Add(el);
+                var group = mesh.Vertices
+                    .Where(v => v.IsElectrode && v.ElectrodeId == template.Id)
+                    .ToList();
+
+                if (group.Count == 0)
+                {
+                    var preserved = new FEMElectrode(template.Id, template.FEMVertexIds ?? new List<int>(), template.Current, template.ZContact, template.Potential, template.IsExcitation, template.IsGround, template.IsMeasuring)
+                    {
+                        PointElectrode = template.PointElectrode,
+                        Length = template.Length
+                    };
+                    updated.Add(preserved);
+                    continue;
+                }
+
+                var orderedIds = mesh.OrderVerticesAlongBoundary(group.Select(v => v.GlobalId));
+                foreach (var vertex in group)
+                    vertex.ElectrodeId = template.Id;
+
+                var electrode = new FEMElectrode(template.Id, orderedIds, template.Current, ElectrodeContactImpedance, template.Potential, template.IsExcitation, template.IsGround, template.IsMeasuring)
+                {
+                    PointElectrode = orderedIds.Count <= 1,
+                    Length = mesh.ComputeElectrodeLength(orderedIds)
+                };
+                updated.Add(electrode);
             }
-            mesh.SetElectrodes(electrodes);
+
+            mesh.SetElectrodes(updated);
 
             Workspace.SetDiscretization(_currentDiscretization);
             Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
@@ -395,13 +425,51 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
             else if (_currentDiscretization is FEMMesh fem)
             {
-                fem.PlaceEquidistantElectrodes(value, ElectrodeContactImpedance, ElectrodeSize);
+                fem.PlaceEquidistantElectrodes(value, ElectrodeContactImpedance, ElectrodeSize, FemElectrodeNodeCount);
             }
 
             _currentDiscretization.Metadata.Parameters["electrodeCount"] = value.ToString();
             Workspace.SetDiscretization(_currentDiscretization);
             Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
             MeshChanged?.Invoke();
+        }
+
+        partial void OnFemElectrodeNodeCountChanged(int value)
+        {
+            if (_currentDiscretization is FEMMesh fem)
+            {
+                ApplyFemElectrodeLayout(fem);
+                Workspace.SetDiscretization(_currentDiscretization);
+                Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
+                MeshChanged?.Invoke();
+            }
+        }
+
+        partial void OnElectrodeSizeChanged(double value)
+        {
+            if (_currentDiscretization is FEMMesh fem)
+            {
+                ApplyFemElectrodeLayout(fem);
+                Workspace.SetDiscretization(_currentDiscretization);
+                Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
+                MeshChanged?.Invoke();
+            }
+        }
+
+        partial void OnElectrodeContactImpedanceChanged(double value)
+        {
+            if (_currentDiscretization is FEMMesh fem)
+            {
+                ApplyFemElectrodeLayout(fem);
+                Workspace.SetDiscretization(_currentDiscretization);
+                Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());
+                MeshChanged?.Invoke();
+            }
+            else if (_currentDiscretization != null)
+            {
+                foreach (var electrode in _currentDiscretization.GetElectrodes())
+                    electrode.ZContact = value;
+            }
         }
 
         partial void OnMeshSearchTextChanged(string value) => ApplyMeshFilter();

--- a/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MainPage.xaml.cs
@@ -22,6 +22,7 @@ namespace ElectricalImpedanceTomography.Views
         private readonly SKPaint _femStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1 };
         private readonly SKPaint _femFill = new() { Style = SKPaintStyle.Fill };
         private readonly SKPaint _electrodeFill = new() { Style = SKPaintStyle.Fill, Color = SKColors.Yellow };
+        private readonly SKPaint _electrodeSegmentStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.Gold, StrokeWidth = 3, IsAntialias = true };
 
         private float _scale, _marginX, _marginY, _minX, _minY, _meshWidth, _meshHeight;
 
@@ -164,6 +165,13 @@ namespace ElectricalImpedanceTomography.Views
                 _femFill.Color = ColorForValue(el.Conductivity, min, max);
                 canvas.DrawPath(path, _femFill);
                 canvas.DrawPath(path, _femStroke);
+            }
+
+            foreach (var segment in mesh.GetElectrodeSegments())
+            {
+                var start = ToCanvas(segment.Start);
+                var end = ToCanvas(segment.End);
+                canvas.DrawLine(start, end, _electrodeSegmentStroke);
             }
 
             foreach (var v in mesh.Vertices.Where(v => v.IsElectrode))

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml
@@ -155,6 +155,13 @@
                                                     Value="{Binding ElectrodeCount}"
                                                     Max="32"/>
 
+                    <controls:PlusMinusEntryControl Margin="0"
+                                                    LabelText="Nodes / Electrode"
+                                                    PlusImageSource="icon_plus2.png"
+                                                    MinusImageSource="icon_minus2.png"
+                                                    Value="{Binding FemElectrodeNodeCount}"
+                                                    Max="{Binding BoundaryFEMVertexCount}"/>
+
                     <Grid ColumnDefinitions="Auto, *"
                           ColumnSpacing="12"
                           IsVisible="{Binding InhomogenityEditing}">

--- a/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/MeshingPage.xaml.cs
@@ -25,6 +25,7 @@ public partial class MeshingPage : ContentPage
     private readonly SKPaint _femStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1 };
     private readonly SKPaint _femFill = new() { Style = SKPaintStyle.Fill };
     private readonly SKPaint _electrodeFill = new() { Style = SKPaintStyle.Fill, Color = SKColors.Yellow };
+    private readonly SKPaint _electrodeSegmentStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.Gold, StrokeWidth = 3, IsAntialias = true };
     private readonly SKPaint _pointFill = new() { Style = SKPaintStyle.Fill, Color = SKColors.SkyBlue };
 
     // caching values for coordinate transforms
@@ -41,6 +42,7 @@ public partial class MeshingPage : ContentPage
     // dragging state
     private LBMElement? _draggedLbmElectrode;
     private FEMVertex? _draggedFemVertex;
+    private int? _draggedFemElectrodeId;
 
     private bool _isConductivityPainting;
     private int? _lastPaintedElementId;
@@ -241,6 +243,13 @@ public partial class MeshingPage : ContentPage
             _femFill.Color = ColorForValue(el.Conductivity, min, max);
             canvas.DrawPath(path, _femFill);
             canvas.DrawPath(path, _femStroke);
+        }
+
+        foreach (var segment in mesh.GetElectrodeSegments())
+        {
+            var start = ToCanvas(segment.Start);
+            var end = ToCanvas(segment.End);
+            canvas.DrawLine(start, end, _electrodeSegmentStroke);
         }
 
         foreach (var v in mesh.Vertices.Where(v => v.IsElectrode))
@@ -446,7 +455,9 @@ public partial class MeshingPage : ContentPage
                     if (target != null && target != _draggedFemVertex)
                     {
                         _draggedFemVertex.IsElectrode = false;
+                        _draggedFemVertex.ElectrodeId = -1;
                         target.IsElectrode = true;
+                        target.ElectrodeId = _draggedFemElectrodeId ?? -1;
                         _draggedFemVertex = target;
                         _viewModel.RefreshFemElectrodes();
                         MeshCanvas.InvalidateSurface();
@@ -455,6 +466,7 @@ public partial class MeshingPage : ContentPage
                 else if (e.ActionType == SKTouchAction.Released)
                 {
                     _draggedFemVertex = null;
+                    _draggedFemElectrodeId = null;
                 }
                 e.Handled = true;
                 return;
@@ -467,6 +479,7 @@ public partial class MeshingPage : ContentPage
                 if (hit != null)
                 {
                     _draggedFemVertex = hit;
+                    _draggedFemElectrodeId = hit.ElectrodeId;
                     e.Handled = true;
                     return;
                 }

--- a/Utility/Classes/Discretizer/FiniteElementMesh/Edge.cs
+++ b/Utility/Classes/Discretizer/FiniteElementMesh/Edge.cs
@@ -1,4 +1,6 @@
-﻿namespace Utility.Classes.Discretizer.FiniteElementMesh
+using System;
+
+namespace Utility.Classes.Discretizer.FiniteElementMesh
 {
     /// <summary>
     /// Represents an edge in the FEM model.
@@ -6,16 +8,37 @@
     public class Edge
     {
         /// <summary>
-        /// Start FEMVertex of the edge.
+        /// Start FEM vertex of the edge.
         /// </summary>
         public FEMVertex Start { get; set; } = new(0, 0.0, 0.0);
 
         /// <summary>
-        /// End FEMVertex of the edge.
+        /// End FEM vertex of the edge.
         /// </summary>
         public FEMVertex End { get; set; } = new(0, 0.0, 0.0);
 
-        public int Id { get; set; } 
+        /// <summary>
+        /// Unique edge identifier.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// True when the edge belongs to the exterior boundary of the mesh.
+        /// </summary>
+        public bool IsBoundary { get; set; }
+
+        /// <summary>
+        /// Length of the edge in the current coordinate system.
+        /// </summary>
+        public double Length
+        {
+            get
+            {
+                double dx = Start.X - End.X;
+                double dy = Start.Y - End.Y;
+                return Math.Sqrt(dx * dx + dy * dy);
+            }
+        }
 
         public Edge(FEMVertex start, FEMVertex end, int id)
         {

--- a/Utility/Classes/Discretizer/FiniteElementMesh/FEMElectrode.cs
+++ b/Utility/Classes/Discretizer/FiniteElementMesh/FEMElectrode.cs
@@ -1,19 +1,29 @@
-﻿namespace Utility.Classes.Discretizer.FiniteElementMesh
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Utility.Classes.Discretizer.FiniteElementMesh
 {
     public class FEMElectrode : Electrode
     {
-
-        // Global index of this electrode (0 … Ne-1).</summary>
+        /// <summary>
+        /// Global index of the representative mesh vertex for the electrode.
+        /// </summary>
         public int MeshId { get; }
 
+        /// <summary>
+        /// Ordered list of FEM vertex ids that belong to the electrode patch.
+        /// </summary>
         public List<int> FEMVertexIds { get; } = [];
 
-        // FEM case: Surface area of the electrode, which correspond to the integral
-        // specified in %, so 0.1 means it takes length as on a connection like: Vn ----- Ve ----- Vm
-        // |Ve-Vn| * 0.1 and |Ve - Vm| * 0.1
-        public double Length { get; set; } = 0.3;   // TODO: add length calculateions
+        /// <summary>
+        /// Physical length of the electrode contact region on the boundary.
+        /// </summary>
+        public double Length { get; set; } = 0.3;
 
-        // Determines wether the electode is interpreted over a single FEMVertex or several vertices
+        /// <summary>
+        /// Indicates whether the electrode is interpreted as a single-node contact.
+        /// </summary>
         public bool PointElectrode { get; set; } = true;
 
         public FEMElectrode(int meshId, List<int> femVertexIds, double current = double.NaN, double zContact = 0.1, double voltage = double.NaN, bool pointElectrode = true)
@@ -22,7 +32,8 @@
             Current = current;
             ZContact = zContact;
             Potential = voltage;
-            FEMVertexIds = femVertexIds;
+            if (femVertexIds != null)
+                FEMVertexIds.AddRange(femVertexIds);
             PointElectrode = pointElectrode;
         }
 
@@ -37,6 +48,27 @@
             IsGround = isGround;
             IsMeasuring = isMeasuring;
             PointElectrode = pointElectrode;
+        }
+
+        public FEMElectrode(int id, IEnumerable<int> femVertexIds, double current = double.NaN, double zContact = 0.1, double voltage = double.NaN, bool isExcitation = false, bool isGround = false, bool isMeasuring = false)
+        {
+            if (femVertexIds == null)
+                throw new ArgumentNullException(nameof(femVertexIds));
+
+            var ids = femVertexIds.ToList();
+            if (ids.Count == 0)
+                throw new ArgumentException("At least one FEM vertex id must be provided.", nameof(femVertexIds));
+
+            Id = id;
+            MeshId = ids[0];
+            Current = current;
+            ZContact = zContact;
+            Potential = voltage;
+            IsExcitation = isExcitation;
+            IsGround = isGround;
+            IsMeasuring = isMeasuring;
+            PointElectrode = ids.Count == 1;
+            FEMVertexIds.AddRange(ids);
         }
     }
 }

--- a/Utility/Classes/Discretizer/FiniteElementMesh/FEMMesh.cs
+++ b/Utility/Classes/Discretizer/FiniteElementMesh/FEMMesh.cs
@@ -8,7 +8,11 @@ namespace Utility.Classes.Discretizer.FiniteElementMesh
     public class FEMMesh : Discretization<FEMElement, FEMElectrode>
     {
         public List<FEMVertex> Vertices { get; set; } = [];
-        private List<Edge> _edges { get; set; } = [];
+        private readonly List<Edge> _edges = [];
+        private readonly List<Edge> _boundaryEdges = [];
+        private Dictionary<int, FEMVertex> _vertexLookup = new();
+        private List<FEMVertex> _orderedBoundaryVertices = [];
+        private Dictionary<int, int> _boundaryOrderLookup = new();
 
         public FEMMesh(IEnumerable<FEMVertex> vertices,
                        IEnumerable<FEMElement> elements,
@@ -87,20 +91,158 @@ namespace Utility.Classes.Discretizer.FiniteElementMesh
 
             PotentialDistribution = new PotentialDistribution(potentialDistribution);
 
+            RebuildVertexLookup();
+            BuildEdgeTopology();
+        }
+
+        private void RebuildVertexLookup()
+        {
+            _vertexLookup = Vertices.ToDictionary(v => v.GlobalId);
+        }
+
+        private void BuildEdgeTopology()
+        {
+            _edges.Clear();
+            _boundaryEdges.Clear();
+
+            var edgeUsage = new Dictionary<(int a, int b), (Edge edge, int count)>();
             int edgeId = 0;
 
-            // Add edges
-            foreach(var element in _elements)
+            foreach (var element in _elements.Cast<FEMElement>())
             {
-                _edges.Add(new Edge(element.Vertices[0], element.Vertices[1], edgeId++));
-                _edges.Add(new Edge(element.Vertices[0], element.Vertices[2], edgeId++));
-                _edges.Add(new Edge(element.Vertices[1], element.Vertices[2], edgeId++));
+                var verts = element.Vertices;
+                var triples = new (FEMVertex A, FEMVertex B)[]
+                {
+                    (verts[0], verts[1]),
+                    (verts[1], verts[2]),
+                    (verts[2], verts[0])
+                };
+
+                foreach (var (A, B) in triples)
+                {
+                    var key = (Math.Min(A.GlobalId, B.GlobalId), Math.Max(A.GlobalId, B.GlobalId));
+                    if (edgeUsage.TryGetValue(key, out var entry))
+                    {
+                        entry.count++;
+                        edgeUsage[key] = entry;
+                    }
+                    else
+                    {
+                        edgeUsage[key] = (new Edge(A, B, edgeId++), 1);
+                    }
+                }
             }
 
-            // Remove duplicates
-            foreach(var edge in _edges.ToList())
-                _edges.RemoveAll(x => x.Start.X == edge.Start.X && x.Start.Y == edge.Start.Y && x.Id != edgeId ||
-                                     x.Start.Y == edge.Start.X && x.Start.X == edge.Start.Y && x.Id != edgeId);
+            foreach (var (_, value) in edgeUsage)
+            {
+                var edge = value.edge;
+                edge.IsBoundary = value.count == 1;
+                _edges.Add(edge);
+                if (edge.IsBoundary)
+                    _boundaryEdges.Add(edge);
+            }
+
+            BuildOrderedBoundaryVertices();
+        }
+
+        private void BuildOrderedBoundaryVertices()
+        {
+            _orderedBoundaryVertices = [];
+            _boundaryOrderLookup = new Dictionary<int, int>();
+
+            var boundaryVerts = Vertices.Where(v => v.IsBoundary).ToList();
+            if (boundaryVerts.Count == 0)
+                return;
+
+            var adjacency = new Dictionary<int, List<int>>();
+            foreach (var edge in _boundaryEdges)
+            {
+                int a = edge.Start.GlobalId;
+                int b = edge.End.GlobalId;
+                if (!adjacency.TryGetValue(a, out var listA))
+                {
+                    listA = new List<int>();
+                    adjacency[a] = listA;
+                }
+                if (!listA.Contains(b))
+                    listA.Add(b);
+
+                if (!adjacency.TryGetValue(b, out var listB))
+                {
+                    listB = new List<int>();
+                    adjacency[b] = listB;
+                }
+                if (!listB.Contains(a))
+                    listB.Add(a);
+            }
+
+            List<FEMVertex> ordered;
+            if (adjacency.Count == 0)
+            {
+                double cx = boundaryVerts.Average(v => v.X);
+                double cy = boundaryVerts.Average(v => v.Y);
+                ordered = [.. boundaryVerts.OrderBy(v => Math.Atan2(v.Y - cy, v.X - cx))];
+            }
+            else
+            {
+                double cx = boundaryVerts.Average(v => v.X);
+                double cy = boundaryVerts.Average(v => v.Y);
+                var start = boundaryVerts
+                    .OrderBy(v => Math.Atan2(v.Y - cy, v.X - cx))
+                    .First();
+
+                ordered = new List<FEMVertex>(boundaryVerts.Count);
+                int current = start.GlobalId;
+                int previous = -1;
+                var visited = new HashSet<int>();
+
+                while (visited.Add(current))
+                {
+                    if (!_vertexLookup.TryGetValue(current, out var vertex))
+                        break;
+
+                    ordered.Add(vertex);
+
+                    if (!adjacency.TryGetValue(current, out var neighbours) || neighbours.Count == 0)
+                        break;
+
+                    int next = -1;
+                    if (neighbours.Count == 1)
+                    {
+                        next = neighbours[0];
+                    }
+                    else
+                    {
+                        foreach (var candidate in neighbours)
+                        {
+                            if (candidate != previous)
+                            {
+                                next = candidate;
+                                break;
+                            }
+                        }
+                        if (next == -1)
+                            next = neighbours[0];
+                    }
+
+                    previous = current;
+                    current = next;
+
+                    if (current == start.GlobalId)
+                        break;
+                }
+
+                if (ordered.Count != boundaryVerts.Count)
+                {
+                    double cx2 = boundaryVerts.Average(v => v.X);
+                    double cy2 = boundaryVerts.Average(v => v.Y);
+                    ordered = [.. boundaryVerts.OrderBy(v => Math.Atan2(v.Y - cy2, v.X - cx2))];
+                }
+            }
+
+            _orderedBoundaryVertices = ordered;
+            for (int i = 0; i < _orderedBoundaryVertices.Count; i++)
+                _boundaryOrderLookup[_orderedBoundaryVertices[i].GlobalId] = i;
         }
 
         protected override IEnumerable<int> StateKeys() => Vertices.Select(v => v.GlobalId);
@@ -128,7 +270,7 @@ namespace Utility.Classes.Discretizer.FiniteElementMesh
             return vv.Potential;
         }
 
-        public void PlaceEquidistantElectrodes(int numElectrodes, double zContact, double length)
+        public void PlaceEquidistantElectrodes(int numElectrodes, double zContact, double lengthHint, int nodesPerElectrode = 1)
         {
             foreach (var v in Vertices)
             {
@@ -136,36 +278,209 @@ namespace Utility.Classes.Discretizer.FiniteElementMesh
                 v.ElectrodeId = -1;
             }
 
-            _electrodes.Clear();
-
             if (numElectrodes <= 0)
+            {
+                SetElectrodes(new List<FEMElectrode>());
                 return;
+            }
 
-            var boundary = Vertices.Where(v => v.IsBoundary).ToList();
+            if (_orderedBoundaryVertices.Count == 0)
+                BuildEdgeTopology();
+
+            var boundary = _orderedBoundaryVertices;
             if (boundary.Count == 0)
+            {
+                SetElectrodes(new List<FEMElectrode>());
                 return;
+            }
 
-            double cx = boundary.Average(v => v.X);
-            double cy = boundary.Average(v => v.Y);
+            numElectrodes = Math.Clamp(numElectrodes, 1, boundary.Count);
+            nodesPerElectrode = Math.Clamp(nodesPerElectrode, 1, Math.Max(1, boundary.Count / numElectrodes));
 
-            boundary = [.. boundary.OrderBy(v => Math.Atan2(v.Y - cy, v.X - cx))];
-
-            int count = boundary.Count;
-            numElectrodes = Math.Min(numElectrodes, count);
-            double step = count / (double)numElectrodes;
+            var used = new bool[boundary.Count];
+            var electrodes = new List<FEMElectrode>(numElectrodes);
+            double step = boundary.Count / (double)numElectrodes;
             double pos = 0.0;
+
             for (int i = 0; i < numElectrodes; i++)
             {
-                int idx = (int)Math.Floor(pos) % count;
-                var v = boundary[idx];
-                v.IsElectrode = true;
-                v.ElectrodeId = i;
-                var el = new FEMElectrode(i, v.GlobalId, 0.0, zContact, 0.0);
-                el.Length = length;
-                el.FEMVertexIds.Add(v.GlobalId);
-                _electrodes.Add(el);
+                int startIndex = FindNextUnusedIndex(used, (int)Math.Round(pos) % boundary.Count);
+                if (startIndex < 0)
+                    break;
+
+                var assigned = new List<int>(nodesPerElectrode);
+                int current = startIndex;
+                for (int n = 0; n < nodesPerElectrode; n++)
+                {
+                    if (used[current])
+                    {
+                        current = FindNextUnusedIndex(used, current);
+                        if (current < 0)
+                            break;
+                    }
+
+                    used[current] = true;
+                    var vertex = boundary[current];
+                    vertex.IsElectrode = true;
+                    vertex.ElectrodeId = i;
+                    assigned.Add(vertex.GlobalId);
+
+                    current = (current + 1) % boundary.Count;
+                }
+
+                if (assigned.Count == 0)
+                    continue;
+
+                var electrode = new FEMElectrode(
+                    id: i,
+                    meshId: assigned[0],
+                    current: 0.0,
+                    zContact: zContact,
+                    voltage: 0.0,
+                    pointElectrode: assigned.Count == 1);
+                electrode.PointElectrode = assigned.Count == 1;
+                electrode.FEMVertexIds.AddRange(assigned);
+                double arcLength = ComputeElectrodeLength(assigned);
+                electrode.Length = arcLength > 0.0 ? arcLength : lengthHint;
+                electrodes.Add(electrode);
+
                 pos += step;
             }
+
+            for (int idx = 0; idx < boundary.Count; idx++)
+            {
+                if (!used[idx])
+                {
+                    boundary[idx].IsElectrode = false;
+                    boundary[idx].ElectrodeId = -1;
+                }
+            }
+
+            SetElectrodes(electrodes);
+        }
+
+        public IReadOnlyList<FEMVertex> GetOrderedBoundaryVertices() => _orderedBoundaryVertices;
+
+        public bool TryGetBoundaryIndex(int vertexId, out int index) => _boundaryOrderLookup.TryGetValue(vertexId, out index);
+
+        public FEMVertex GetVertexById(int vertexId)
+            => _vertexLookup.TryGetValue(vertexId, out var vertex)
+                ? vertex
+                : throw new InvalidOperationException($"No FEMVertex.GlobalId = {vertexId}.");
+
+        public List<int> OrderVerticesAlongBoundary(IEnumerable<int> vertexIds)
+        {
+            if (vertexIds == null)
+                return [];
+
+            var ids = vertexIds.Where(id => _boundaryOrderLookup.ContainsKey(id)).Distinct().ToList();
+            if (ids.Count <= 1)
+                return ids;
+
+            var ordered = new List<int>(ids.Count);
+            var idSet = new HashSet<int>(ids);
+
+            foreach (var vertex in _orderedBoundaryVertices)
+            {
+                if (idSet.Contains(vertex.GlobalId))
+                    ordered.Add(vertex.GlobalId);
+            }
+
+            if (ordered.Count <= 1)
+                return ordered;
+
+            int n = ordered.Count;
+            int boundaryCount = _orderedBoundaryVertices.Count;
+            var boundaryIndices = ordered.Select(id => _boundaryOrderLookup[id]).ToArray();
+            int bestBreak = 0;
+            int maxGap = -1;
+
+            for (int i = 0; i < n; i++)
+            {
+                int current = boundaryIndices[i];
+                int next = boundaryIndices[(i + 1) % n];
+                int diff = (next - current + boundaryCount) % boundaryCount;
+                if (diff > maxGap)
+                {
+                    maxGap = diff;
+                    bestBreak = (i + 1) % n;
+                }
+            }
+
+            if (bestBreak == 0)
+                return ordered;
+
+            var rotated = new List<int>(n);
+            for (int offset = 0; offset < n; offset++)
+                rotated.Add(ordered[(bestBreak + offset) % n]);
+            return rotated;
+        }
+
+        public double ComputeElectrodeLength(IList<int> orderedVertexIds)
+        {
+            if (orderedVertexIds == null || orderedVertexIds.Count == 0)
+                return 0.0;
+
+            if (orderedVertexIds.Count == 1)
+            {
+                if (_orderedBoundaryVertices.Count < 2)
+                    return 0.0;
+                if (!_boundaryOrderLookup.TryGetValue(orderedVertexIds[0], out var idx))
+                    return 0.0;
+                int prevIdx = (idx - 1 + _orderedBoundaryVertices.Count) % _orderedBoundaryVertices.Count;
+                int nextIdx = (idx + 1) % _orderedBoundaryVertices.Count;
+                var current = GetVertexById(orderedVertexIds[0]);
+                var prev = _orderedBoundaryVertices[prevIdx];
+                var next = _orderedBoundaryVertices[nextIdx];
+                return Distance(current, prev) * 0.5 + Distance(current, next) * 0.5;
+            }
+
+            double length = 0.0;
+            for (int i = 0; i < orderedVertexIds.Count - 1; i++)
+            {
+                var a = GetVertexById(orderedVertexIds[i]);
+                var b = GetVertexById(orderedVertexIds[i + 1]);
+                length += Distance(a, b);
+            }
+            return length;
+        }
+
+        public IEnumerable<(FEMVertex Start, FEMVertex End, FEMElectrode Electrode)> GetElectrodeSegments()
+        {
+            foreach (var electrode in ElectrodesTyped.Cast<FEMElectrode>())
+            {
+                if (electrode.FEMVertexIds == null || electrode.FEMVertexIds.Count < 2)
+                    continue;
+
+                var ids = electrode.FEMVertexIds;
+                for (int i = 0; i < ids.Count - 1; i++)
+                {
+                    if (_vertexLookup.TryGetValue(ids[i], out var start) &&
+                        _vertexLookup.TryGetValue(ids[i + 1], out var end))
+                    {
+                        yield return (start, end, electrode);
+                    }
+                }
+            }
+        }
+
+        private static int FindNextUnusedIndex(bool[] used, int start)
+        {
+            int n = used.Length;
+            for (int step = 0; step < n; step++)
+            {
+                int idx = (start + step) % n;
+                if (!used[idx])
+                    return idx;
+            }
+            return -1;
+        }
+
+        private static double Distance(FEMVertex a, FEMVertex b)
+        {
+            double dx = a.X - b.X;
+            double dy = a.Y - b.Y;
+            return Math.Sqrt(dx * dx + dy * dy);
         }
 
 

--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -31,9 +31,9 @@ namespace Utility.Classes.Factories
         /// Builds a circular FEM mesh with given concentric layers and boundary vertices,
         /// then distributes `electrodeCount` electrodes evenly around the outer boundary.
         /// </summary>
-        public static FEMMesh CreateCircularFEMMesh(int layers, int boundaryFEMVertexCount, int electrodeCount = 16)
+        public static FEMMesh CreateCircularFEMMesh(int layers, int boundaryFEMVertexCount, int electrodeCount = 16, int nodesPerElectrode = 1, double electrodeLengthHint = 0.3)
         {
-            var mesh = CreateCircularFEMMeshInternal(layers, boundaryFEMVertexCount, electrodeCount, inhomogeneityValue: 3.0);
+            var mesh = CreateCircularFEMMeshInternal(layers, boundaryFEMVertexCount, electrodeCount, inhomogeneityValue: 3.0, nodesPerElectrode: nodesPerElectrode, electrodeLengthHint: electrodeLengthHint);
 
             mesh.Metadata.Generator = nameof(CreateCircularFEMMesh);
             mesh.Metadata.Parameters["layers"] = layers.ToString();
@@ -47,9 +47,9 @@ namespace Utility.Classes.Factories
         /// Builds an inhomogeneous circular FEM mesh where elements in the inner rings
         /// have conductivity scaled by inhomogeneityValue (default 3.0).
         /// </summary>
-        public static FEMMesh CreateCircularFEMMesh(int layers, int boundaryFEMVertexCount, int electrodeCount = 16, double inhomogeneityValue = 3.0)
+        public static FEMMesh CreateCircularFEMMesh(int layers, int boundaryFEMVertexCount, int electrodeCount = 16, double inhomogeneityValue = 3.0, int nodesPerElectrode = 1, double electrodeLengthHint = 0.3)
         {
-            var mesh = CreateCircularFEMMeshInternal(layers, boundaryFEMVertexCount, electrodeCount, inhomogeneityValue);
+            var mesh = CreateCircularFEMMeshInternal(layers, boundaryFEMVertexCount, electrodeCount, inhomogeneityValue, nodesPerElectrode, electrodeLengthHint);
 
             mesh.Metadata.Generator = nameof(CreateCircularFEMMesh);
             mesh.Metadata.Parameters["layers"] = layers.ToString();
@@ -63,7 +63,7 @@ namespace Utility.Classes.Factories
         }
 
         // common implementation with inhomogeneity scaling
-        private static FEMMesh CreateCircularFEMMeshInternal(int layers, int boundaryFEMVertexCount, int electrodeCount, double inhomogeneityValue)
+        private static FEMMesh CreateCircularFEMMeshInternal(int layers, int boundaryFEMVertexCount, int electrodeCount, double inhomogeneityValue, int nodesPerElectrode, double electrodeLengthHint)
         {
             if (electrodeCount > boundaryFEMVertexCount)
                 electrodeCount = boundaryFEMVertexCount;
@@ -128,52 +128,7 @@ namespace Utility.Classes.Factories
             // 4) assemble mesh
             var mesh = new FEMMesh(vertices, elements);
 
-            // 5) distribute electrodes
-
-            // clear any leftover flags
-            foreach (var v in vertices)
-            {
-                v.IsElectrode = false;
-                v.ElectrodeId = -1;
-            }
-
-            // gather boundary vertices sorted by their BoundaryId
-            var boundaryVerts = vertices
-                .Where(v => v.IsBoundary)
-                .OrderBy(v => v.BoundaryId)
-                .ToList();
-            int boundaryCount = boundaryVerts.Count;
-
-            // use fractional steps so electrodes remain evenly spaced even
-            // when boundaryCount isn't divisible by electrodeCount
-            double step = boundaryCount / (double)electrodeCount;
-            double pos = 0.0;
-
-            var electrodes = new List<FEMElectrode>(electrodeCount);
-            for (int elId = 0; elId < electrodeCount; elId++)
-            {
-                int idx = (int)Math.Round(pos, MidpointRounding.AwayFromZero);
-                if (idx >= boundaryCount)
-                    idx = boundaryCount - 1;
-
-                FEMVertex v = boundaryVerts[idx];
-                v.IsElectrode = true;
-                v.ElectrodeId = elId;
-
-                var el = new FEMElectrode(
-                    id: elId,
-                    meshId: v.GlobalId,
-                    current: 0.0,
-                    zContact: 0.1,
-                    voltage: 1.0);
-
-                el.FEMVertexIds.Add(v.GlobalId);
-                electrodes.Add(el);
-
-                pos += step;
-            }
-
-            mesh.SetElectrodes(electrodes);
+            mesh.PlaceEquidistantElectrodes(electrodeCount, 0.1, electrodeLengthHint, nodesPerElectrode);
 
             // Assing FEMVertex neighbors
             foreach (var element in elements)
@@ -244,7 +199,7 @@ namespace Utility.Classes.Factories
         /// equally spaced boundary vertices. If electrodeCount exceeds the number of boundary
         /// vertices it is clamped accordingly.
         /// </summary>
-        public static FEMMesh CreatePolygonFEMMesh(IList<(double x, double y)> perimeter, int layers, int electrodeCount = 16)
+        public static FEMMesh CreatePolygonFEMMesh(IList<(double x, double y)> perimeter, int layers, int electrodeCount = 16, int nodesPerElectrode = 1, double electrodeLengthHint = 0.3)
         {
             ValidatePerimeter(perimeter);
 
@@ -293,34 +248,7 @@ namespace Utility.Classes.Factories
 
             var mesh = new FEMMesh(vertices, elements);
 
-            var boundaryVerts = vertices.Where(v => v.IsBoundary).OrderBy(v => v.BoundaryId).ToList();
-            electrodeCount = Math.Min(electrodeCount, boundaryVerts.Count);
-            double step = boundaryVerts.Count / (double)electrodeCount;
-            double pos = 0.0;
-
-            var electrodes = new List<FEMElectrode>();
-            for (int e = 0; e < electrodeCount; e++)
-            {
-                int idx = (int)Math.Round(pos, MidpointRounding.AwayFromZero);
-                if (idx >= boundaryVerts.Count)
-                    idx = boundaryVerts.Count - 1;
-                var v = boundaryVerts[idx];
-                v.IsElectrode = true;
-                v.ElectrodeId = e;
-
-                var el = new FEMElectrode(
-                    id: e,
-                    meshId: v.GlobalId,
-                    current: 0.0,
-                    zContact: 0.1,
-                    voltage: 1.0);
-                el.FEMVertexIds.Add(v.GlobalId);
-                electrodes.Add(el);
-
-                pos += step;
-            }
-
-            mesh.SetElectrodes(electrodes);
+            mesh.PlaceEquidistantElectrodes(electrodeCount, 0.1, electrodeLengthHint, nodesPerElectrode);
 
             foreach (var element in elements)
             {
@@ -364,7 +292,7 @@ namespace Utility.Classes.Factories
         /// <summary>
         /// Convenience wrapper that builds a rectangular FEM mesh from corner points.
         /// </summary>
-        public static FEMMesh CreateRectangularFEMMesh(double width, double height, int electrodeCount = 16, int layers = 1)
+        public static FEMMesh CreateRectangularFEMMesh(double width, double height, int electrodeCount = 16, int layers = 1, int nodesPerElectrode = 1, double electrodeLengthHint = 0.3)
         {
             var hw = width / 2.0;
             var hh = height / 2.0;
@@ -375,7 +303,7 @@ namespace Utility.Classes.Factories
                 ( hw,  hh),
                 (-hw,  hh)
             };
-            var mesh = CreatePolygonFEMMesh(pts, layers, electrodeCount);
+            var mesh = CreatePolygonFEMMesh(pts, layers, electrodeCount, nodesPerElectrode, electrodeLengthHint);
             mesh.Metadata.Generator = nameof(CreateRectangularFEMMesh);
             mesh.Metadata.Parameters["width"] = width.ToString();
             mesh.Metadata.Parameters["height"] = height.ToString();
@@ -387,9 +315,9 @@ namespace Utility.Classes.Factories
         /// <summary>
         /// Create a FEM mesh from an arbitrary thorax-shaped perimeter.
         /// </summary>
-        public static FEMMesh CreateThoraxFEMMesh(IList<(double x, double y)> perimeter, int electrodeCount = 16, int layers = 1)
+        public static FEMMesh CreateThoraxFEMMesh(IList<(double x, double y)> perimeter, int electrodeCount = 16, int layers = 1, int nodesPerElectrode = 1, double electrodeLengthHint = 0.3)
         {
-            var mesh = CreatePolygonFEMMesh(perimeter, layers, electrodeCount);
+            var mesh = CreatePolygonFEMMesh(perimeter, layers, electrodeCount, nodesPerElectrode, electrodeLengthHint);
             mesh.Metadata.Generator = nameof(CreateThoraxFEMMesh);
             mesh.Metadata.Parameters["electrodeCount"] = electrodeCount.ToString();
             mesh.Metadata.Parameters["perimeter"] = string.Join(";", perimeter.Select(p => $"{p.x},{p.y}"));

--- a/Utility/Classes/Solvers/FiniteElementSolver/FiniteElementSolver.cs
+++ b/Utility/Classes/Solvers/FiniteElementSolver/FiniteElementSolver.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Numerics;
 using Utility.Classes.Measurement;
 using Utility.Classes.Discretizer;
@@ -24,6 +25,7 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
         private readonly INumericSolver _numericSolver;
         private readonly bool _useOmpParallelization;
         private readonly object[] _nodeLocks;
+        private readonly object[] _electrodeLocks;
 
         public int N_phi { get; }
         public int L { get; }
@@ -59,6 +61,9 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             _nodeLocks = Enumerable.Range(0, N_phi)
                                     .Select(_ => new object())
                                     .ToArray();
+            _electrodeLocks = Enumerable.Range(0, L)
+                                        .Select(_ => new object())
+                                        .ToArray();
         }
 
         /// <summary>
@@ -249,12 +254,39 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
 
             foreach (var el in electrodes)
             {
-                double invZ = 1.0 / el.ZContact;
-                double h = el.Length / el.FEMVertexIds.Count;
+                if (el.ZContact <= 0.0)
+                    continue;
 
-                foreach (int vid in el.FEMVertexIds)
-                    M[vid, vid] += invZ * h;
-        }
+                double invZ = 1.0 / el.ZContact;
+                if (!el.PointElectrode && el.FEMVertexIds != null && el.FEMVertexIds.Count >= 2)
+                {
+                    var segments = BuildElectrodeSegments(mesh, el);
+                    foreach (var (a, b, length) in segments)
+                    {
+                        var diag = new Complex(invZ * length / 3.0, 0.0);
+                        var off = new Complex(invZ * length / 6.0, 0.0);
+                        M[a, a] += diag;
+                        M[b, b] += diag;
+                        M[a, b] += off;
+                        M[b, a] += off;
+                    }
+                }
+                else
+                {
+                    int count = Math.Max(1, el.FEMVertexIds?.Count ?? 1);
+                    double share = invZ * (el.Length / count);
+                    var diag = new Complex(share, 0.0);
+                    if (el.FEMVertexIds != null && el.FEMVertexIds.Count > 0)
+                    {
+                        foreach (int vid in el.FEMVertexIds)
+                            M[vid, vid] += diag;
+                    }
+                    else
+                    {
+                        M[el.MeshId, el.MeshId] += diag;
+                    }
+                }
+            }
             //Debug.WriteLine("M:\n" + FormatComplexMatrix(M));
         }
 
@@ -265,15 +297,36 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
 
             Parallel.ForEach(electrodes, el =>
             {
-                double invZ = 1.0 / el.ZContact;
-                double h = el.Length / el.FEMVertexIds.Count;
+                if (el.ZContact <= 0.0)
+                    return;
 
-                foreach (int vid in el.FEMVertexIds)
+                double invZ = 1.0 / el.ZContact;
+
+                if (!el.PointElectrode && el.FEMVertexIds != null && el.FEMVertexIds.Count >= 2)
                 {
-                    var contribution = new Complex(invZ * h, 0);
-                    lock (_nodeLocks[vid])
+                    var segments = BuildElectrodeSegments(mesh, el);
+                    foreach (var (a, b, length) in segments)
                     {
-                        M[vid, vid] += contribution;
+                        var diag = new Complex(invZ * length / 3.0, 0.0);
+                        var off = new Complex(invZ * length / 6.0, 0.0);
+                        AddToNodeMatrixThreadSafe(M, a, a, diag);
+                        AddToNodeMatrixThreadSafe(M, b, b, diag);
+                        AddToNodeMatrixThreadSafe(M, a, b, off);
+                        AddToNodeMatrixThreadSafe(M, b, a, off);
+                    }
+                }
+                else
+                {
+                    int count = Math.Max(1, el.FEMVertexIds?.Count ?? 1);
+                    var diag = new Complex(invZ * (el.Length / count), 0.0);
+                    if (el.FEMVertexIds != null && el.FEMVertexIds.Count > 0)
+                    {
+                        foreach (int vid in el.FEMVertexIds)
+                            AddToNodeMatrixThreadSafe(M, vid, vid, diag);
+                    }
+                    else
+                    {
+                        AddToNodeMatrixThreadSafe(M, el.MeshId, el.MeshId, diag);
                     }
                 }
             });
@@ -290,11 +343,34 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
 
             foreach (var el in electrodes)
             {
-                double invZ = 1.0 / el.ZContact;
-                double h = el.Length / el.FEMVertexIds.Count;
+                if (el.ZContact <= 0.0)
+                    continue;
 
-                foreach (int vid in el.FEMVertexIds)
-                    A_coup[vid, el.Id] += invZ * h;
+                double invZ = 1.0 / el.ZContact;
+                if (!el.PointElectrode && el.FEMVertexIds != null && el.FEMVertexIds.Count >= 2)
+                {
+                    var segments = BuildElectrodeSegments(mesh, el);
+                    foreach (var (a, b, length) in segments)
+                    {
+                        var value = new Complex(invZ * length / 2.0, 0.0);
+                        A_coup[a, el.Id] += value;
+                        A_coup[b, el.Id] += value;
+                    }
+                }
+                else
+                {
+                    int count = Math.Max(1, el.FEMVertexIds?.Count ?? 1);
+                    var value = new Complex(invZ * (el.Length / count), 0.0);
+                    if (el.FEMVertexIds != null && el.FEMVertexIds.Count > 0)
+                    {
+                        foreach (int vid in el.FEMVertexIds)
+                            A_coup[vid, el.Id] += value;
+                    }
+                    else
+                    {
+                        A_coup[el.MeshId, el.Id] += value;
+                    }
+                }
             }
             //Debug.WriteLine("A_coup:\n" + FormatComplexMatrix(A_coup));
         }
@@ -306,15 +382,32 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
 
             Parallel.ForEach(electrodes, el =>
             {
-                double invZ = 1.0 / el.ZContact;
-                double h = el.Length / el.FEMVertexIds.Count;
+                if (el.ZContact <= 0.0)
+                    return;
 
-                foreach (int vid in el.FEMVertexIds)
+                double invZ = 1.0 / el.ZContact;
+                if (!el.PointElectrode && el.FEMVertexIds != null && el.FEMVertexIds.Count >= 2)
                 {
-                    var value = new Complex(invZ * h, 0);
-                    lock (_nodeLocks[vid])
+                    var segments = BuildElectrodeSegments(mesh, el);
+                    foreach (var (a, b, length) in segments)
                     {
-                        A_coup[vid, el.Id] += value;
+                        var value = new Complex(invZ * length / 2.0, 0.0);
+                        AddToCouplingMatrixThreadSafe(a, el.Id, value);
+                        AddToCouplingMatrixThreadSafe(b, el.Id, value);
+                    }
+                }
+                else
+                {
+                    int count = Math.Max(1, el.FEMVertexIds?.Count ?? 1);
+                    var value = new Complex(invZ * (el.Length / count), 0.0);
+                    if (el.FEMVertexIds != null && el.FEMVertexIds.Count > 0)
+                    {
+                        foreach (int vid in el.FEMVertexIds)
+                            AddToCouplingMatrixThreadSafe(vid, el.Id, value);
+                    }
+                    else
+                    {
+                        AddToCouplingMatrixThreadSafe(el.MeshId, el.Id, value);
                     }
                 }
             });
@@ -330,7 +423,26 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
             var electrodes = mesh.GetElectrodes().Cast<FEMElectrode>();
 
             foreach (var el in electrodes)
-                D[el.Id, el.Id] = el.Length / el.ZContact;
+            {
+                if (el.ZContact <= 0.0)
+                {
+                    D[el.Id, el.Id] = 0.0;
+                    continue;
+                }
+
+                double invZ = 1.0 / el.ZContact;
+                if (!el.PointElectrode && el.FEMVertexIds != null && el.FEMVertexIds.Count >= 2)
+                {
+                    double total = 0.0;
+                    foreach (var segment in BuildElectrodeSegments(mesh, el))
+                        total += segment.Length;
+                    D[el.Id, el.Id] = total * invZ;
+                }
+                else
+                {
+                    D[el.Id, el.Id] = el.Length * invZ;
+                }
+            }
 
             //Debug.WriteLine("D:\n" + FormatComplexMatrix(D));
         }
@@ -342,8 +454,42 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
 
             Parallel.ForEach(electrodes, el =>
             {
-                D[el.Id, el.Id] = el.Length / el.ZContact;
+                if (el.ZContact <= 0.0)
+                    return;
+
+                double invZ = 1.0 / el.ZContact;
+                if (!el.PointElectrode && el.FEMVertexIds != null && el.FEMVertexIds.Count >= 2)
+                {
+                    double total = 0.0;
+                    foreach (var segment in BuildElectrodeSegments(mesh, el))
+                        total += segment.Length;
+                    AddToElectrodeMatrixThreadSafe(el.Id, new Complex(total * invZ, 0.0));
+                }
+                else
+                {
+                    AddToElectrodeMatrixThreadSafe(el.Id, new Complex(el.Length * invZ, 0.0));
+                }
             });
+        }
+
+        private static List<(int StartId, int EndId, double Length)> BuildElectrodeSegments(FEMMesh mesh, FEMElectrode electrode)
+        {
+            var segments = new List<(int, int, double)>();
+            if (electrode.FEMVertexIds == null || electrode.FEMVertexIds.Count < 2)
+                return segments;
+
+            var ids = electrode.FEMVertexIds;
+            for (int i = 0; i < ids.Count - 1; i++)
+            {
+                var start = mesh.GetVertexById(ids[i]);
+                var end = mesh.GetVertexById(ids[i + 1]);
+                double dx = start.X - end.X;
+                double dy = start.Y - end.Y;
+                double length = Math.Sqrt(dx * dx + dy * dy);
+                if (length > 0.0)
+                    segments.Add((start.GlobalId, end.GlobalId, length));
+            }
+            return segments;
         }
 
         /// <summary>
@@ -460,6 +606,38 @@ namespace Utility.Classes.Solvers.FiniteElementSolver
         #endregion
 
         #region Utils
+        private void AddToNodeMatrixThreadSafe(Complex[,] matrix, int row, int col, Complex value)
+        {
+            if (row == col)
+            {
+                lock (_nodeLocks[row])
+                    matrix[row, col] += value;
+                return;
+            }
+
+            int first = Math.Min(row, col);
+            int second = Math.Max(row, col);
+            lock (_nodeLocks[first])
+            {
+                lock (_nodeLocks[second])
+                {
+                    matrix[row, col] += value;
+                }
+            }
+        }
+
+        private void AddToCouplingMatrixThreadSafe(int nodeId, int electrodeId, Complex value)
+        {
+            lock (_nodeLocks[nodeId])
+                A_coup[nodeId, electrodeId] += value;
+        }
+
+        private void AddToElectrodeMatrixThreadSafe(int electrodeId, Complex value)
+        {
+            lock (_electrodeLocks[electrodeId])
+                D[electrodeId, electrodeId] += value;
+        }
+
         /// <summary>
         /// Converts the provided complex 2D array to real 2D array by neglecting the complex parts.
         /// </summary>


### PR DESCRIPTION
## Summary
- add boundary ordering, electrode length calculation, and segment helpers so FEM meshes can manage multi-node electrodes
- rebuild the FEM solver’s CEM boundary assembly to integrate over electrode segments and update coupling/diagonal blocks accordingly
- expose "nodes per electrode" in the MAUI mesh editor and visualization so multi-node pads are generated and highlighted

## Testing
- dotnet --version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f61fc61c9c8333859cf121aff9e221