### PR TITLE
Handle FEM reconstruction with non-active electrode data

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -1,5 +1,6 @@
 ﻿using DataAccessLayer;
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Utility.Classes;
@@ -360,6 +361,41 @@ namespace BusinessLayer
             return new ReconstructionFrame(dataGrad, phi, mu, new ConductivityDistribution([]));
         }
 
+        private static double[] AlignMeasurementVector(double[] measurement, List<FEMElectrode> electrodes)
+        {
+            // Rebuild a length-M vector compatible with the FEM solver.  Missing entries
+            // from non-active datasets are padded with NaNs so that the misfit ignores
+            // excitation electrodes while preserving index alignment.
+            int electrodeCount = electrodes.Count;
+            if (electrodeCount == 0)
+                return measurement;
+
+            if (measurement.Length == electrodeCount)
+                return measurement;
+
+            if (measurement.Length > electrodeCount)
+                return measurement.Take(electrodeCount).ToArray();
+
+            double[] expanded = Enumerable.Repeat(double.NaN, electrodeCount).ToArray();
+            int measurementIndex = 0;
+            int measuringElectrodes = electrodes.Count(e => e.IsMeasuring);
+
+            for (int i = 0; i < electrodeCount && measurementIndex < measurement.Length; i++)
+            {
+                if (!electrodes[i].IsMeasuring)
+                    continue;
+
+                expanded[i] = measurement[measurementIndex++];
+            }
+
+            if (measurementIndex < measurement.Length)
+                Workspace.AddWarningMessage($"Discarding {measurement.Length - measurementIndex} excess measurement entries that cannot be mapped to electrodes.");
+            else if (measurementIndex < measuringElectrodes)
+                Workspace.AddWarningMessage($"Measurement frame supplies only {measurementIndex} of {measuringElectrodes} measuring electrodes. Missing values will be ignored.");
+
+            return expanded;
+        }
+
         private ReconstructionFrame ComputeFemInverseStep(FEMMesh mesh,
                                                           FEMBoundaryCondition bc,
                                                           double[] currentMeasurement,
@@ -396,10 +432,12 @@ namespace BusinessLayer
                 elements = mesh.GetElements().Cast<FEMElement>().ToList();
             }
 
+            // Ensure the data vector mirrors the electrode ordering that the solver expects.
+            var measurementVector = AlignMeasurementVector(currentMeasurement, electrodes);
             PotentialDistribution phi = PotentialClipper.Clip(solver.Solve(mesh, bc, null));
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
 
-            var adjSrc = errorMetric.EvaluateAdjointSource(mesh, currentMeasurement, simulatedPotentials);
+            var adjSrc = errorMetric.EvaluateAdjointSource(mesh, measurementVector, simulatedPotentials);
             Complex[] adjointSource = new Complex[adjSrc.Length];
             for (int k = 0; k < adjSrc.Length; k++)
                 adjointSource[k] = adjSrc[k];
@@ -887,7 +925,9 @@ namespace BusinessLayer
                 _ = _differentialEquationSolver.Solve(mesh, bc, null);
                 double[] dSimNew = mesh.GetElectrodePotentials();
                 double[] dObs = simulatedMeasurements[exc];
-                Jtotal += _errorMetric.Evaluate(mesh, dObs, dSimNew);
+                // Compare only the electrodes that are physically measured in the current configuration.
+                var alignedObs = AlignMeasurementVector(dObs, electrodes);
+                Jtotal += _errorMetric.Evaluate(mesh, alignedObs, dSimNew);
             }
 
             return Jtotal;
@@ -1257,7 +1297,9 @@ namespace BusinessLayer
                     var phiNew = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, bc, null));
                     double[] dSimNew = PotentialClipper.Clip(mesh.GetElectrodePotentials());
                     double[] dObs = simulatedMeasurements[exc];
-                    Jtotal += _errorMetric.Evaluate(mesh, dObs, dSimNew);
+                    // Restrict the misfit to the subset of electrodes that produced readings.
+                    var alignedObs = AlignMeasurementVector(dObs, electrodes);
+                    Jtotal += _errorMetric.Evaluate(mesh, alignedObs, dSimNew);
                 }
                 Debug.WriteLine($"Iteration {iter}: total misfit = {Jtotal}");
 

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Storage;
@@ -128,6 +128,23 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
         }
 
