### PR TITLE
Fix CUDA kernel delegate types

### DIFF
--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
@@ -31,11 +32,11 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
         private static readonly object _cudaKernelLock = new(); // Thread-safe kernel compilation
         
         // Pre-compiled CUDA kernels for LBM operations
-        private static Action<Index1D, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<double>>? _initializeKernel;
-        private static Action<Index1D, ArrayView<double>, ArrayView<int>, ArrayView<double>, double, double, ArrayView<double>>? _collisionKernel;
-        private static Action<Index1D, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<int>>? _streamKernel;
-        private static Action<Index1D, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<double>>? _updateKernel;
-        private static Action<Index1D, ArrayView<double>, ArrayView<double>>? _phiKernel;
+        private static System.Action<Index1D, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<double>>? _initializeKernel;
+        private static System.Action<Index1D, ArrayView<double>, ArrayView<int>, ArrayView<double>, double, double, ArrayView<double>>? _collisionKernel;
+        private static System.Action<Index1D, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<int>>? _streamKernel;
+        private static System.Action<Index1D, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<double>, int>? _updateKernel;
+        private static System.Action<Index1D, ArrayView<double>, ArrayView<double>>? _phiKernel;
 
         /// <summary>
         /// Initializes LBM solver with specified convergence criteria and execution mode.
@@ -303,7 +304,8 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                             for (int i = 0; i < 9; i++)
                                 el.Fi[i] = weights[i] * Math.Abs(current);
 
-                            ApplyNeumannBoundaryCondition(el, electrode, phiStreamed, elementIndexLookup, opposite);
+                            bool useDefaultPotentialDifference = t == 0;
+                            ApplyNeumannBoundaryCondition(el, electrode, phiStreamed, elementIndexLookup, opposite, useDefaultPotentialDifference);
                         }
                     }
                 }
@@ -375,7 +377,8 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             LBMElectrode electrode,
             IReadOnlyList<double> phiStreamed,
             IReadOnlyDictionary<int, int> elementIndexLookup,
-            int[] opposite)
+            int[] opposite,
+            bool useDefaultPotentialDifference)
         {
             if (!elementIndexLookup.TryGetValue(element.Id, out int elementIndex))
                 return;
@@ -395,11 +398,15 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             double phiBoundary = phiStreamed[elementIndex];
             double phiInterior = phiStreamed[interiorIndex];
 
+            double potentialDifference = useDefaultPotentialDifference
+                ? 1.0
+                : (phiInterior - phiBoundary);
+
             // The normal current correction is obtained from the discrete gradient of the
             // potential field multiplied by the local conductivity.  This mirrors the
             // continuous expression j = -γ ∂φ/∂n while remaining compatible with the
             // streamed potential that was already computed for the current iteration.
-            double deltaFi = element.Conductivity * (phiInterior - phiBoundary);
+            double deltaFi = element.Conductivity * potentialDifference;
 
             double current = electrode.Current;
 
@@ -624,7 +631,8 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                     conductivityBuffer.View,                     // Material conductivity
                     phiBuffer.View,                              // Streamed potentials
                     LatticeBoltzmannCudaContext.OppositeView,    // Opposite directions
-                    LatticeBoltzmannCudaContext.WeightsView);    // D2Q9 equilibrium weights
+                    LatticeBoltzmannCudaContext.WeightsView,     // D2Q9 equilibrium weights
+                    t == 0 ? 1 : 0);                             // Use default potential difference on first iteration
 
                 // Check convergence periodically
                 if (t % checkFreq == 0)
@@ -718,7 +726,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 _initializeKernel = accelerator.LoadAutoGroupedStreamKernel<Index1D, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<double>>(InitializeKernel);
                 _collisionKernel = accelerator.LoadAutoGroupedStreamKernel<Index1D, ArrayView<double>, ArrayView<int>, ArrayView<double>, double, double, ArrayView<double>>(CollisionKernel);
                 _streamKernel = accelerator.LoadAutoGroupedStreamKernel<Index1D, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<int>>(StreamingKernel);
-                _updateKernel = accelerator.LoadAutoGroupedStreamKernel<Index1D, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<double>>(UpdateKernel);
+                _updateKernel = accelerator.LoadAutoGroupedStreamKernel<Index1D, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<int>, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<double>, int>(UpdateKernel);
                 _phiKernel = accelerator.LoadAutoGroupedStreamKernel<Index1D, ArrayView<double>, ArrayView<double>>(PhiKernel);
             }
         }
@@ -942,7 +950,8 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             ArrayView<double> conductivity,     // Conductivity per element
             ArrayView<double> phiStreamed,      // Streamed potential field
             ArrayView<int> opposite,            // Opposite direction mapping
-            ArrayView<double> weights)          // D2Q9 equilibrium weights
+            ArrayView<double> weights,          // D2Q9 equilibrium weights
+            int useDefaultPotentialDifference)  // Flag for first-iteration fallback
         {
             // Skip wall elements (no update needed)
             if (isWall[index] == 1)
@@ -996,7 +1005,10 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                     {
                         double phiBoundary = phiStreamed[index];
                         double phiInterior = phiStreamed[interiorIndex];
-                        double deltaFi = conductivity[index] * (phiInterior - phiBoundary);
+                        double potentialDifference = useDefaultPotentialDifference == 1
+                            ? 1.0
+                            : (phiInterior - phiBoundary);
+                        double deltaFi = conductivity[index] * potentialDifference;
 
                         // Remove the gradient-driven flux from the interior pointing
                         // population and add it, together with the prescribed electrode


### PR DESCRIPTION
## Summary
- qualify the cached CUDA kernel delegates with System.Action to avoid non-generic Action collisions
- correct the cached update kernel signature to include the first-iteration flag parameter so null checks compile

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f8d604a508833390197b0c0e832466