### PR TITLE
Enable in-place, optionally parallel reconstruction clipping

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -1,5 +1,6 @@
 ﻿using DataAccessLayer;
 using System.Diagnostics;
+using System.Linq;
 using System.Numerics;
 using Utility.Classes;
 using Utility.Classes.Application;
@@ -9,6 +10,7 @@ using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Models;
+using Utility.Classes.Reconstruction;
 using Utility.Classes.ReconstructionParameters;
 using Utility.Exports;
 using Utility.Classes.Solvers.FiniteElementSolver;
@@ -39,6 +41,9 @@ namespace BusinessLayer
         private NumericSolver _numericSolverChoice = NumericSolver.LU;
         private ErrorMetric _errorMetricChoice = ErrorMetric.L2;
 
+        private double _conductivityMinimumBound = 0.1;
+        private double _conductivityMaximumBound = 10.0;
+
         private ConductivityDistribution? _originalSigma = null;
         private ConductivityDistribution? _initialSigma = null;
 
@@ -64,8 +69,8 @@ namespace BusinessLayer
 
         public void SetConductivityDistributions(ConductivityDistribution original, ConductivityDistribution initial)
         {
-            _originalSigma = original;
-            _initialSigma = initial;
+            _originalSigma = ConductivityClipper.Clip(original);
+            _initialSigma = ConductivityClipper.Clip(initial);
         }
 
         public void InitializeReconstruction(IDiscretization discretization, EITReconstructionParameters parameters, bool reinit)
@@ -102,6 +107,14 @@ namespace BusinessLayer
                 _errorMetric = ErrorMetricFactory.Create(_errorMetricChoice);
                 _initialDistributionType = parameters.InitialDistributionType;
                 var initSigma = _initialSigma ?? ConductivityDistributionFactory.CreateInitialDistribution(discretization, _initialDistributionType);
+                _conductivityMinimumBound = parameters.ConductivityMinimumBound;
+                _conductivityMaximumBound = parameters.ConductivityMaximumBound;
+                ConductivityClipper.UpdateBounds(_conductivityMinimumBound, _conductivityMaximumBound);
+                if (_initialSigma != null)
+                    _initialSigma = ConductivityClipper.Clip(_initialSigma);
+                if (_originalSigma != null)
+                    _originalSigma = ConductivityClipper.Clip(_originalSigma);
+                initSigma = ConductivityClipper.Clip(initSigma);
                 _numericOptimizer = NumericOptimizerFactory.Create(parameters.NumericOptimizer, initSigma);
                 _drivePattern = parameters.DrivePattern;
 
@@ -131,6 +144,7 @@ namespace BusinessLayer
 
                 var sigma = femMesh.GetConductivityDistribution();
                 var updated = _numericOptimizer.OptimizationStep(sigma, totalGrad, gradientStepSize);
+                updated = ConductivityClipper.Clip(updated);
                 femMesh.SetConductivityDistribution(updated);
 
                 return new ReconstructionFrame(totalGrad,
@@ -151,6 +165,7 @@ namespace BusinessLayer
 
                 var sigma = lbmGrid.GetConductivityDistribution();
                 var updated = _numericOptimizer.OptimizationStep(sigma, totalGrad, gradientStepSize);
+                updated = ConductivityClipper.Clip(updated);
                 lbmGrid.SetConductivityDistribution(updated);
 
                 return new ReconstructionFrame(totalGrad,
@@ -224,7 +239,8 @@ namespace BusinessLayer
             var boundaryConditions = new FEMBoundaryCondition(electrodes);
             Workspace.SetCurrentGlobalFemBoundaryCondition(boundaryConditions);
 
-            return _differentialEquationSolver.Solve(mesh, boundaryConditions, null);
+            var potential = _differentialEquationSolver.Solve(mesh, boundaryConditions, null);
+            return PotentialClipper.Clip(potential);
         }
 
         public PotentialDistribution ForwardSolveStepLbm()
@@ -240,7 +256,8 @@ namespace BusinessLayer
             var boundaryConditions = new LBMBoundaryCondition(electrodes);
             Workspace.SetCurrentGlobalLbmBoundaryCondition(boundaryConditions);
 
-            return _differentialEquationSolver.Solve(lbmGrid, boundaryConditions, null);
+            var potential = _differentialEquationSolver.Solve(lbmGrid, boundaryConditions, null);
+            return PotentialClipper.Clip(potential);
         }
 
         public PotentialDistribution ForwardSolveStepLbmCuda()
