### PR TITLE
Improve MATLAB mesh import and add real measurement support

### DIFF
--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Xml.Linq;
 using System.Linq;
 using Utility.Classes;
@@ -9,6 +10,7 @@ using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Factories;
 using Utility.Classes.Measurement;
+using Utility.Classes.Application;
 
 namespace DataAccessLayer
 {
@@ -756,6 +758,7 @@ namespace DataAccessLayer
             var potentials = mesh.Vertices.ToDictionary(v => v.GlobalId, v => v.Potential);
             mesh.SetPotentialDistribution(new PotentialDistribution(potentials));
 
+            Workspace.ClearImportedMeasurement();
             TryAugmentFemMeshFromMatlabJson(mesh, filePath);
 
             return mesh;
@@ -770,14 +773,19 @@ namespace DataAccessLayer
             if (string.IsNullOrEmpty(jsonPath) || !File.Exists(jsonPath))
                 return;
 
-            MatlabImportDefinition? import;
+            MatlabImportDefinition? import = null;
+            MatlabJsonSupplement? supplement = null;
+
             try
             {
                 var json = File.ReadAllText(jsonPath);
-                import = JsonSerializer.Deserialize<MatlabImportDefinition>(json, new JsonSerializerOptions
+                using var document = JsonDocument.Parse(json, new JsonDocumentOptions { AllowTrailingCommas = true });
+                import = document.RootElement.Deserialize<MatlabImportDefinition>(new JsonSerializerOptions
                 {
                     PropertyNameCaseInsensitive = true
                 });
+
+                supplement = ExtractMatlabSupplement(document.RootElement);
             }
             catch
             {
@@ -788,7 +796,6 @@ namespace DataAccessLayer
                 return;
 
             const double CoordinateTolerance = 2e-2;
-
 
             mesh.Metadata.Parameters ??= new Dictionary<string, string>();
             mesh.Metadata.Parameters["matlabJson"] = Path.GetFileName(jsonPath);
@@ -821,7 +828,39 @@ namespace DataAccessLayer
                 }
             }
 
+            if (supplement?.MeasurementFrames != null && supplement.MeasurementFrames.Count > 0)
+            {
+                mesh.Metadata.Parameters["matlabMeasurementFrameCount"] = supplement.MeasurementFrames.Count.ToString(CultureInfo.InvariantCulture);
+                try
+                {
+                    var measurement = supplement.MeasurementAmplitude.HasValue
+                        ? new EITMeasurement(supplement.MeasurementFrames, supplement.MeasurementAmplitude.Value)
+                        : new EITMeasurement(supplement.MeasurementFrames);
+
+                    string label = ResolveMeasurementLabel(import);
+                    Workspace.SetImportedMeasurement(measurement, label);
+                    mesh.Metadata.Parameters["matlabMeasurementSource"] = label;
+                }
+                catch
+                {
+                    Workspace.ClearImportedMeasurement();
+                }
+            }
+
+            if ((import.ElectrodeZContact == null || import.ElectrodeZContact.Count == 0) && supplement?.ContactImpedances != null)
+                import.ElectrodeZContact = supplement.ContactImpedances;
+
+            var electrodeCoordinates = import.ElectrodeVertexCoordinates;
+            if ((electrodeCoordinates == null || electrodeCoordinates.Count == 0) && supplement?.ElectrodeCoordinates != null)
+                electrodeCoordinates = supplement.ElectrodeCoordinates;
+
             var vertices = mesh.Vertices;
+            foreach (var vertex in vertices)
+            {
+                vertex.IsElectrode = false;
+                vertex.ElectrodeId = -1;
+            }
+
             var electrodes = new List<FEMElectrode>();
             var reassignedElectrodes = new List<int>();
 
@@ -832,70 +871,19 @@ namespace DataAccessLayer
             double meshRangeX = meshMaxX - meshMinX;
             double meshRangeY = meshMaxY - meshMinY;
 
-            double electrodeMinX = double.PositiveInfinity;
-            double electrodeMaxX = double.NegativeInfinity;
-            double electrodeMinY = double.PositiveInfinity;
-            double electrodeMaxY = double.NegativeInfinity;
-            bool haveElectrodeBounds = false;
+            var transform = DetermineElectrodeTransform(vertices, electrodeCoordinates, meshMinX, meshMaxX, meshMinY, meshMaxY);
+            if (!string.IsNullOrEmpty(transform.Description))
+                mesh.Metadata.Parameters["electrodeTransform"] = transform.Description!;
 
-            if (import.ElectrodeVertexCoordinates != null && import.ElectrodeVertexCoordinates.Count > 0)
+            if (electrodeCoordinates != null && electrodeCoordinates.Count > 0)
             {
-                foreach (var coords in import.ElectrodeVertexCoordinates)
+                for (int i = 0; i < electrodeCoordinates.Count; i++)
                 {
-                    if (coords == null || coords.Length < 2)
+                    var coords = electrodeCoordinates[i];
+                    if (coords == null || coords.Length == 0)
                         continue;
 
-                    double x = coords[0];
-                    double y = coords[1];
-
-                    if (!double.IsFinite(x) || !double.IsFinite(y))
-                        continue;
-
-                    electrodeMinX = Math.Min(electrodeMinX, x);
-                    electrodeMaxX = Math.Max(electrodeMaxX, x);
-                    electrodeMinY = Math.Min(electrodeMinY, y);
-                    electrodeMaxY = Math.Max(electrodeMaxY, y);
-                    haveElectrodeBounds = true;
-                }
-            }
-
-            static double NormalizeCoordinate(double value, double min, double max)
-            {
-                double range = max - min;
-                if (range <= 1e-12)
-                    return 0.5;
-                double normalized = (value - min) / range;
-                return Math.Clamp(normalized, 0.0, 1.0);
-            }
-
-            foreach (var vertex in vertices)
-            {
-                vertex.IsElectrode = false;
-                vertex.ElectrodeId = -1;
-            }
-
-            if (import.ElectrodeVertexCoordinates != null && import.ElectrodeVertexCoordinates.Count > 0)
-            {
-                for (int i = 0; i < import.ElectrodeVertexCoordinates.Count; i++)
-                {
-                    var coords = import.ElectrodeVertexCoordinates[i];
-                    if (coords == null || coords.Length < 2)
-                        continue;
-
-                    double targetX = coords[0];
-                    double targetY = coords[1];
-
-                    if (haveElectrodeBounds)
-                    {
-                        double normalizedX = NormalizeCoordinate(targetX, electrodeMinX, electrodeMaxX);
-                        double normalizedY = NormalizeCoordinate(targetY, electrodeMinY, electrodeMaxY);
-
-                        double scaleX = meshRangeX <= 1e-12 ? 0.0 : meshRangeX;
-                        double scaleY = meshRangeY <= 1e-12 ? 0.0 : meshRangeY;
-
-                        targetX = meshMinX + normalizedX * scaleX;
-                        targetY = meshMinY + normalizedY * scaleY;
-                    }
+                    var (targetX, targetY) = ProjectElectrodeCoordinate(coords, transform, meshMinX, meshRangeX, meshMinY, meshRangeY);
 
                     var vertex = FindNearestVertex(
                         vertices,
@@ -904,8 +892,13 @@ namespace DataAccessLayer
                         CoordinateTolerance,
                         out bool withinTolerance,
                         v => v.IsBoundary);
+
                     if (vertex == null)
-                        continue;
+                    {
+                        vertex = FindNearestVertex(vertices, targetX, targetY, CoordinateTolerance, out withinTolerance, null);
+                        if (vertex == null)
+                            continue;
+                    }
 
                     if (!withinTolerance)
                         reassignedElectrodes.Add(i);
@@ -933,9 +926,7 @@ namespace DataAccessLayer
             }
 
             if (reassignedElectrodes.Count > 0)
-            {
                 mesh.Metadata.Parameters["electrodeReassignmentIndices"] = string.Join(",", reassignedElectrodes);
-            }
 
             if (import.DrivePatternPairs != null && import.DrivePatternPairs.Count > 0 && electrodes.Count > 0)
             {
@@ -979,10 +970,205 @@ namespace DataAccessLayer
                 }
 
                 if (conductivity.Count == mesh.ElementsTyped.Count)
-                {
                     mesh.SetConductivityDistribution(new ConductivityDistribution(conductivity));
+            }
+        }
+
+        private static (double X, double Y) ProjectElectrodeCoordinate(
+            IReadOnlyList<double> coords,
+            ElectrodeTransform transform,
+            double meshMinX,
+            double meshRangeX,
+            double meshMinY,
+            double meshRangeY)
+        {
+            double ExtractValue(int axis)
+            {
+                if (axis >= 0 && axis < coords.Count)
+                {
+                    double value = coords[axis];
+                    if (double.IsFinite(value))
+                        return value;
+                }
+
+                foreach (var value in coords)
+                {
+                    if (double.IsFinite(value))
+                        return value;
+                }
+
+                return 0.0;
+            }
+
+            double rawX = ExtractValue(transform.AxisX);
+            double rawY = ExtractValue(transform.AxisY);
+
+            if (!transform.HasBounds)
+                return (rawX, rawY);
+
+            double normalizedX = Normalize(rawX, transform.SourceMinX, transform.SourceMaxX);
+            if (transform.FlipX)
+                normalizedX = 1.0 - normalizedX;
+
+            double normalizedY = Normalize(rawY, transform.SourceMinY, transform.SourceMaxY);
+            if (transform.FlipY)
+                normalizedY = 1.0 - normalizedY;
+
+            double mappedX = meshMinX + normalizedX * meshRangeX;
+            double mappedY = meshMinY + normalizedY * meshRangeY;
+
+            return (mappedX, mappedY);
+        }
+
+        private static ElectrodeTransform DetermineElectrodeTransform(
+            IReadOnlyList<FEMVertex> vertices,
+            IReadOnlyList<double[]>? electrodeCoordinates,
+            double meshMinX,
+            double meshMaxX,
+            double meshMinY,
+            double meshMaxY)
+        {
+            var defaultTransform = new ElectrodeTransform(0, 1, 0.0, 1.0, 0.0, 1.0, false, false, false, null);
+
+            if (electrodeCoordinates == null || electrodeCoordinates.Count == 0)
+                return defaultTransform;
+
+            int dimension = electrodeCoordinates.Max(c => c?.Length ?? 0);
+            if (dimension < 2)
+                return defaultTransform;
+
+            var boundaryVertices = vertices.Where(v => v.IsBoundary).ToList();
+            if (boundaryVertices.Count == 0)
+                boundaryVertices = vertices.ToList();
+
+            var axisPairs = new List<(int X, int Y)>();
+            for (int a = 0; a < dimension; a++)
+                for (int b = a + 1; b < dimension; b++)
+                    axisPairs.Add((a, b));
+
+            if (axisPairs.Count == 0)
+                axisPairs.Add((0, 1));
+
+            double meshRangeX = meshMaxX - meshMinX;
+            double meshRangeY = meshMaxY - meshMinY;
+
+            double bestError = double.PositiveInfinity;
+            ElectrodeTransform bestTransform = defaultTransform;
+
+            foreach (var (axisX, axisY) in axisPairs)
+            {
+                var (minX, maxX, hasBoundsX) = GetAxisBounds(electrodeCoordinates, axisX);
+                var (minY, maxY, hasBoundsY) = GetAxisBounds(electrodeCoordinates, axisY);
+
+                bool hasBounds = hasBoundsX && hasBoundsY;
+
+                if (hasBounds)
+                {
+                    foreach (bool flipX in new[] { false, true })
+                    foreach (bool flipY in new[] { false, true })
+                    {
+                        string description = $"axes[{axisX},{axisY}] {(flipX ? "invX" : "x")}/{(flipY ? "invY" : "y")}";
+                        var transform = new ElectrodeTransform(axisX, axisY, minX, maxX, minY, maxY, flipX, flipY, true, description);
+                        double error = ComputeMappingError(electrodeCoordinates, boundaryVertices, transform,
+                            meshMinX, meshRangeX, meshMinY, meshRangeY);
+                        if (error < bestError)
+                        {
+                            bestError = error;
+                            bestTransform = transform;
+                        }
+                    }
+                }
+                else
+                {
+                    var transform = new ElectrodeTransform(axisX, axisY, minX, maxX, minY, maxY, false, false, false,
+                        $"axes[{axisX},{axisY}] raw");
+                    double error = ComputeMappingError(electrodeCoordinates, boundaryVertices, transform,
+                        meshMinX, meshRangeX, meshMinY, meshRangeY);
+                    if (error < bestError)
+                    {
+                        bestError = error;
+                        bestTransform = transform;
+                    }
                 }
             }
+
+            return bestTransform;
+        }
+
+        private static double ComputeMappingError(
+            IReadOnlyList<double[]> coordinates,
+            IReadOnlyList<FEMVertex> searchVertices,
+            ElectrodeTransform transform,
+            double meshMinX,
+            double meshRangeX,
+            double meshMinY,
+            double meshRangeY)
+        {
+            if (coordinates.Count == 0 || searchVertices.Count == 0)
+                return double.PositiveInfinity;
+
+            double total = 0.0;
+            int count = 0;
+
+            foreach (var entry in coordinates)
+            {
+                if (entry == null || entry.Length == 0)
+                    continue;
+
+                var (mappedX, mappedY) = ProjectElectrodeCoordinate(entry, transform, meshMinX, meshRangeX, meshMinY, meshRangeY);
+
+                var vertex = FindNearestVertex(searchVertices, mappedX, mappedY, 0.0, out _, null);
+                if (vertex == null)
+                    continue;
+
+                double dx = vertex.X - mappedX;
+                double dy = vertex.Y - mappedY;
+                total += dx * dx + dy * dy;
+                count++;
+            }
+
+            if (count == 0)
+                return double.PositiveInfinity;
+
+            return total / count;
+        }
+
+        private static (double Min, double Max, bool HasBounds) GetAxisBounds(
+            IReadOnlyList<double[]> coordinates,
+            int axis)
+        {
+            double min = double.PositiveInfinity;
+            double max = double.NegativeInfinity;
+            bool hasBounds = false;
+
+            foreach (var entry in coordinates)
+            {
+                if (entry == null || axis < 0 || axis >= entry.Length)
+                    continue;
+
+                double value = entry[axis];
+                if (!double.IsFinite(value))
+                    continue;
+
+                hasBounds = true;
+                if (value < min) min = value;
+                if (value > max) max = value;
+            }
+
+            return (min, max, hasBounds);
+        }
+
+        private static double Normalize(double value, double min, double max)
+        {
+            double range = max - min;
+            if (!double.IsFinite(value) || range <= 1e-12)
+                return 0.5;
+
+            double normalized = (value - min) / range;
+            if (!double.IsFinite(normalized))
+                return 0.5;
+
+            return Math.Clamp(normalized, 0.0, 1.0);
         }
 
         private static FEMVertex? FindNearestVertex(
@@ -1050,6 +1236,328 @@ namespace DataAccessLayer
             if (values == null || index < 0 || index >= values.Count)
                 return fallback;
             return values[index];
+        }
+
+        private static MatlabJsonSupplement? ExtractMatlabSupplement(JsonElement root)
+        {
+            try
+            {
+                var nodes = ExtractNodeCoordinates(root);
+                var electrodeData = ExtractElectrodeData(root, nodes);
+                var measurement = ExtractMeasurementData(root);
+
+                return new MatlabJsonSupplement
+                {
+                    ElectrodeCoordinates = electrodeData.Coordinates,
+                    ContactImpedances = electrodeData.ZContact,
+                    MeasurementFrames = measurement.Frames,
+                    MeasurementAmplitude = measurement.Amplitude
+                };
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static List<double[]>? ExtractNodeCoordinates(JsonElement root)
+        {
+            if (!TryFindPropertyCaseInsensitive(root, "nodes", out var nodesElement))
+                return null;
+
+            if (nodesElement.ValueKind != JsonValueKind.Array)
+                return null;
+
+            var nodes = new List<double[]>();
+            foreach (var node in nodesElement.EnumerateArray())
+            {
+                if (node.ValueKind != JsonValueKind.Array)
+                    continue;
+
+                var coords = new List<double>();
+                foreach (var component in node.EnumerateArray())
+                {
+                    if (TryReadDouble(component, out double value))
+                        coords.Add(value);
+                }
+
+                if (coords.Count > 0)
+                    nodes.Add(coords.ToArray());
+            }
+
+            return nodes.Count > 0 ? nodes : null;
+        }
+
+        private static (List<double[]>? Coordinates, List<double>? ZContact) ExtractElectrodeData(JsonElement root, List<double[]>? nodes)
+        {
+            if (!TryFindPropertyCaseInsensitive(root, "electrode", out var electrodeElement))
+            {
+                if (!TryFindPropertyCaseInsensitive(root, "electrodes", out electrodeElement))
+                    return (null, null);
+            }
+
+            if (electrodeElement.ValueKind != JsonValueKind.Array)
+                return (null, null);
+
+            var coordinates = new List<double[]>();
+            List<double>? zContacts = null;
+
+            foreach (var electrode in electrodeElement.EnumerateArray())
+            {
+                double[]? coord = null;
+
+                var indices = ExtractIntArray(electrode, "nodes")
+                    ?? ExtractIntArray(electrode, "node_indices")
+                    ?? ExtractIntArray(electrode, "nodeNumbers");
+
+                if (indices != null && nodes != null && nodes.Count > 0)
+                {
+                    var positions = new List<double[]>();
+                    foreach (int idx in indices)
+                    {
+                        var position = ResolveNode(nodes, idx);
+                        if (position != null)
+                            positions.Add(position);
+                    }
+
+                    if (positions.Count > 0)
+                    {
+                        int dimension = positions.Max(p => p.Length);
+                        var averages = new double[dimension];
+                        foreach (var pos in positions)
+                        {
+                            for (int i = 0; i < dimension && i < pos.Length; i++)
+                                averages[i] += pos[i];
+                        }
+
+                        for (int i = 0; i < dimension; i++)
+                            averages[i] /= positions.Count;
+
+                        coord = averages;
+                    }
+                }
+
+                if (coord == null)
+                {
+                    var centre = ExtractDoubleArray(electrode, "centre") ?? ExtractDoubleArray(electrode, "center");
+                    if (centre != null && centre.Length > 0)
+                        coord = centre;
+                }
+
+                if (coord != null)
+                    coordinates.Add(coord);
+
+                double? z = ExtractDouble(electrode, "z_contact");
+                if (z.HasValue)
+                {
+                    zContacts ??= new List<double>();
+                    zContacts.Add(z.Value);
+                }
+                else if (zContacts != null)
+                {
+                    zContacts.Add(0.0);
+                }
+            }
+
+            if (zContacts != null && zContacts.Count < coordinates.Count)
+            {
+                while (zContacts.Count < coordinates.Count)
+                    zContacts.Add(0.0);
+            }
+
+            return (coordinates.Count > 0 ? coordinates : null, zContacts);
+        }
+
+        private static (List<double[]>? Frames, double? Amplitude) ExtractMeasurementData(JsonElement root)
+        {
+            if (!TryFindPropertyCaseInsensitive(root, "vv", out var vvElement))
+                return (null, null);
+
+            if (vvElement.ValueKind != JsonValueKind.Array)
+                return (null, null);
+
+            var frames = new List<double[]>();
+            foreach (var row in vvElement.EnumerateArray())
+            {
+                if (row.ValueKind != JsonValueKind.Array)
+                    continue;
+
+                var values = new List<double>();
+                foreach (var entry in row.EnumerateArray())
+                {
+                    if (TryReadDouble(entry, out double value))
+                        values.Add(value);
+                }
+
+                if (values.Count > 0)
+                    frames.Add(values.ToArray());
+            }
+
+            return (frames.Count > 0 ? frames : null, null);
+        }
+
+        private static bool TryFindPropertyCaseInsensitive(JsonElement element, string name, out JsonElement value)
+        {
+            if (element.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var property in element.EnumerateObject())
+                {
+                    if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        value = property.Value;
+                        return true;
+                    }
+
+                    if (TryFindPropertyCaseInsensitive(property.Value, name, out value))
+                        return true;
+                }
+            }
+            else if (element.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in element.EnumerateArray())
+                {
+                    if (TryFindPropertyCaseInsensitive(item, name, out value))
+                        return true;
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+        private static bool TryGetPropertyCaseInsensitive(JsonElement element, string name, out JsonElement value)
+        {
+            if (element.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var property in element.EnumerateObject())
+                {
+                    if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        value = property.Value;
+                        return true;
+                    }
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+        private static List<int>? ExtractIntArray(JsonElement element, string propertyName)
+        {
+            if (!TryGetPropertyCaseInsensitive(element, propertyName, out var array) || array.ValueKind != JsonValueKind.Array)
+                return null;
+
+            var values = new List<int>();
+            foreach (var item in array.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.Number && item.TryGetInt32(out int intValue))
+                    values.Add(intValue);
+                else if (item.ValueKind == JsonValueKind.String && int.TryParse(item.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out intValue))
+                    values.Add(intValue);
+            }
+
+            return values.Count > 0 ? values : null;
+        }
+
+        private static double[]? ExtractDoubleArray(JsonElement element, string propertyName)
+        {
+            if (!TryGetPropertyCaseInsensitive(element, propertyName, out var array) || array.ValueKind != JsonValueKind.Array)
+                return null;
+
+            var values = new List<double>();
+            foreach (var item in array.EnumerateArray())
+            {
+                if (TryReadDouble(item, out double value))
+                    values.Add(value);
+            }
+
+            return values.Count > 0 ? values.ToArray() : null;
+        }
+
+        private static double? ExtractDouble(JsonElement element, string propertyName)
+        {
+            if (!TryGetPropertyCaseInsensitive(element, propertyName, out var value))
+                return null;
+
+            return TryReadDouble(value, out double result) ? result : null;
+        }
+
+        private static bool TryReadDouble(JsonElement element, out double value)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Number when element.TryGetDouble(out double numeric):
+                    value = numeric;
+                    return true;
+                case JsonValueKind.String:
+                    return double.TryParse(element.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+                default:
+                    value = 0.0;
+                    return false;
+            }
+        }
+
+        private static double[]? ResolveNode(List<double[]> nodes, int index)
+        {
+            if (nodes.Count == 0)
+                return null;
+
+            if (index >= 0 && index < nodes.Count)
+                return nodes[index];
+
+            int oneBased = index - 1;
+            if (oneBased >= 0 && oneBased < nodes.Count)
+                return nodes[oneBased];
+
+            return null;
+        }
+
+        private static string ResolveMeasurementLabel(MatlabImportDefinition import)
+        {
+            if (!string.IsNullOrWhiteSpace(import.ModelType))
+                return import.ModelType!;
+
+            if (!string.IsNullOrWhiteSpace(import.EidorsVersion))
+                return $"EIDORS {import.EidorsVersion}";
+
+            return "Matlab";
+        }
+
+        private readonly struct ElectrodeTransform
+        {
+            public ElectrodeTransform(int axisX, int axisY, double sourceMinX, double sourceMaxX, double sourceMinY, double sourceMaxY, bool flipX, bool flipY, bool hasBounds, string? description)
+            {
+                AxisX = axisX;
+                AxisY = axisY;
+                SourceMinX = sourceMinX;
+                SourceMaxX = sourceMaxX;
+                SourceMinY = sourceMinY;
+                SourceMaxY = sourceMaxY;
+                FlipX = flipX;
+                FlipY = flipY;
+                HasBounds = hasBounds;
+                Description = description;
+            }
+
+            public int AxisX { get; }
+            public int AxisY { get; }
+            public double SourceMinX { get; }
+            public double SourceMaxX { get; }
+            public double SourceMinY { get; }
+            public double SourceMaxY { get; }
+            public bool FlipX { get; }
+            public bool FlipY { get; }
+            public bool HasBounds { get; }
+            public string? Description { get; }
+        }
+
+        private sealed class MatlabJsonSupplement
+        {
+            public List<double[]>? ElectrodeCoordinates { get; init; }
+            public List<double>? ContactImpedances { get; init; }
+            public List<double[]>? MeasurementFrames { get; init; }
+            public double? MeasurementAmplitude { get; init; }
         }
 
         private sealed class MatlabImportDefinition

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -46,6 +46,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         private bool _resetMetricsOnStart = true;
         private bool _updatingDrivePatternSelection;
         private EITReconstructionParameters? _trackedParameters;
+        private MeasurementSourceOption _selectedMeasurementSource = Workspace.GetMeasurementSource();
 
         [ObservableProperty]
         private int iterationCount = 0;
@@ -92,6 +93,82 @@ namespace ElectricalImpedanceTomography.ViewModels
 
                 OnPropertyChanged(nameof(UseParallelizationToggle));
             }
+        }
+
+        public bool HasMeasurementSourceOptions => Workspace.GetImportedMeasurement() != null;
+
+        public bool IsSimulatedMeasurementSelected
+        {
+            get => SelectedMeasurementSource == MeasurementSourceOption.Simulated;
+            set
+            {
+                if (value)
+                    SelectedMeasurementSource = MeasurementSourceOption.Simulated;
+            }
+        }
+
+        public bool IsRealMeasurementSelected
+        {
+            get => SelectedMeasurementSource == MeasurementSourceOption.Real;
+            set
+            {
+                if (value)
+                    SelectedMeasurementSource = MeasurementSourceOption.Real;
+            }
+        }
+
+        public string RealMeasurementOptionLabel
+        {
+            get
+            {
+                var label = Workspace.GetImportedMeasurementLabel();
+                if (HasMeasurementSourceOptions && !string.IsNullOrWhiteSpace(label))
+                    return $"Real ({label})";
+                return "Real";
+            }
+        }
+
+        public void RefreshMeasurementSourceOptions() => RefreshMeasurementSourceSelection();
+
+        private MeasurementSourceOption SelectedMeasurementSource
+        {
+            get => _selectedMeasurementSource;
+            set
+            {
+                var desired = value;
+                if (desired == MeasurementSourceOption.Real && Workspace.GetImportedMeasurement() == null)
+                    desired = MeasurementSourceOption.Simulated;
+
+                Workspace.SetMeasurementSource(desired);
+                var actual = Workspace.GetMeasurementSource();
+
+                if (_selectedMeasurementSource != actual)
+                {
+                    _selectedMeasurementSource = actual;
+                    OnPropertyChanged(nameof(IsSimulatedMeasurementSelected));
+                    OnPropertyChanged(nameof(IsRealMeasurementSelected));
+                }
+                else if (_selectedMeasurementSource != desired)
+                {
+                    // Requested source was not available; update bindings to reflect the enforced value.
+                    OnPropertyChanged(nameof(IsSimulatedMeasurementSelected));
+                    OnPropertyChanged(nameof(IsRealMeasurementSelected));
+                }
+            }
+        }
+
+        private void RefreshMeasurementSourceSelection()
+        {
+            if (!HasMeasurementSourceOptions && _selectedMeasurementSource == MeasurementSourceOption.Real)
+            {
+                Workspace.SetMeasurementSource(MeasurementSourceOption.Simulated);
+            }
+
+            _selectedMeasurementSource = Workspace.GetMeasurementSource();
+            OnPropertyChanged(nameof(HasMeasurementSourceOptions));
+            OnPropertyChanged(nameof(RealMeasurementOptionLabel));
+            OnPropertyChanged(nameof(IsSimulatedMeasurementSelected));
+            OnPropertyChanged(nameof(IsRealMeasurementSelected));
         }
 
         [ObservableProperty]
