### PR TITLE
Fix reconstruction export metrics and initial distribution handling

### DIFF
--- a/DataAccessLayer/IReconstructionExportRepository.cs
+++ b/DataAccessLayer/IReconstructionExportRepository.cs
@@ -15,4 +15,5 @@ public sealed record ReconstructionExportRequest(IDiscretization Discretization,
                                                   IReadOnlyList<ReconstructionResult> Results,
                                                   ReconstructionFrame RenderFrame,
                                                   PotentialDisplayMode DisplayMode,
-                                                  string TargetDirectory);
+                                                  string TargetDirectory,
+                                                  ConductivityDistribution InitialDistribution);

--- a/DataAccessLayer/ReconstructionExportRepository.cs
+++ b/DataAccessLayer/ReconstructionExportRepository.cs
@@ -24,6 +24,9 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
             var firstSnapshot = snapshots.First();
             var latestSnapshot = snapshots.Last();
 
+            var initialDistribution = request.InitialDistribution;
+            var initialResult = CreateInitialDistributionResult(firstSnapshot.Result, initialDistribution);
+
             ReconstructionVideoRenderer.SaveDistributionSnapshot(request.TargetDirectory,
                                      "original_distribution.png",
                                      request.Discretization,
@@ -34,23 +37,24 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
                                      CreateRangeMetadata(latestSnapshot.Result.OriginalConductivityDistribution),
                                      request.DisplayMode);
 
-            var initialMetadata = CreateRangeMetadata(firstSnapshot.Result.InitialConductivitiyDistribution);
-            double initialResidual = CalculateResidual(firstSnapshot.Result.InitialConductivitiyDistribution,
+            var initialMetadata = CreateRangeMetadata(initialDistribution);
+            double initialResidual = CalculateResidual(initialDistribution,
                                                        firstSnapshot.Result.OriginalConductivityDistribution);
             initialMetadata.Add(("Residual L2", FormatDouble(initialResidual)));
 
-            var initialMetrics = ComputeInitialDistributionMetrics(firstSnapshot.Result);
+            var initialMetrics = ComputeDistributionMetrics(initialResult, CancellationToken.None);
             if (initialMetrics.HasValue)
             {
-                initialMetadata.Add(("MAE", FormatDouble(initialMetrics.Value.Mae)));
-                initialMetadata.Add(("RMSE", FormatDouble(initialMetrics.Value.Rmse)));
+                var metrics = initialMetrics.Value;
+                initialMetadata.Add(("MAE", FormatDouble(metrics.Mae)));
+                initialMetadata.Add(("RMSE", FormatDouble(metrics.Rmse)));
             }
 
             ReconstructionVideoRenderer.SaveDistributionSnapshot(request.TargetDirectory,
                                      "initial_distribution.png",
                                      request.Discretization,
                                      GetFrameForResult(firstSnapshot.Result, request.RenderFrame),
-                                     firstSnapshot.Result,
+                                     initialResult,
                                      ReconstructionVideoRenderer.DistributionSnapshotType.Initial,
                                      "Initial Conductivity Distribution",
                                      initialMetadata,
@@ -153,7 +157,7 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
             var ssimSnapshot = metricSnapshots
                 .Where(s => !double.IsNaN(s.Metrics!.Value.Ssim))
-                .OrderBy(s => s.Metrics!.Value.Ssim)
+                .OrderByDescending(s => s.Metrics!.Value.Ssim)
                 .FirstOrDefault();
 
             if (ssimSnapshot.Result != null)
@@ -175,7 +179,7 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
                                          GetFrameForResult(ssimSnapshot.Result, fallbackFrame),
                                          ssimSnapshot.Result,
                                          ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
-                                         "Reconstruction – Min SSIM",
+                                         "Reconstruction – Max SSIM",
                                          metadata,
                                          mode);
             }
@@ -215,7 +219,7 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
         var correlationSnapshot = snapshots
             .Where(s => !double.IsNaN(s.Correlation))
-            .OrderBy(s => s.Correlation)
+            .OrderByDescending(s => s.Correlation)
             .FirstOrDefault();
 
         if (correlationSnapshot.Result != null)
@@ -241,10 +245,29 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
                                      GetFrameForResult(correlationSnapshot.Result, fallbackFrame),
                                      correlationSnapshot.Result,
                                      ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
-                                     "Reconstruction – Min Correlation",
+                                     "Reconstruction – Max Correlation",
                                      metadata,
                                      mode);
         }