@@ -256,7 +273,8 @@ namespace BusinessLayer
             var boundaryConditions = new LBMBoundaryCondition(electrodes);
             Workspace.SetCurrentGlobalLbmBoundaryCondition(boundaryConditions);
 
-            return lbmSolver.CUDASolveForward(lbmGrid, boundaryConditions);
+            var potential = lbmSolver.CUDASolveForward(lbmGrid, boundaryConditions);
+            return PotentialClipper.Clip(potential);
         }
 
         public ReconstructionFrame InverseSolveStepFem(FEMMesh mesh, FEMBoundaryCondition bc, double[] currentMeasurement, double gradientStepSize)
@@ -300,9 +318,10 @@ namespace BusinessLayer
             PotentialDistribution phi = _useCudaParallelization && lbmSolver != null
                 ? lbmSolver.CUDASolveForward(mesh, bc)
                 : _differentialEquationSolver.Solve(mesh, bc, null);
+            phi = PotentialClipper.Clip(phi);
 
             // Extract simulated potentials
-            double[] simulatedPotentials = mesh.GetElectrodePotentials();
+            double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
 
             double currentError = _errorMetric.Evaluate(mesh, currentMeasurement, simulatedPotentials);
 
@@ -318,6 +337,7 @@ namespace BusinessLayer
             PotentialDistribution mu = _useCudaParallelization && lbmSolver != null
                 ? lbmSolver.CUDASolveAdjoint(mesh, adjointBoundaryCondition, adjointSource)
                 : _differentialEquationSolver.Solve(mesh, adjointBoundaryCondition, adjointSource);
+            mu = PotentialClipper.Clip(mu);
 
             var phiGradientField = _useCudaParallelization
                 ? LatticeBoltzmannOperators.CalculateGradientCuda(mesh, phi)
@@ -376,8 +396,8 @@ namespace BusinessLayer
                 elements = mesh.GetElements().Cast<FEMElement>().ToList();
             }
 
-            PotentialDistribution phi = solver.Solve(mesh, bc, null);
-            double[] simulatedPotentials = mesh.GetElectrodePotentials();
+            PotentialDistribution phi = PotentialClipper.Clip(solver.Solve(mesh, bc, null));
+            double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
 
             var adjSrc = errorMetric.EvaluateAdjointSource(mesh, currentMeasurement, simulatedPotentials);
             Complex[] adjointSource = new Complex[adjSrc.Length];
@@ -388,7 +408,7 @@ namespace BusinessLayer
             if (updateWorkspace)
                 Workspace.SetCurrentGlobalFemBoundaryCondition(adjointBoundaryCondition);
 
-            PotentialDistribution mu = solver.Solve(mesh, adjointBoundaryCondition, adjointSource);
+            PotentialDistribution mu = PotentialClipper.Clip(solver.Solve(mesh, adjointBoundaryCondition, adjointSource));
 
             var phiGradient = FiniteElementOperators.CalculateElementWiseGradient(mesh, phi);
             var muGradient = FiniteElementOperators.CalculateElementWiseGradient(mesh, mu);
@@ -540,7 +560,8 @@ namespace BusinessLayer
                     kvp => kvp.Key,
                     kvp => kvp.Value + _gradientStepSize * totalGrad[kvp.Key]);
 