@@ -225,6 +302,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             TrackReconstructionParameters(ReconstructionParameters);
             SyncDrivePatternSelection();
             UpdateParallelizationToggleState();
+            RefreshMeasurementSourceSelection();
 
             //UpdateMetric(MetricKeys.ErrorMetric, ReconstructionParameters.ErrorMetric.ToString());
             //UpdateMetric(MetricKeys.RegularizationWeight, FormatDouble(RegularizationWeight, "G3"));
@@ -567,7 +645,11 @@ namespace ElectricalImpedanceTomography.ViewModels
         }
 
         partial void OnReconstructionSearchTextChanged(string value) => ApplyReconstructionFilter();
-        private void UpdateMesh() => _discretization = Workspace.GetDiscretization();
+        private void UpdateMesh()
+        {
+            _discretization = Workspace.GetDiscretization();
+            RefreshMeasurementSourceSelection();
+        }
         private void UpdateReconstructionParameters() => ReconstructionParameters = Workspace.GetReconstructionParameters();
 
         private void InitializeReconstruction(bool force = false)

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -146,20 +146,40 @@
                         <Border Grid.Column="0"
                                 Style="{StaticResource PanelSectionBorderStyle}"
                                 BackgroundColor="{AppThemeBinding Light=#27344D, Dark=#27344D}">