+        private string _electrodeMeasurementSetupLabel = FormatMeasurementSetupLabel(Workspace.GetElectrodeMeasurementSetup());
+
+        public string ElectrodeMeasurementSetupLabel
+        {
+            get => _electrodeMeasurementSetupLabel;
+            private set => SetProperty(ref _electrodeMeasurementSetupLabel, value);
+        }
+
+        private static string FormatMeasurementSetupLabel(ElectrodeMeasurementSetup setup) => setup == ElectrodeMeasurementSetup.Active
+            ? "Electrode measurement setup: Active (excitation electrodes are sampled)"
+            : "Electrode measurement setup: Non-active (excitation electrodes are ignored)";
+
+        private void OnElectrodeMeasurementSetupChanged(ElectrodeMeasurementSetup setup)
+        {
+            ElectrodeMeasurementSetupLabel = FormatMeasurementSetupLabel(setup);
+        }
+
         public void RefreshMeasurementSourceOptions() => RefreshMeasurementSourceSelection();
 
         private MeasurementSourceOption SelectedMeasurementSource
@@ -169,6 +186,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             OnPropertyChanged(nameof(RealMeasurementOptionLabel));
             OnPropertyChanged(nameof(IsSimulatedMeasurementSelected));
             OnPropertyChanged(nameof(IsRealMeasurementSelected));
+            ElectrodeMeasurementSetupLabel = FormatMeasurementSetupLabel(Workspace.GetElectrodeMeasurementSetup());
         }
 
         [ObservableProperty]
@@ -303,6 +321,8 @@ namespace ElectricalImpedanceTomography.ViewModels
             SyncDrivePatternSelection();
             UpdateParallelizationToggleState();
             RefreshMeasurementSourceSelection();
+            ElectrodeMeasurementSetupLabel = FormatMeasurementSetupLabel(Workspace.GetElectrodeMeasurementSetup());
+            Workspace.ElectrodeMeasurementSetupChanged += OnElectrodeMeasurementSetupChanged;
 
             //UpdateMetric(MetricKeys.ErrorMetric, ReconstructionParameters.ErrorMetric.ToString());
             //UpdateMetric(MetricKeys.RegularizationWeight, FormatDouble(RegularizationWeight, "G3"));

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -217,20 +217,25 @@
                                    FontFamily="SF Pro Text"
                                    FontAttributes="None"
                                    IsVisible="{Binding HasMeasurementSourceOptions}"/>
-                            <Grid Grid.Row="2"
-                                  ColumnDefinitions="*, *"
-                                  ColumnSpacing="10"
-                                  IsVisible="{Binding HasMeasurementSourceOptions}">
-                                <RadioButton Content="Simulated"
-                                             IsChecked="{Binding IsSimulatedMeasurementSelected}"
-                                             GroupName="MeasurementSourceOptions"
-                                             HorizontalOptions="Start"/>
-                                <RadioButton Grid.Column="1"
-                                             Content="{Binding RealMeasurementOptionLabel}"
-                                             IsChecked="{Binding IsRealMeasurementSelected}"
-                                             GroupName="MeasurementSourceOptions"
-                                             HorizontalOptions="Start"/>        
-                            </Grid>
+                            <VerticalStackLayout Grid.Row="2"
+                                                  Spacing="4"
+                                                  IsVisible="{Binding HasMeasurementSourceOptions}">
+                                <Grid ColumnDefinitions="*, *" ColumnSpacing="10">
+                                    <RadioButton Content="Simulated"
+                                                 IsChecked="{Binding IsSimulatedMeasurementSelected}"
+                                                 GroupName="MeasurementSourceOptions"
+                                                 HorizontalOptions="Start"/>
+                                    <RadioButton Grid.Column="1"
+                                                 Content="{Binding RealMeasurementOptionLabel}"
+                                                 IsChecked="{Binding IsRealMeasurementSelected}"
+                                                 GroupName="MeasurementSourceOptions"
+                                                 HorizontalOptions="Start"/>
+                                </Grid>
+                                <Label Text="{Binding ElectrodeMeasurementSetupLabel}"
+                                       FontSize="12"
+                                       FontAttributes="Italic"
+                                       LineBreakMode="WordWrap"/>
+                            </VerticalStackLayout>
 
                             <HorizontalStackLayout Grid.Row="3" Spacing="30">
                                 <Label Grid.Row="3" Text="Starting Excitation Electrode" FontAttributes="None" VerticalOptions="Center"/>

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -1,5 +1,6 @@
 ﻿using BusinessLayer;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Utility.Classes;