-                mesh.SetConductivityDistribution(new ConductivityDistribution(newSigmaDict));
+                var updatedSigma = ConductivityClipper.Clip(new ConductivityDistribution(newSigmaDict));
+                mesh.SetConductivityDistribution(updatedSigma);
             }
 
             // Final reconstructed distribution after termination of the loop.
@@ -577,6 +598,7 @@ namespace BusinessLayer
             }
 
             ConductivityDistribution initialSigma = _initialSigma ?? mesh.GetConductivityDistribution();
+            initialSigma = ConductivityClipper.Clip(initialSigma);
             mesh.SetConductivityDistribution(initialSigma);
 
             Workspace.UpdateCurrentGlobalLbmElectrodes(mesh);
@@ -636,7 +658,8 @@ namespace BusinessLayer
                     kvp => kvp.Key,
                     kvp => kvp.Value + _gradientStepSize * totalGrad[kvp.Key]);
 
-                mesh.SetConductivityDistribution(new ConductivityDistribution(newSigmaDict));
+                var updated = ConductivityClipper.Clip(new ConductivityDistribution(newSigmaDict));
+                mesh.SetConductivityDistribution(updated);
             }
 
             ConductivityDistribution reconstructed = mesh.GetConductivityDistribution();
@@ -673,6 +696,7 @@ namespace BusinessLayer
                 simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude, _drivePattern);
             
             ConductivityDistribution initialConductivityDistribution = _initialSigma ?? ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
+            initialConductivityDistribution = ConductivityClipper.Clip(initialConductivityDistribution);
             mesh.SetConductivityDistribution(initialConductivityDistribution);
 
             Workspace.UpdateCurrentGlobalFemElectrodes(mesh);
@@ -755,6 +779,7 @@ namespace BusinessLayer
 
                 // Apply optimization step
                 var newConductivityDistribution = _numericOptimizer.OptimizationStep(mesh.ConductivityDistribution, grad, gradientStepSize);
+                newConductivityDistribution = ConductivityClipper.Clip(newConductivityDistribution);
 
                 mesh.SetConductivityDistribution(newConductivityDistribution);
 
@@ -886,10 +911,10 @@ namespace BusinessLayer
             var elements = Workspace.GetCurrentGlobalLbmElements();
 
             // Solve Forward to extract simulated potentials
-            PotentialDistribution phi = _differentialEquationSolver.Solve(mesh, bc, null);
+            PotentialDistribution phi = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, bc, null));
 
             // Extract simulated potentials
-            double[] simulatedPotentials = mesh.GetElectrodePotentials();
+            double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
 
             double currentError = _errorMetric.Evaluate(mesh, currentMeasurement, simulatedPotentials);
 
@@ -902,7 +927,7 @@ namespace BusinessLayer
 
             var adjointBoundaryCondition = new LBMBoundaryCondition(electrodes);
             Workspace.SetCurrentGlobalLbmBoundaryCondition(adjointBoundaryCondition);
-            PotentialDistribution mu = _differentialEquationSolver.Solve(mesh, adjointBoundaryCondition, adjointSource);
+            PotentialDistribution mu = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, adjointBoundaryCondition, adjointSource));
 
             var phiGradientField = _useCudaParallelization
                 ? LatticeBoltzmannOperators.CalculateGradientCuda(mesh, phi)
@@ -976,13 +1001,11 @@ namespace BusinessLayer
 
                     var newSigmaDict = sigma.Conductivities.ToDictionary(
                         kvp => kvp.Key,
-                        // Clamp conductivites which got below 0
-                        kvp => ((kvp.Value - step * frame.ConductivityGradient.GetConductivity(kvp.Key)) < 0.0) ?
-                                                                1e-1 : kvp.Value - step * frame.ConductivityGradient.GetConductivity(kvp.Key)
+                        _ => kvp.Value - step * frame.ConductivityGradient.GetConductivity(kvp.Key)
                     );
 