-                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
+                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
                                 <Label Grid.Row="0" Text="Methods" FontSize="Medium" FontAttributes="Bold" Margin="0,0,0,12"/>
-                                <Label Grid.Row="1" HorizontalOptions="Start" Text="DE Solver" FontFamily="SF Pro Text" FontAttributes="None"/>
-                                <Picker Grid.Row="2" ItemsSource="{Binding DifferentialEquationSolverOptions}" SelectedItem="{Binding ReconstructionParameters.DifferentialEquationSolver}" WidthRequest="150"/>
-                                <Label Grid.Row="3" HorizontalOptions="Start" Text="Error Metric" FontFamily="SF Pro Text" FontAttributes="None"/>
-                                <Picker Grid.Row="4" HorizontalOptions="Start" ItemsSource="{Binding ErrorMetricOptions}" SelectedItem="{Binding ReconstructionParameters.ErrorMetric}" WidthRequest="150"/>
-                                <Label Grid.Row="5" HorizontalOptions="Start" Text="Regularization" FontFamily="SF Pro Text" FontAttributes="None"/>
-                                <Picker Grid.Row="6" ItemsSource="{Binding RegularizationTechniqueOptions}" SelectedItem="{Binding ReconstructionParameters.RegularizationTechnique}"/>
-                                <Label Grid.Row="7" HorizontalOptions="Start" Text="Optimizer" FontFamily="SF Pro Text" FontAttributes="None"/>
-                                <Picker Grid.Row="8" ItemsSource="{Binding NumericOptimizerOptions}" SelectedItem="{Binding ReconstructionParameters.NumericOptimizer}"/>
-                                <Label Grid.Row="9" HorizontalOptions="Start" Text="Linear Solver" FontFamily="SF Pro Text" FontAttributes="None"/>
-                                <Picker Grid.Row="10" ItemsSource="{Binding NumericSolverOptions}" SelectedItem="{Binding ReconstructionParameters.NumericSolver}" WidthRequest="150"/>
-                                <Label Grid.Row="11" HorizontalOptions="Start" Text="{Binding ParallelizationToggleLabel}" FontFamily="SF Pro Text" FontAttributes="None"/>
-                                <Switch Grid.Row="12" IsToggled="{Binding UseParallelizationToggle}" HorizontalOptions="Start"/>
+                                <Label Grid.Row="1"
+                                       HorizontalOptions="Start"
+                                       Text="Measurement Source"
+                                       FontFamily="SF Pro Text"
+                                       FontAttributes="None"
+                                       IsVisible="{Binding HasMeasurementSourceOptions}"/>
+                                <Grid Grid.Row="2"
+                                      ColumnDefinitions="*, *"
+                                      ColumnSpacing="10"
+                                      IsVisible="{Binding HasMeasurementSourceOptions}">
+                                    <RadioButton Content="Simulated"
+                                                 IsChecked="{Binding IsSimulatedMeasurementSelected}"
+                                                 GroupName="MeasurementSourceOptions"
+                                                 HorizontalOptions="Start"/>
+                                    <RadioButton Grid.Column="1"
+                                                 Content="{Binding RealMeasurementOptionLabel}"
+                                                 IsChecked="{Binding IsRealMeasurementSelected}"
+                                                 GroupName="MeasurementSourceOptions"
+                                                 HorizontalOptions="Start"/>
+                                </Grid>
+                                <Label Grid.Row="3" HorizontalOptions="Start" Text="DE Solver" FontFamily="SF Pro Text" FontAttributes="None"/>
+                                <Picker Grid.Row="4" ItemsSource="{Binding DifferentialEquationSolverOptions}" SelectedItem="{Binding ReconstructionParameters.DifferentialEquationSolver}" WidthRequest="150"/>
+                                <Label Grid.Row="5" HorizontalOptions="Start" Text="Error Metric" FontFamily="SF Pro Text" FontAttributes="None"/>
+                                <Picker Grid.Row="6" HorizontalOptions="Start" ItemsSource="{Binding ErrorMetricOptions}" SelectedItem="{Binding ReconstructionParameters.ErrorMetric}" WidthRequest="150"/>
+                                <Label Grid.Row="7" HorizontalOptions="Start" Text="Regularization" FontFamily="SF Pro Text" FontAttributes="None"/>
+                                <Picker Grid.Row="8" ItemsSource="{Binding RegularizationTechniqueOptions}" SelectedItem="{Binding ReconstructionParameters.RegularizationTechnique}"/>
+                                <Label Grid.Row="9" HorizontalOptions="Start" Text="Optimizer" FontFamily="SF Pro Text" FontAttributes="None"/>
+                                <Picker Grid.Row="10" ItemsSource="{Binding NumericOptimizerOptions}" SelectedItem="{Binding ReconstructionParameters.NumericOptimizer}"/>
+                                <Label Grid.Row="11" HorizontalOptions="Start" Text="Linear Solver" FontFamily="SF Pro Text" FontAttributes="None"/>
+                                <Picker Grid.Row="12" ItemsSource="{Binding NumericSolverOptions}" SelectedItem="{Binding ReconstructionParameters.NumericSolver}" WidthRequest="150"/>
+                                <Label Grid.Row="13" HorizontalOptions="Start" Text="{Binding ParallelizationToggleLabel}" FontFamily="SF Pro Text" FontAttributes="None"/>
+                                <Switch Grid.Row="14" IsToggled="{Binding UseParallelizationToggle}" HorizontalOptions="Start"/>
                             </Grid>
                         </Border>
                         <!-- Parameter Configuration -->

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -126,13 +126,14 @@ public partial class ReconstructionPage : ContentPage
         MetricTrendCanvas.InvalidateSurface();
     }
 