@@ -45,6 +46,10 @@ namespace ServiceLayer
         private bool _useOmpParallelization;
         private MeasurementSourceOption _measurementSource = MeasurementSourceOption.Simulated;
         private double? _realMeasurementAmplitude;
+        // Tracks whether the currently loaded measurements include voltages on the driven electrodes
+        // ("active") or omit them ("non-active").  This flag is mirrored to the workspace so that
+        // the UI can communicate the acquisition mode to the user.
+        private ElectrodeMeasurementSetup _measurementSetup = ElectrodeMeasurementSetup.Active;
 
         public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
         public event EventHandler<ReconstructionFrame>? ReconstructionFrameUpdated;
@@ -171,6 +176,9 @@ namespace ServiceLayer
                 _reconstructionPersistence.SetConductivityDistributions(_originalSigma, _initialSigma);
                 _reconstructionPersistence.InitializeReconstruction(discretization, parameters, reinit);
 
+                _measurementSetup = ElectrodeMeasurementSetup.Active;
+                Workspace.SetElectrodeMeasurementSetup(ElectrodeMeasurementSetup.Active);
+
                 _drivePattern = parameters.DrivePattern;
                 _drivePatternStrategy = DrivePatternStrategyProvider.GetStrategy(_drivePattern);
                 _useOmpParallelization = parameters.UseOmpParallelization;
@@ -260,8 +268,10 @@ namespace ServiceLayer
             {
                 var femBc = boundaryCondition as FEMBoundaryCondition
                              ?? throw new ArgumentException("Boundary condition must be FEMBoundaryCondition", nameof(boundaryCondition));
+                // Ensure the measurement vector respects the per-electrode measuring/drive state encoded in the boundary condition.
+                var preparedMeasurement = PrepareMeasurementFrame(measurement, femBc.GetElectrodes());
 
-                ReconstructionFrame frame = _reconstructionPersistence.InverseSolveStepFem(mesh, femBc, measurement, stepSize);
+                ReconstructionFrame frame = _reconstructionPersistence.InverseSolveStepFem(mesh, femBc, preparedMeasurement, stepSize);
 
                 Workspace.AddReconstructionFrameToWorkspace(frame);
 
@@ -374,12 +384,21 @@ namespace ServiceLayer
             _simulatedMeasurements.Clear();
             _simMeasurementIndex = 0;
             _realMeasurementAmplitude = null;
+            _measurementSetup = ElectrodeMeasurementSetup.Active;
+            Workspace.SetElectrodeMeasurementSetup(ElectrodeMeasurementSetup.Active);
         }
 
         private void EnsureSimulatedMeasurements()
         {
             if (_simulatedMeasurements.Count > 0)
                 return;
+
+            int electrodeCount = _discretization switch
+            {
+                FEMMesh fem => fem.GetElectrodes().Count,
+                LBMGrid lbm => lbm.GetElectrodes().Count,
+                _ => 0
+            };
 
             if (_measurementSource == MeasurementSourceOption.Real)
             {
@@ -388,6 +407,8 @@ namespace ServiceLayer
                 {
                     _simulatedMeasurements = measurement.Frames.Select(frame => (double[])frame.Clone()).ToList();
                     _realMeasurementAmplitude = measurement.CurrentAmplitude;
+                    // Persist whether this imported dataset follows the active or non-active convention.
+                    UpdateMeasurementSetupFromFrames(electrodeCount, _simulatedMeasurements);
                     return;
                 }
 
@@ -404,12 +425,15 @@ namespace ServiceLayer
                 var frames = _reconstructionPersistence.SimulateFemMeasurements(femOrig, _excitationAmplitude, _drivePattern);
                 _simulatedMeasurements = CloneMeasurementsWithNoise(frames, _measurementNoiseType, _measurementNoiseAmplitude);
                 _realMeasurementAmplitude = null;
+                // Simulations currently emit active frames, but we still record the mode to keep the UI consistent.
+                UpdateMeasurementSetupFromFrames(electrodeCount, _simulatedMeasurements);
             }
             else if (_discretization is LBMGrid && original is LBMGrid lbmOrig)
             {
                 var measurement = _reconstructionPersistence.SimulateLbmMeasurements(lbmOrig, _excitationAmplitude, _drivePattern);
                 _simulatedMeasurements = CloneMeasurementsWithNoise(measurement.Frames, _measurementNoiseType, _measurementNoiseAmplitude);
                 _realMeasurementAmplitude = null;
+                UpdateMeasurementSetupFromFrames(electrodeCount, _simulatedMeasurements);
             }
             else
             {
@@ -454,6 +478,77 @@ namespace ServiceLayer
             }
         }
 