+    }
+
+    private static ReconstructionResult CreateInitialDistributionResult(ReconstructionResult snapshot,
+                                                                        ConductivityDistribution initialDistribution)
+    {
+        var discretization = snapshot.GetDiscretization();
+        if (discretization != null)
+        {
+            return new ReconstructionResult(discretization,
+                                            snapshot.OriginalConductivityDistribution,
+                                            initialDistribution,
+                                            initialDistribution,
+                                            snapshot.Frames);
+        }
+
+        return new ReconstructionResult(snapshot.OriginalConductivityDistribution,
+                                        initialDistribution,
+                                        initialDistribution,
+                                        snapshot.Frames);
     }
 
     private static void WriteIterationMetricsCsv(string directory,
@@ -428,15 +451,6 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
         double correlation = numerator / denominator;
         return double.IsNaN(correlation) ? double.NaN : correlation;
-    }
-
-    private static DistributionMetrics? ComputeInitialDistributionMetrics(ReconstructionResult snapshot)
-    {
-        var initialResult = new ReconstructionResult(snapshot.OriginalConductivityDistribution,
-                                                     snapshot.InitialConductivitiyDistribution,
-                                                     snapshot.InitialConductivitiyDistribution,
-                                                     snapshot.Frames);
-        return ComputeDistributionMetrics(initialResult, CancellationToken.None);
     }
 
     private static DistributionMetrics? ComputeDistributionMetrics(ReconstructionResult result, CancellationToken token)

--- a/ServiceLayer/ReconstructionExportService.cs
+++ b/ServiceLayer/ReconstructionExportService.cs
@@ -37,12 +37,16 @@ public sealed class ReconstructionExportService : IReconstructionExportService
 
         string directory = Path.Combine(rootDirectory, $"reconstruction_export_{DateTime.Now:yyyyMMdd_HHmmss}");
 
+        var initialDistribution = Workspace.GetInitialConductivityDistribution()
+                                   ?? results[0].InitialConductivitiyDistribution;
+
         var request = new ReconstructionExportRequest(discretization,
                                                       frames,
                                                       results,
                                                       renderFrame,
                                                       displayMode,
-                                                      directory);
+                                                      directory,
+                                                      initialDistribution);
 
         return Task.Run(() => _repository.ExportReconstructionData(request), cancellationToken);
     }

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -238,6 +238,7 @@ namespace ServiceLayer
                 // Apply initial distribution to the active discretization.
                 discretization.SetConductivityDistribution(_initialSigma);
                 Workspace.SetOriginalConductivityDistribution(_originalSigma);
+                Workspace.SetInitialConductivityDistribution(_initialSigma);
 
                 // Bootstrap persistence with the conductivity benchmark values.
                 _reconstructionPersistence.SetConductivityDistributions(_originalSigma, _initialSigma);
@@ -1115,6 +1116,7 @@ namespace ServiceLayer
                 var frames = _reconstructionPersistence.LoadReconstruction(filePath);
                 Workspace.SetReconstructionResults(frames);
                 Workspace.SetReconstructionFrames([.. frames.SelectMany(r => r.Frames)]);
+                Workspace.SetInitialConductivityDistribution(frames.FirstOrDefault()?.InitialConductivitiyDistribution);
                 return frames;
             }
             catch (Exception ex)

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -28,6 +28,7 @@ namespace Utility.Classes.Application
         private static List<ReconstructionFrame> _reconstructionFrames = [];
         private static List<WorkspaceMessage> _messages = [];
         private static ConductivityDistribution? _originalConductivityDistribution = null;
+        private static ConductivityDistribution? _initialConductivityDistribution = null;
         public static event Action<WorkspaceMessage>? MessageAdded;
 
         private static List<FEMElement>? _currentGlobalFemElements;
@@ -78,6 +79,7 @@ namespace Utility.Classes.Application
         public static void SetReconstructionResults(List<ReconstructionResult> results) => _reconstructionResults = results;
         public static void SetReconstructionFrames(List<ReconstructionFrame> frames) => _reconstructionFrames = frames;
         public static void SetOriginalConductivityDistribution(ConductivityDistribution? sigma) => _originalConductivityDistribution = sigma;
+        public static void SetInitialConductivityDistribution(ConductivityDistribution? sigma) => _initialConductivityDistribution = sigma;
 
         public static User GetUser() => _user;
         public static EITReconstructionParameters GetReconstructionParameters() => _reconstructionParameters;
@@ -87,6 +89,7 @@ namespace Utility.Classes.Application
         public static List<ReconstructionResult> GetReconstructionResults() => _reconstructionResults;
         public static List<ReconstructionFrame> GetReconstructionFrames() => _reconstructionFrames;
         public static ConductivityDistribution? GetOriginalConductivityDistribution() => _originalConductivityDistribution;
+        public static ConductivityDistribution? GetInitialConductivityDistribution() => _initialConductivityDistribution;
 
         public static void UpdateCurrentGlobalFemElements(FEMMesh mesh)
             => _currentGlobalFemElements = [.. mesh.GetElements().Cast<FEMElement>()];


### PR DESCRIPTION
## Summary
- track the original initial conductivity distribution in the workspace and include it in export requests
- export the stored initial distribution snapshot with correct residual/metric metadata
- choose maximum SSIM and correlation snapshots when saving best metric images

## Testing
- `dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7e6c585008333af233b4811c48344