-    protected override void OnAppearing()
-    {
-        base.OnAppearing();
-        var (startColor, endColor) = GetBackgroundPulseColors();
-        this.StartBackgroundPulse(startColor, endColor);
-        _viewModel.LoadAvailableReconstructions();
-    }
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            var (startColor, endColor) = GetBackgroundPulseColors();
+            this.StartBackgroundPulse(startColor, endColor);
+            _viewModel.RefreshMeasurementSourceOptions();
+            _viewModel.LoadAvailableReconstructions();
+        }
 
     protected override void OnDisappearing()
     {

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -43,6 +43,8 @@ namespace ServiceLayer
         private IDrivePatternStrategy _drivePatternStrategy = DrivePatternStrategyProvider.GetStrategy(DrivePattern.Adjecent);
         private readonly Random _noiseRandom = new();
         private bool _useOmpParallelization;
+        private MeasurementSourceOption _measurementSource = MeasurementSourceOption.Simulated;
+        private double? _realMeasurementAmplitude;
 
         public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
         public event EventHandler<ReconstructionFrame>? ReconstructionFrameUpdated;
@@ -195,6 +197,9 @@ namespace ServiceLayer
                     Workspace.AddLogMessage("Reconstruction Service",
                         $"Measurement noise enabled: {_measurementNoiseType} (amplitude {amplitudeDescriptor}).");
                 }