-                    sigma = new ConductivityDistribution(newSigmaDict);
-                    lbmGrid.SetConductivityDistribution(sigma);
+                    var updatedSigma = ConductivityClipper.Clip(new ConductivityDistribution(newSigmaDict));
+                    lbmGrid.SetConductivityDistribution(updatedSigma);
 
                     // Add partial results
                     frames.Add(frame);
@@ -1064,7 +1087,7 @@ namespace BusinessLayer
             var boundaryConditions = new FEMBoundaryCondition(electrodes);
             Workspace.SetCurrentGlobalFemBoundaryCondition(boundaryConditions);
 
-            PotentialDistribution potentialDistribution = _differentialEquationSolver.Solve(mesh, boundaryConditions, null);
+            PotentialDistribution potentialDistribution = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, boundaryConditions, null));
             mesh.SetPotentialDistribution(potentialDistribution);
 
             return mesh;
@@ -1083,7 +1106,7 @@ namespace BusinessLayer
             List<double[]> simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude, _drivePattern);
             
             // 2) Initialize conductivity (σ^{(0)}) based on user selection
-            ConductivityDistribution sigma = ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
+            ConductivityDistribution sigma = ConductivityClipper.Clip(ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType));
             mesh.SetConductivityDistribution(sigma);
 
             Workspace.UpdateCurrentGlobalFemElectrodes(mesh);
@@ -1133,11 +1156,11 @@ namespace BusinessLayer
                     bc = new FEMBoundaryCondition(electrodes);
 
                     // 4a) Forward solve φ⁽ᵏ⁾ = S(σ⁽ᵏ⁾)   (thesis Eq. 1.1.16)
-                    PotentialDistribution phi = _differentialEquationSolver.Solve(mesh, bc, null);
+                    PotentialDistribution phi = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, bc, null));
                     Debug.WriteLine("Forward φ computed.");
 
                     // 4b) Extract simulated boundary data d_sim
-                    double[] dSim = mesh.GetElectrodePotentials();
+                    double[] dSim = PotentialClipper.Clip(mesh.GetElectrodePotentials());
                     Debug.WriteLine("The simulated electrode potentials during iteration:");
                     for (int i = 0; i < dSim.Length; i++)
                         Debug.WriteLine($"{dSim[i]}");
@@ -1145,7 +1168,7 @@ namespace BusinessLayer
                     double[] dObs = simulatedMeasurements[exc];
 
                     // 4e) Build adjoint source s = EvaluateAdjointSource (L2: residual; W2: Kantorovich φ) 
-                    var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, dObs, dSim);
+                    var adjSrc = PotentialClipper.Clip(_errorMetric.EvaluateAdjointSource(mesh, dObs, dSim));
 
                     Complex[] adjointSource = new Complex[adjSrc.Length];
                     for(int i = 0; i < adjSrc.Length; i++)
@@ -1161,7 +1184,7 @@ namespace BusinessLayer
                     // 4f) Adjoint solve μ: same forward‐solver but feed in adjSrc as boundary currents
                     var adjointBoundaryCondition = new FEMBoundaryCondition(electrodes, srcDist);
                     Workspace.SetCurrentGlobalFemBoundaryCondition(adjointBoundaryCondition);
-                    var mu = _differentialEquationSolver.Solve(mesh, adjointBoundaryCondition, adjointSource);
+                    var mu = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, adjointBoundaryCondition, adjointSource));
                     Debug.WriteLine("Adjoint μ computed.");
 
                     // 4g) Compute gradient ∇J_data = ∇μ·∇φ elementwise  (thesis Eq. 2.1.20)
@@ -1205,6 +1228,7 @@ namespace BusinessLayer
 
                 // 4i) Apply optimization step
                 var newConductivityDistribution = _numericOptimizer.OptimizationStep(mesh.ConductivityDistribution, grad, stepSize);
+                newConductivityDistribution = ConductivityClipper.Clip(newConductivityDistribution);
 
                 mesh.SetConductivityDistribution(newConductivityDistribution);
 
