### PR TITLE
Improve SVD solver and add conjugate gradient solver

### DIFF
--- a/Utility/Classes/Factories/NumericSolverFactory.cs
+++ b/Utility/Classes/Factories/NumericSolverFactory.cs
@@ -17,6 +17,7 @@ namespace Utility.Classes.Factories
             NumericSolver.SVD => CreateSVDSolver(),
             NumericSolver.tSVD => CreatetSVDSolver(),
             NumericSolver.GMRES => CreateGMRESSolver(),
+            NumericSolver.ConjugateGradient => CreateConjugateGradientSolver(),
             _ => throw new NotSupportedException()
         };
 
@@ -51,6 +52,15 @@ namespace Utility.Classes.Factories
             Workspace.AddLogMessage("NumericSolverFactory","Created GRMES Numeric Solver object.");
 
             return solver;
-        }        
+        }
+
+        private static ConjugateGradientSolver CreateConjugateGradientSolver()
+        {
+            var solver = new ConjugateGradientSolver();
+
+            Workspace.AddLogMessage("NumericSolverFactory","Created Conjugate Gradient Numeric Solver object.");
+
+            return solver;
+        }
     }
 }

--- a/Utility/Classes/Reconstruction/NumericSolvers/ConjugateGradientSolver.cs
+++ b/Utility/Classes/Reconstruction/NumericSolvers/ConjugateGradientSolver.cs
@@ -1,0 +1,85 @@
+using System;
+using Utility.Classes.ReconstructionParameters;
+
+using Vector = MathNet.Numerics.LinearAlgebra.Vector<double>;
+using Matrix = MathNet.Numerics.LinearAlgebra.Matrix<double>;
+
+namespace Utility.Classes.Reconstruction.NumericSolvers
+{
+    /// <summary>
+    /// Solves Ax = b using the Conjugate Gradient (CG) method with a diagonal preconditioner.
+    /// CG is extremely efficient for large, sparse, symmetric positive definite systems
+    /// that frequently arise from FEM discretisations.
+    /// </summary>
+    public sealed class ConjugateGradientSolver : INumericSolver
+    {
+        public Vector SolveLinearSystem(Matrix A, Vector b)
+        {
+            if (A == null)
+                throw new ArgumentNullException(nameof(A));
+            if (b == null)
+                throw new ArgumentNullException(nameof(b));
+
+            if (A.RowCount != b.Count)
+                throw new ArgumentException("Matrix and vector dimensions do not agree.");
+            if (A.RowCount != A.ColumnCount)
+                throw new ArgumentException("Conjugate Gradient requires a square matrix.");
+
+            int n = b.Count;
+            const double tolerance = 1e-10;
+            int maxIterations = Math.Min(5 * n, 5000);
+
+            var x = Vector.Build.Dense(n, 0.0);
+            var r = b - A * x;
+
+            if (r.L2Norm() < tolerance)
+                return x;
+
+            var diagonal = new double[n];
+            for (int i = 0; i < n; i++)
+            {
+                double d = A[i, i];
+                if (Math.Abs(d) < 1e-14)
+                    throw new InvalidOperationException("Matrix diagonal contains zeros making Jacobi preconditioning impossible.");
+                diagonal[i] = d;
+            }
+
+            Vector Precondition(Vector residual)
+            {
+                var z = Vector.Build.Dense(residual.Count);
+                for (int i = 0; i < residual.Count; i++)
+                    z[i] = residual[i] / diagonal[i];
+                return z;
+            }
+
+            var z0 = Precondition(r);
+            var p = z0.Clone();
+            double rzOld = r.DotProduct(z0);
+
+            for (int iteration = 0; iteration < maxIterations; iteration++)
+            {
+                var Ap = A * p;
+                double alphaDenominator = p.DotProduct(Ap);
+                if (Math.Abs(alphaDenominator) < 1e-20)
+                    throw new InvalidOperationException("Breakdown in conjugate gradient solver: direction became orthogonal.");
+
+                double alpha = rzOld / alphaDenominator;
+                x += alpha * p;
+                r -= alpha * Ap;
+
+                double residualNorm = r.L2Norm();
+                if (residualNorm < tolerance)
+                    return x;
+
+                var z = Precondition(r);
+                double rzNew = r.DotProduct(z);
+
+                double beta = rzNew / rzOld;
+                p = z + beta * p;
+                rzOld = rzNew;
+            }
+
+            throw new InvalidOperationException("Conjugate Gradient did not converge within the allotted iterations.");
+        }
+    }
+}