+
+                _measurementSource = Workspace.GetMeasurementSource();
+                _realMeasurementAmplitude = null;
             }
             catch(Exception ex)
             {
@@ -359,10 +364,37 @@ namespace ServiceLayer
             ground.Current = -excitationAmplitude;
         }
 
+        private void SyncMeasurementSource()
+        {
+            var desired = Workspace.GetMeasurementSource();
+            if (desired == _measurementSource)
+                return;
+
+            _measurementSource = desired;
+            _simulatedMeasurements.Clear();
+            _simMeasurementIndex = 0;
+            _realMeasurementAmplitude = null;
+        }
+
         private void EnsureSimulatedMeasurements()
         {
             if (_simulatedMeasurements.Count > 0)
                 return;
+
+            if (_measurementSource == MeasurementSourceOption.Real)
+            {
+                var measurement = Workspace.GetImportedMeasurement();
+                if (measurement != null && measurement.Frames.Count > 0)
+                {
+                    _simulatedMeasurements = measurement.Frames.Select(frame => (double[])frame.Clone()).ToList();
+                    _realMeasurementAmplitude = measurement.CurrentAmplitude;
+                    return;
+                }
+
+                Workspace.AddWarningMessage("Real measurement data was requested but is not available. Falling back to simulated measurements.");
+                _measurementSource = MeasurementSourceOption.Simulated;
+                _realMeasurementAmplitude = null;
+            }
 
             var original = Workspace.GetOriginalDiscretization()
                            ?? throw new NullReferenceException("Original mesh not set.");
@@ -371,11 +403,13 @@ namespace ServiceLayer
             {
                 var frames = _reconstructionPersistence.SimulateFemMeasurements(femOrig, _excitationAmplitude, _drivePattern);
                 _simulatedMeasurements = CloneMeasurementsWithNoise(frames, _measurementNoiseType, _measurementNoiseAmplitude);
+                _realMeasurementAmplitude = null;
             }
             else if (_discretization is LBMGrid && original is LBMGrid lbmOrig)
             {
                 var measurement = _reconstructionPersistence.SimulateLbmMeasurements(lbmOrig, _excitationAmplitude, _drivePattern);
                 _simulatedMeasurements = CloneMeasurementsWithNoise(measurement.Frames, _measurementNoiseType, _measurementNoiseAmplitude);
+                _realMeasurementAmplitude = null;
             }
             else
             {
@@ -430,6 +464,8 @@ namespace ServiceLayer
 
         private ReconstructionFrame? PerformInverseStep()
         {
+            SyncMeasurementSource();
+
             if (_discretization is FEMMesh femMesh)
             {
                 EnsureSimulatedMeasurements();
@@ -444,7 +480,8 @@ namespace ServiceLayer
                 var measurement = _simulatedMeasurements[stepIndex];
 
                 var electrodes = femMesh.GetElectrodes().Cast<FEMElectrode>().ToList();
-                ApplyDrivePatternToElectrodes(electrodes, _excitationAmplitude, stepIndex);
+                double effectiveAmplitude = _realMeasurementAmplitude ?? _excitationAmplitude;
+                ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, stepIndex);
 
                 var bc = new FEMBoundaryCondition(electrodes);
 
@@ -479,7 +516,8 @@ namespace ServiceLayer
                 int electrodeCount = electrodes.Count;
                 int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(electrodeCount));
                 int stepIndex = _simMeasurementIndex % cycleLength;
-                ApplyDrivePatternToElectrodes(electrodes, _excitationAmplitude, stepIndex);
+                double effectiveAmplitude = _realMeasurementAmplitude ?? _excitationAmplitude;
+                ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, stepIndex);
 
                 var bc = new LBMBoundaryCondition(electrodes);
                 double[] measurement = _simulatedMeasurements[stepIndex];
@@ -563,6 +601,8 @@ namespace ServiceLayer
 
             return await Task.Run(() =>
             {
+                SyncMeasurementSource();
+
                 if (_discretization is FEMMesh femMesh)
                 {
                     EnsureSimulatedMeasurements();
@@ -572,7 +612,8 @@ namespace ServiceLayer
 
                     for (int i = 0; i < _simulatedMeasurements.Count; i++)
                     {
-                        ApplyDrivePatternToElectrodes(electrodes, _excitationAmplitude, i);
+                        double effectiveAmplitude = _realMeasurementAmplitude ?? _excitationAmplitude;
+                        ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, i);
 
                         var bc = new FEMBoundaryCondition(electrodes);
                         var measurement = _simulatedMeasurements[i];
@@ -624,7 +665,8 @@ namespace ServiceLayer
                     for (int i = 0; i < _simulatedMeasurements.Count; i++)
                     {
                         var electrodes = lbmGrid.GetElectrodes().Cast<LBMElectrode>().ToList();
-                        ApplyDrivePatternToElectrodes(electrodes, _excitationAmplitude, i);
+                        double effectiveAmplitude = _realMeasurementAmplitude ?? _excitationAmplitude;
+                        ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, i);
                         var bc = new LBMBoundaryCondition(electrodes);
 
                         var measurement = _simulatedMeasurements[i];

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -37,7 +37,11 @@ namespace Utility.Classes.Application
         private static List<LBMElectrode>? _currentGlobalLbmElectrodes;
         private static LBMBoundaryCondition? _currentGlobalLbmBoundaryCondition;
 
-        private static bool _initialized = false; 
+        private static bool _initialized = false;
+
+        private static EITMeasurement? _importedMeasurement;
+        private static string? _importedMeasurementLabel;
+        private static MeasurementSourceOption _measurementSource = MeasurementSourceOption.Simulated;
 
         public static void Initialize(User user, EITReconstructionParameters? eITReconstructionParameters, IDiscretization? discretization)
         {
@@ -130,6 +134,44 @@ namespace Utility.Classes.Application
 
         public static LBMBoundaryCondition GetCurrentGlobalLbmBoundaryCondition()
             => _currentGlobalLbmBoundaryCondition ?? throw new InvalidOperationException("Current LBM boundary condition has not been cached in the workspace.");
+
+        public static void SetImportedMeasurement(EITMeasurement? measurement, string? label = null)
+        {
+            bool hadMeasurement = _importedMeasurement != null;
+
+            if (measurement == null)
+            {
+                _importedMeasurement = null;
+                _importedMeasurementLabel = null;
+                _measurementSource = MeasurementSourceOption.Simulated;
+                return;
+            }
+
+            _importedMeasurement = measurement;
+            _importedMeasurementLabel = label;
+
+            if (!hadMeasurement)
+                _measurementSource = MeasurementSourceOption.Real;
+        }
+
+        public static void ClearImportedMeasurement() => SetImportedMeasurement(null);
+
+        public static EITMeasurement? GetImportedMeasurement() => _importedMeasurement;
+
+        public static string? GetImportedMeasurementLabel() => _importedMeasurementLabel;
+
+        public static MeasurementSourceOption GetMeasurementSource() => _measurementSource;
+
+        public static void SetMeasurementSource(MeasurementSourceOption source)
+        {
+            if (source == MeasurementSourceOption.Real && _importedMeasurement == null)
+            {
+                _measurementSource = MeasurementSourceOption.Simulated;
+                return;
+            }
+
+            _measurementSource = source;
+        }
 
         public static int MaxIterationCount
         {

--- a/Utility/Classes/Measurement/MeasurementSourceOption.cs
+++ b/Utility/Classes/Measurement/MeasurementSourceOption.cs
@@ -1,0 +1,8 @@
+namespace Utility.Classes.Measurement
+{
+    public enum MeasurementSourceOption
+    {
+        Simulated,
+        Real
+    }
+}


### PR DESCRIPTION
## Summary
- enhance STL+JSON mesh augmentation to recover electrode mappings reliably and consume optional MATLAB measurement frames
- persist imported measurement data in the workspace and extend the reconstruction service to honour real measurements when selected
- expose measurement source selection in the reconstruction UI so users can toggle between simulated and imported readings

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7668c19fc83338c36852c81221445