### PR TITLE
Improve FEM measurement handling and cap workspace log

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -390,8 +390,14 @@ namespace BusinessLayer
 
             if (measurementIndex < measurement.Length)
                 Workspace.AddWarningMessage($"Discarding {measurement.Length - measurementIndex} excess measurement entries that cannot be mapped to electrodes.");
-            else if (measurementIndex < measuringElectrodes)
-                Workspace.AddWarningMessage($"Measurement frame supplies only {measurementIndex} of {measuringElectrodes} measuring electrodes. Missing values will be ignored.");
+            else if (measurement.Length < measuringElectrodes)
+            {
+                bool expectedMissing = Workspace.GetElectrodeMeasurementSetup() == ElectrodeMeasurementSetup.NonActive &&
+                                        measurement.Length == Math.Max(0, measuringElectrodes - 1);
+
+                if (!expectedMissing)
+                    Workspace.AddWarningMessage($"Measurement frame supplies only {measurementIndex} of {measuringElectrodes} measuring electrodes. Missing values will be ignored.");
+            }
 
             return expanded;
         }

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -697,8 +697,14 @@ namespace ServiceLayer
 
             if (measurementIndex < measurement.Length)
                 Workspace.AddWarningMessage($"Discarded {measurement.Length - measurementIndex} surplus measurement values that could not be mapped to measuring electrodes.");
-            else if (measurementIndex < measuringElectrodeCount)
-                Workspace.AddWarningMessage($"Measurement frame provides only {measurementIndex} values for {measuringElectrodeCount} measuring electrodes. Missing entries will be ignored during reconstruction.");
+            else if (measurement.Length < measuringElectrodeCount)
+            {
+                bool expectedMissing = Workspace.GetElectrodeMeasurementSetup() == ElectrodeMeasurementSetup.NonActive &&
+                                        measurement.Length == Math.Max(0, measuringElectrodeCount - 1);
+
+                if (!expectedMissing)
+                    Workspace.AddWarningMessage($"Measurement frame provides only {measurementIndex} values for {measuringElectrodeCount} measuring electrodes. Missing entries will be ignored during reconstruction.");
+            }
 
             return prepared;
         }

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Linq;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
@@ -10,6 +11,8 @@ namespace Utility.Classes.Application
 {
     public static class Workspace
     {
+        private const int MaxMessageCount = 200;
+
         private static User _user { get; set; } = new DefaultUser(0, "No User");
         private static EITReconstructionParameters _reconstructionParameters = new();
         private static IDiscretization? _discretization{ get; set; } = null;
@@ -231,6 +234,7 @@ namespace Utility.Classes.Application
             DateTime time = DateTime.Now;
             var msg = new WorkspaceMessage(time, message, type);
             _messages.Add(msg);
+            EnforceMessageLimit();
             MessageAdded?.Invoke(msg);
         }
 
@@ -241,5 +245,30 @@ namespace Utility.Classes.Application
         public static void AddLogMessage(string source, string message, WorkspaceMessageType type = WorkspaceMessageType.Log) => AddMessage(source + ": " + message, type);
 
         public static IReadOnlyList<WorkspaceMessage> GetMessages() => _messages;
+
+        private static void EnforceMessageLimit()
+        {
+            while (_messages.Count > MaxMessageCount)
+            {
+                var candidate = _messages
+                    .OrderBy(m => GetMessagePriority(m.Type))
+                    .ThenBy(m => m.Time)
+                    .FirstOrDefault();
+
+                if (candidate == null)
+                    break;
+
+                _messages.Remove(candidate);
+            }
+        }
+
+        private static int GetMessagePriority(WorkspaceMessageType type) => type switch
+        {
+            WorkspaceMessageType.Error => 4,
+            WorkspaceMessageType.Warning => 3,
+            WorkspaceMessageType.Loading => 2,
+            WorkspaceMessageType.Info => 1,
+            _ => 0,
+        };
     }
 }


### PR DESCRIPTION
## Summary
- adjust FEM measurement alignment to avoid repeated warnings for expected non-active frames
- cap workspace message history at 200 items by discarding the oldest low-priority entries first

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f8a580b1788333b05075402fb47355