--- a/Utility/Classes/Reconstruction/NumericSolvers/SVDSolver.cs
+++ b/Utility/Classes/Reconstruction/NumericSolvers/SVDSolver.cs
@@ -1,4 +1,7 @@
+using System;
+using MathNet.Numerics;
 using MathNet.Numerics.LinearAlgebra;
+using MathNet.Numerics.LinearAlgebra.Double;
 using Utility.Classes.ReconstructionParameters;
 
 using Vector = MathNet.Numerics.LinearAlgebra.Vector<double>;
@@ -26,8 +29,34 @@ namespace Utility.Classes.Reconstruction.NumericSolvers
             //    b.Enumerate(Zeros.AllowSkip).Any(d => double.IsNaN(d) || double.IsInfinity(d)))
             //    throw new InvalidOperationException("SVD solver received non-finite entries. This typically indicates a degenerate FEM element in the mesh assembly.");
 
-            var svd = A.Svd(computeVectors: true);
-            return svd.Solve(b);
+            var dense = A as DenseMatrix ?? DenseMatrix.OfMatrix(A);
+
+            var svd = dense.Svd(computeVectors: true, fullVectors: false);
+            var singularValues = svd.S;
+
+            if (singularValues.Count == 0)
+                throw new InvalidOperationException("SVD failed to compute singular values.");
+
+            double sigmaMax = singularValues[0];
+            double tolerance = Math.Max(dense.RowCount, dense.ColumnCount) * Precision.DoubleMachineEpsilon * sigmaMax;
+
+            var projected = svd.U.TransposeThisAndMultiply(b);
+            var y = Vector.Build.Dense(singularValues.Count);
+
+            for (int i = 0; i < singularValues.Count; i++)
+            {
+                double sigma = singularValues[i];
+                if (sigma > tolerance)
+                {
+                    y[i] = projected[i] / sigma;
+                }
+                else
+                {
+                    y[i] = 0.0;
+                }
+            }
+
+            return svd.VT.TransposeThisAndMultiply(y);
         }
     }
 }

--- a/Utility/Classes/ReconstructionParameters/NumericSolver.cs
+++ b/Utility/Classes/ReconstructionParameters/NumericSolver.cs
@@ -5,7 +5,8 @@
         LU = 1,
         SVD = 2,
         tSVD = 3,
-        GMRES = 4
+        GMRES = 4,
+        ConjugateGradient = 5
     };
 
     public interface INumericSolver

--- a/Utility/Tests/NumericSolverTests.cs
+++ b/Utility/Tests/NumericSolverTests.cs
@@ -57,5 +57,18 @@ namespace Utility.Tests
             Assert.Equal(2.0, x[0], 6);
             Assert.Equal(3.0, x[1], 6);
         }
+
+        [Fact]
+        public void ConjugateGradient_Solves_SPD_System()
+        {
+            INumericSolver s = NumericSolverFactory.Create(NumericSolver.ConjugateGradient);
+            Matrix<double> A = DenseMatrix.OfArray(new double[,] { { 4, 1 }, { 1, 3 } });
+            Vector<double> b = Vector<double>.Build.DenseOfArray(new double[] { 1, 2 });
+
+            var x = s.SolveLinearSystem(A, b);
+
+            Assert.Equal(1.0 / 11.0, x[0], 6);
+            Assert.Equal(7.0 / 11.0, x[1], 6);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- optimize the SVD-based linear solver to use a thin decomposition with tolerance-based filtering for faster solves
- add a preconditioned conjugate gradient numeric solver and expose it through the factory
- extend numeric solver tests to cover the new solver option

## Testing
- `dotnet test` *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7593f4d4483339ed5fd1df72bc7ed