@@ -1230,8 +1254,8 @@ namespace BusinessLayer
                     electrodes[(exc + 1) % electrodeCount].IsMeasuring = false;
                     electrodes[(exc + 1) % electrodeCount].Current = -excitationAmplitude;
 
-                    var phiNew = _differentialEquationSolver.Solve(mesh, bc, null);
-                    double[] dSimNew = mesh.GetElectrodePotentials();
+                    var phiNew = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, bc, null));
+                    double[] dSimNew = PotentialClipper.Clip(mesh.GetElectrodePotentials());
                     double[] dObs = simulatedMeasurements[exc];
                     Jtotal += _errorMetric.Evaluate(mesh, dObs, dSimNew);
                 }
@@ -1295,7 +1319,7 @@ namespace BusinessLayer
 
                 FEMMesh result = SolveFemForward(deepCopy);
 
-                measurements.Add(result.GetElectrodePotentials());
+                measurements.Add(PotentialClipper.Clip(result.GetElectrodePotentials()));
             }
 
             return measurements;
@@ -1320,7 +1344,7 @@ namespace BusinessLayer
             var electrodes = Workspace.GetCurrentGlobalFemElectrodes();
             var bc = new FEMBoundaryCondition(electrodes);
             Workspace.SetCurrentGlobalFemBoundaryCondition(bc);
-            var pd = _differentialEquationSolver.Solve(mesh, bc, null);
+            var pd = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, bc, null));
             mesh.SetPotentialDistribution(pd);
             return mesh;
         }
@@ -1341,13 +1365,13 @@ namespace BusinessLayer
             if (_differentialEquationSolver is not GraphSolver graphSolver || _numericSolver == null || _errorMetric == null)
                 throw new NullReferenceException("Graph solver path not initialized.");
 
-            PotentialDistribution phi = _differentialEquationSolver.Solve(mesh, boundaryCondition, null);
-            var dSim = mesh.GetElectrodePotentials();
-            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, measurement, dSim);
+            PotentialDistribution phi = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, boundaryCondition, null));
+            var dSim = PotentialClipper.Clip(mesh.GetElectrodePotentials());
+            var adjSrc = PotentialClipper.Clip(_errorMetric.EvaluateAdjointSource(mesh, measurement, dSim));
             var adjComplex = adjSrc.Select(x => new Complex(x, 0.0)).ToArray();
-            PotentialDistribution mu = graphSolver.SolveAdjoint(mesh, _numericSolver, adjComplex);
+            PotentialDistribution mu = PotentialClipper.Clip(graphSolver.SolveAdjoint(mesh, _numericSolver, adjComplex));
             ConductivityDistribution original = mesh.GetConductivityDistribution();
-            ConductivityDistribution sigma = graphSolver.InverseSolve(mesh, boundaryCondition, adjComplex);
+            ConductivityDistribution sigma = ConductivityClipper.Clip(graphSolver.InverseSolve(mesh, boundaryCondition, adjComplex));
             mesh.SetConductivityDistribution(sigma);
 
             throw new NotImplementedException();

--- a/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using System.ComponentModel;
+using Utility.Classes.Reconstruction;
 using Utility.Classes.ReconstructionParameters;
 using Utility.Classes.Factories;
 
@@ -42,6 +43,10 @@ namespace ElectricalImpedanceTomography.ViewModels
             _currentParameters = ReconstructionParameters;
             _currentParameters.PropertyChanged += OnReconstructionParametersPropertyChanged;
             OnPropertyChanged(nameof(IsNoiseAmplitudeEnabled));
+            Workspace.ConductivityMinimumBound = _currentParameters.ConductivityMinimumBound;
+            Workspace.ConductivityMaximumBound = _currentParameters.ConductivityMaximumBound;
+            ConductivityClipper.UpdateBounds(_currentParameters.ConductivityMinimumBound,
+                                             _currentParameters.ConductivityMaximumBound);
         }
 
         partial void OnReconstructionParametersChanged(EITReconstructionParameters value)