+        private void UpdateMeasurementSetupFromFrames(int electrodeCount, IReadOnlyList<double[]> frames)
+        {
+            // Measurements originating from an active setup deliver M readings per frame
+            // (yielding M×M values over a full cycle).  Non-active instrumentation omits the
+            // two driven contacts per frame, resulting in M×(M-3) total samples.  We derive the
+            // acquisition mode from these counts so both the solver and the UI can react accordingly.
+            if (electrodeCount <= 0 || frames == null || frames.Count == 0)
+            {
+                _measurementSetup = ElectrodeMeasurementSetup.Active;
+                Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
+                return;
+            }
+
+            int frameLength = frames[0].Length;
+            long totalMeasurements = (long)frameLength * frames.Count;
+            long expectedActiveTotal = (long)electrodeCount * electrodeCount;
+            long expectedNonActiveTotal = (long)electrodeCount * Math.Max(0, electrodeCount - 3);
+
+            bool looksActive = frameLength == electrodeCount || totalMeasurements == expectedActiveTotal;
+            bool looksNonActive = !looksActive && (frameLength == Math.Max(0, electrodeCount - 2) || totalMeasurements == expectedNonActiveTotal);
+
+            _measurementSetup = looksActive ? ElectrodeMeasurementSetup.Active : ElectrodeMeasurementSetup.NonActive;
+
+            if (!looksActive && !looksNonActive)
+            {
+                Workspace.AddWarningMessage($"Ambiguous measurement frame dimensions (frame length {frameLength}, frame count {frames.Count}, electrodes {electrodeCount}). Assuming {_measurementSetup} electrodes.");
+            }
+
+            Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
+        }
+
+        private static double[] PrepareMeasurementFrame(double[] measurement, List<FEMElectrode> electrodes)
+        {
+            // Map the supplied measurement vector to the solver ordering.
+            // When non-active data is provided only the measuring electrodes
+            // are present, so the remaining entries are padded with NaN to
+            // ensure the residual ignores the driven electrodes.
+            int electrodeCount = electrodes.Count;
+            if (electrodeCount == 0)
+                return measurement;
+
+            if (measurement.Length == electrodeCount)
+                return measurement;
+
+            if (measurement.Length > electrodeCount)
+            {
+                Workspace.AddWarningMessage($"Measurement frame has {measurement.Length} values but only {electrodeCount} electrodes. Truncating to match electrode count.");
+                return measurement.Take(electrodeCount).ToArray();
+            }
+
+            double[] prepared = Enumerable.Repeat(double.NaN, electrodeCount).ToArray();
+            int measurementIndex = 0;
+            int measuringElectrodeCount = electrodes.Count(e => e.IsMeasuring);
+
+            for (int i = 0; i < electrodeCount; i++)
+            {
+                if (!electrodes[i].IsMeasuring)
+                    continue;
+
+                if (measurementIndex < measurement.Length)
+                    prepared[i] = measurement[measurementIndex++];
+            }
+
+            if (measurementIndex < measurement.Length)
+                Workspace.AddWarningMessage($"Discarded {measurement.Length - measurementIndex} surplus measurement values that could not be mapped to measuring electrodes.");
+            else if (measurementIndex < measuringElectrodeCount)
+                Workspace.AddWarningMessage($"Measurement frame provides only {measurementIndex} values for {measuringElectrodeCount} measuring electrodes. Missing entries will be ignored during reconstruction.");
+
+            return prepared;
+        }
+
         private double NextGaussian(double mean, double stdDev)
         {
             double u1 = 1.0 - _noiseRandom.NextDouble();
@@ -484,8 +579,10 @@ namespace ServiceLayer
                 ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, stepIndex);
 
                 var bc = new FEMBoundaryCondition(electrodes);
