### PR TITLE
Fix Wasserstein-2 gradient mean subtraction

### DIFF
--- a/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
@@ -147,12 +147,12 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             for (int i = 0; i < m; i++) 
                 grad[i] = 0.5 * phi[i];
             
-            double mean = 0.0;            
+            double mean = 0.0;
             for (int i = 0; i < m; i++)
-            {
                 mean += grad[i] * a[i];
+
+            for (int i = 0; i < m; i++)
                 grad[i] -= mean;
-            }
 
             // Chain rule back to raw (unnormalized) masses
             double[] gradRaw = new double[m];


### PR DESCRIPTION
## Summary
- correct the Wasserstein-2 gradient post-processing to subtract the weighted mean in a dedicated pass, restoring the zero-mean constraint

## Testing
- `dotnet test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fd53214e088333b321c6d2de2ce68d