@@ -60,6 +65,19 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             if (e.PropertyName == nameof(EITReconstructionParameters.MeasurementNoiseType))
                 OnPropertyChanged(nameof(IsNoiseAmplitudeEnabled));
+
+            if (e.PropertyName == nameof(EITReconstructionParameters.ConductivityMinimumBound)
+                || e.PropertyName == nameof(EITReconstructionParameters.ConductivityMaximumBound))
+            {
+                var parameters = ReconstructionParameters;
+                if (parameters != null)
+                {
+                    Workspace.ConductivityMinimumBound = parameters.ConductivityMinimumBound;
+                    Workspace.ConductivityMaximumBound = parameters.ConductivityMaximumBound;
+                    ConductivityClipper.UpdateBounds(parameters.ConductivityMinimumBound,
+                                                     parameters.ConductivityMaximumBound);
+                }
+            }
         }
 
         [ObservableProperty]

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -166,7 +166,7 @@
                         <Border Grid.Column="1"
                                 Style="{StaticResource PanelSectionBorderStyle}"
                                 BackgroundColor="{AppThemeBinding Light=#25324A, Dark=#25324A}">
-                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
+                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
                                 <Label Grid.Row="0" Text="Parameters" FontSize="Medium" FontAttributes="Bold" Margin="0,0,0,12"/>
                                 <Label Grid.Row="1" HorizontalOptions="Start" Text="Initial Distribution" FontFamily="SF Pro Text" FontAttributes="None"/>
                                 <Picker Grid.Row="2" ItemsSource="{Binding InitialDistributionOptions}" SelectedItem="{Binding ReconstructionParameters.InitialDistributionType}"/>
@@ -183,6 +183,21 @@
                                        Text="{Binding ReconstructionParameters.MeasurementNoiseAmplitude}"
                                        Keyboard="Numeric"
                                        IsEnabled="{Binding IsNoiseAmplitudeEnabled}"/>
+                                <Label Grid.Row="13"
+                                       HorizontalOptions="Start"
+                                       Text="Conductivity Bounds"
+                                       FontFamily="SF Pro Text"
+                                       FontAttributes="None"/>
+                                <Grid Grid.Row="14" ColumnDefinitions="*, *" ColumnSpacing="8">
+                                    <Entry Grid.Column="0"
+                                           Placeholder="Min"
+                                           Keyboard="Numeric"
+                                           Text="{Binding ReconstructionParameters.ConductivityMinimumBound}"/>
+                                    <Entry Grid.Column="1"
+                                           Placeholder="Max"
+                                           Keyboard="Numeric"
+                                           Text="{Binding ReconstructionParameters.ConductivityMaximumBound}"/>
+                                </Grid>
                             </Grid>
                         </Border>
                     </Grid>

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -2,6 +2,7 @@
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Measurement;
+using Utility.Classes.Reconstruction;
 using Utility.Classes.ReconstructionParameters;
 
 namespace Utility.Classes.Application
@@ -17,6 +18,8 @@ namespace Utility.Classes.Application
         private static int _maxIterationCount = 50;
         private static double _stepSize = 0.001;
         private static double _regularizationWeight = 1e-3;
+        private static double _conductivityMinimumBound = 0.1;
+        private static double _conductivityMaximumBound = 10.0;
 
         public const int ReconstructionVideoFramesPerSecond = 10;
 
@@ -54,7 +57,13 @@ namespace Utility.Classes.Application
         }
 
         public static void SetUser(User user) => _user = user;