+                // Expand the raw measurement vector to match the solver ordering (injecting NaNs for excluded electrodes).
+                var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes);
 
-                var frame = _reconstructionPersistence.Step(measurement, bc, _stepSize, _regularizationWeight);
+                var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
                 _simMeasurementIndex++;
                 Workspace.AddReconstructionFrameToWorkspace(frame);
                 _currentCycleFrames.Add(frame);
@@ -617,8 +714,10 @@ namespace ServiceLayer
 
                         var bc = new FEMBoundaryCondition(electrodes);
                         var measurement = _simulatedMeasurements[i];
+                        // Convert the measurement snapshot to the solver layout for the current electrode roles.
+                        var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes);
 
-                        var frame = _reconstructionPersistence.Step(measurement, bc, _stepSize, _regularizationWeight);
+                        var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
                         Workspace.AddReconstructionFrameToWorkspace(frame);
                         _currentCycleFrames.Add(frame);

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -1,4 +1,5 @@
-﻿using Utility.Classes.Discretizer;
+﻿using System;
+using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Measurement;
@@ -42,6 +43,9 @@ namespace Utility.Classes.Application
         private static EITMeasurement? _importedMeasurement;
         private static string? _importedMeasurementLabel;
         private static MeasurementSourceOption _measurementSource = MeasurementSourceOption.Simulated;
+        private static ElectrodeMeasurementSetup _electrodeMeasurementSetup = ElectrodeMeasurementSetup.Active;
+
+        public static event Action<ElectrodeMeasurementSetup>? ElectrodeMeasurementSetupChanged;
 
         public static void Initialize(User user, EITReconstructionParameters? eITReconstructionParameters, IDiscretization? discretization)
         {
@@ -159,6 +163,17 @@ namespace Utility.Classes.Application
         public static EITMeasurement? GetImportedMeasurement() => _importedMeasurement;
 
         public static string? GetImportedMeasurementLabel() => _importedMeasurementLabel;
+
+        public static ElectrodeMeasurementSetup GetElectrodeMeasurementSetup() => _electrodeMeasurementSetup;
+
+        public static void SetElectrodeMeasurementSetup(ElectrodeMeasurementSetup setup)
+        {
+            if (_electrodeMeasurementSetup == setup)
+                return;
+
+            _electrodeMeasurementSetup = setup;
+            ElectrodeMeasurementSetupChanged?.Invoke(setup);
+        }
 
         public static MeasurementSourceOption GetMeasurementSource() => _measurementSource;
 

--- a/Utility/Classes/Measurement/ElectrodeMeasurementSetup.cs
+++ b/Utility/Classes/Measurement/ElectrodeMeasurementSetup.cs
@@ -1,0 +1,12 @@
+namespace Utility.Classes.Measurement
+{
+    /// <summary>
+    /// Describes whether voltage readings include the actively driven electrodes
+    /// or omit them because the instrumentation cannot sample excitation contacts.
+    /// </summary>
+    public enum ElectrodeMeasurementSetup
+    {
+        Active,
+        NonActive
+    }
+}


### PR DESCRIPTION
## Summary
- detect whether imported or simulated measurements follow an active or non-active electrode scheme and expose the mode via the workspace
- normalize non-active measurement frames before FEM solves so misfit and adjoint computations ignore excitation electrodes
- surface the active/non-active status in the reconstruction UI to clarify which acquisition pipeline is in use

## Testing
- `dotnet build` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f781fc8e808333b4529fd967ce7448