-        public static void SetReconstructionParameters(EITReconstructionParameters eITReconstructionParameters) => _reconstructionParameters = eITReconstructionParameters;
+        public static void SetReconstructionParameters(EITReconstructionParameters eITReconstructionParameters)
+        {
+            _reconstructionParameters = eITReconstructionParameters;
+            _conductivityMinimumBound = eITReconstructionParameters.ConductivityMinimumBound;
+            _conductivityMaximumBound = eITReconstructionParameters.ConductivityMaximumBound;
+            ConductivityClipper.UpdateBounds(_conductivityMinimumBound, _conductivityMaximumBound);
+        }
         public static void SetDiscretization(IDiscretization? discretization) => _discretization = discretization;
         public static void SetOriginalDiscretization(IDiscretization? originalDiscretization) => _originalDiscretization = originalDiscretization;
         public static void SetInitialDiscretization(IDiscretization? initialDiscretization) => _initialDiscretization = initialDiscretization;
@@ -138,6 +147,18 @@ namespace Utility.Classes.Application
         {
             get => _regularizationWeight;
             set => _regularizationWeight = value;
+        }
+
+        public static double ConductivityMinimumBound
+        {
+            get => _conductivityMinimumBound;
+            set => _conductivityMinimumBound = value;
+        }
+
+        public static double ConductivityMaximumBound
+        {
+            get => _conductivityMaximumBound;
+            set => _conductivityMaximumBound = value;
         }
 
         public static void AddReconstructionResultToWorkspace(ReconstructionResult reconstructionResult) => _reconstructionResults.Add(reconstructionResult);

--- a/Utility/Classes/Reconstruction/ConductivityClipper.cs
+++ b/Utility/Classes/Reconstruction/ConductivityClipper.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Utility.Classes;
+
+namespace Utility.Classes.Reconstruction
+{
+    public static class ConductivityClipper
+    {
+        private static readonly object SyncRoot = new();
+        private static readonly ParallelOptions DefaultParallelOptions = new();
+
+        private static double _minimumBound = 0.1;
+        private static double _maximumBound = 10.0;
+
+        public static double MinimumBound
+        {
+            get
+            {
+                lock (SyncRoot)
+                {
+                    return _minimumBound;
+                }
+            }
+        }
+
+        public static double MaximumBound
+        {
+            get
+            {
+                lock (SyncRoot)
+                {
+                    return _maximumBound;
+                }
+            }
+        }
+
+        public static void UpdateBounds(double minimum, double maximum)
+        {
+            if (double.IsNaN(minimum) || double.IsInfinity(minimum))
+                throw new ArgumentException("Minimum conductivity bound must be a finite number.", nameof(minimum));
+            if (double.IsNaN(maximum) || double.IsInfinity(maximum))
+                throw new ArgumentException("Maximum conductivity bound must be a finite number.", nameof(maximum));
+
+            if (minimum > maximum)
+                (minimum, maximum) = (maximum, minimum);
+
+            lock (SyncRoot)
+            {
+                _minimumBound = minimum;
+                _maximumBound = maximum;
+            }
+        }
+
+        public static ConductivityDistribution Clip(
+            ConductivityDistribution distribution,
+            bool useParallel = false,
+            ParallelOptions? parallelOptions = null)
+        {
+            if (distribution == null)
+                throw new ArgumentNullException(nameof(distribution));
+
+            Dictionary<int, double> conductivities = distribution.Conductivities;
+            if (conductivities.Count == 0)
+                return distribution;
+
+            double min;
+            double max;
+
+            lock (SyncRoot)
+            {
+                min = _minimumBound;
+                max = _maximumBound;
+            }
+
+            bool shouldParallel = (useParallel || parallelOptions != null) && conductivities.Count > 1;
+            if (shouldParallel)
+            {
+                var options = parallelOptions ?? DefaultParallelOptions;
+                int length = conductivities.Count;
+                var keys = conductivities.Keys.ToArray();
+                var sanitizedValues = new double[length];
+
+                Parallel.For(0, length, options, i =>
+                {
+                    double value = conductivities[keys[i]];
+                    sanitizedValues[i] = Sanitize(value, min, max);
+                });
+
+                for (int i = 0; i < keys.Length; i++)
+                {
+                    conductivities[keys[i]] = sanitizedValues[i];
+                }
+            }
+            else
+            {
+                foreach (var key in conductivities.Keys.ToArray())
+                {
+                    double value = conductivities[key];
+                    conductivities[key] = Sanitize(value, min, max);
+                }
+            }
+
+            return distribution;
+        }
+
+        private static double Sanitize(double value, double minimum, double maximum)
+        {
+            if (double.IsNaN(value) || double.IsNegativeInfinity(value))
+            {
+                return minimum;
+            }
+
+            if (double.IsPositiveInfinity(value))
+            {
+                return maximum;
+            }
+
+            return Math.Clamp(value, minimum, maximum);
+        }
+    }
+}

--- a/Utility/Classes/Reconstruction/PotentialClipper.cs
+++ b/Utility/Classes/Reconstruction/PotentialClipper.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Utility.Classes;
+
+namespace Utility.Classes.Reconstruction
+{
+    public static class PotentialClipper
+    {
+        private static readonly ParallelOptions DefaultParallelOptions = new();
+
+        public static PotentialDistribution Clip(
+            PotentialDistribution distribution,
+            bool useParallel = false,
+            ParallelOptions? parallelOptions = null)
+        {
+            if (distribution == null)
+                throw new ArgumentNullException(nameof(distribution));
+
+            Dictionary<int, double> potentials = distribution.Potentials;
+            if (potentials.Count == 0)
+                return distribution;
+
+            bool shouldParallel = (useParallel || parallelOptions != null) && potentials.Count > 1;
+            if (shouldParallel)
+            {
+                var options = parallelOptions ?? DefaultParallelOptions;
+                int length = potentials.Count;
+                var keys = potentials.Keys.ToArray();
+                var sanitizedValues = new double[length];
+
+                Parallel.For(0, length, options, i =>
+                {
+                    double value = potentials[keys[i]];
+                    sanitizedValues[i] = Sanitize(value);
+                });
+
+                for (int i = 0; i < keys.Length; i++)
+                {
+                    potentials[keys[i]] = sanitizedValues[i];
+                }
+            }
+            else
+            {
+                foreach (var key in potentials.Keys.ToArray())
+                {
+                    double value = potentials[key];
+                    potentials[key] = Sanitize(value);
+                }
+            }
+
+            return distribution;
+        }
+
+        public static double[] Clip(
+            double[] potentials,
+            bool useParallel = false,
+            ParallelOptions? parallelOptions = null)
+        {
+            if (potentials == null)
+                throw new ArgumentNullException(nameof(potentials));
+
+            if (potentials.Length == 0)
+                return potentials;
+
+            bool shouldParallel = (useParallel || parallelOptions != null) && potentials.Length > 1;
+            if (shouldParallel)
+            {
+                var options = parallelOptions ?? DefaultParallelOptions;
+                Parallel.For(0, potentials.Length, options, i =>
+                {
+                    double value = potentials[i];
+                    potentials[i] = Sanitize(value);
+                });
+            }
+            else
+            {
+                for (int i = 0; i < potentials.Length; i++)
+                {
+                    double value = potentials[i];
+                    potentials[i] = Sanitize(value);
+                }
+            }
+
+            return potentials;
+        }
+
+        private static double Sanitize(double value)
+        {
+            return double.IsFinite(value) ? value : 0.0;
+        }
+    }
+}

--- a/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
+++ b/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
@@ -39,6 +39,12 @@ namespace Utility.Classes.ReconstructionParameters
         [ObservableProperty]
         private bool useCudaAcceleration = false;
 
+        [ObservableProperty]
+        private double conductivityMinimumBound = 0.1;
+
+        [ObservableProperty]
+        private double conductivityMaximumBound = 10.0;
+
         public DiscretizationType Mesh = DiscretizationType.FEM;
 
         /// <summary>


### PR DESCRIPTION
## Summary
- update conductivity and potential clippers to sanitize existing distributions instead of constructing new instances
- add optional parallel execution paths with configurable ParallelOptions to accelerate clipping when needed

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f6581badac8333a6a466ac84c044a8