### PR TITLE
Add toggle for potential difference reconstruction

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -39,6 +39,7 @@ namespace BusinessLayer
         private InitialDistributionTypes _initialDistributionType = InitialDistributionTypes.SlightlyDiffering;
         private bool _useOmpParallelization = false;
         private bool _useCudaParallelization = false;
+        private bool _usePotentialDifferences = false;
         private NumericSolver _numericSolverChoice = NumericSolver.LU;
         private ErrorMetric _errorMetricChoice = ErrorMetric.L2;
 
@@ -118,6 +119,7 @@ namespace BusinessLayer
                 initSigma = ConductivityClipper.Clip(initSigma);
                 _numericOptimizer = NumericOptimizerFactory.Create(parameters.NumericOptimizer, initSigma);
                 _drivePattern = parameters.DrivePattern;
+                _usePotentialDifferences = parameters.UsePotentialDifferences;
 
                 _inverseModel = InverseModelFactory.Create(_discretization, _numericOptimizer, _regularizer, _errorMetric, _differentialEquationSolver);
 
@@ -323,11 +325,13 @@ namespace BusinessLayer
 
             // Extract simulated potentials
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
+            var projectedMeasurement = PrepareMeasurementData(currentMeasurement, electrodes.Count);
+            var projectedSimulated = PrepareSimulatedData(simulatedPotentials);
 
-            double currentError = _errorMetric.Evaluate(mesh, currentMeasurement, simulatedPotentials);
+            double currentError = _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
 
-            // Error metric based gradeint expression
-            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, currentMeasurement, simulatedPotentials);
+            // Error metric based gradient expression
+            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
 
             Complex[] adjointSource = new Complex[adjSrc.Length];
             for (int k = 0; k < adjSrc.Length; k++)
@@ -402,6 +406,42 @@ namespace BusinessLayer
             return expanded;
         }
 
+        private double[] PrepareMeasurementData(double[] measurement, int electrodeCount)
+        {
+            if (!_usePotentialDifferences)
+                return measurement;
+
+            int differenceLength = Math.Max(0, electrodeCount - 1);
+            if (measurement.Length == differenceLength)
+                return measurement;
+
+            return ComputeSequentialDifferences(measurement);
+        }
+
+        private double[] PrepareSimulatedData(double[] simulated)
+        {
+            if (!_usePotentialDifferences)
+                return simulated;
+
+            return ComputeSequentialDifferences(simulated);
+        }
+
+        private static double[] ComputeSequentialDifferences(double[] values)
+        {
+            if (values.Length <= 1)
+                return System.Array.Empty<double>();
+
+            double[] differences = new double[values.Length - 1];
+            for (int i = 0; i < differences.Length; i++)
+            {
+                double a = values[i];
+                double b = values[i + 1];
+                differences[i] = double.IsNaN(a) || double.IsNaN(b) ? double.NaN : b - a;
+            }
+
+            return differences;
+        }
+
         private ReconstructionFrame ComputeFemInverseStep(FEMMesh mesh,
                                                           FEMBoundaryCondition bc,
                                                           double[] currentMeasurement,
@@ -440,10 +480,13 @@ namespace BusinessLayer
 
             // Ensure the data vector mirrors the electrode ordering that the solver expects.
             var measurementVector = AlignMeasurementVector(currentMeasurement, electrodes);
+            var projectedMeasurement = PrepareMeasurementData(measurementVector, electrodes.Count);
+
             PotentialDistribution phi = PotentialClipper.Clip(solver.Solve(mesh, bc, null));
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
+            var projectedSimulated = PrepareSimulatedData(simulatedPotentials);
 
-            var adjSrc = errorMetric.EvaluateAdjointSource(mesh, measurementVector, simulatedPotentials);
+            var adjSrc = errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
             Complex[] adjointSource = new Complex[adjSrc.Length];
             for (int k = 0; k < adjSrc.Length; k++)
                 adjointSource[k] = adjSrc[k];
@@ -933,7 +976,9 @@ namespace BusinessLayer
                 double[] dObs = simulatedMeasurements[exc];
                 // Compare only the electrodes that are physically measured in the current configuration.
                 var alignedObs = AlignMeasurementVector(dObs, electrodes);
-                Jtotal += _errorMetric.Evaluate(mesh, alignedObs, dSimNew);
+                var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodeCount);
+                var projectedSimulated = PrepareSimulatedData(dSimNew);
+                Jtotal += _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
             }
 
             return Jtotal;
@@ -961,11 +1006,13 @@ namespace BusinessLayer
 
             // Extract simulated potentials
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
+            var projectedMeasurement = PrepareMeasurementData(currentMeasurement, electrodes.Count);
+            var projectedSimulated = PrepareSimulatedData(simulatedPotentials);
 
-            double currentError = _errorMetric.Evaluate(mesh, currentMeasurement, simulatedPotentials);
+            double currentError = _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
 
-            // Error metric based gradeint expression
-            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, currentMeasurement, simulatedPotentials);
+            // Error metric based gradient expression
+            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
 
             Complex[] adjointSource = new Complex[adjSrc.Length];
             for (int k = 0; k < adjSrc.Length; k++)
@@ -1305,7 +1352,9 @@ namespace BusinessLayer
                     double[] dObs = simulatedMeasurements[exc];
                     // Restrict the misfit to the subset of electrodes that produced readings.
                     var alignedObs = AlignMeasurementVector(dObs, electrodes);
-                    Jtotal += _errorMetric.Evaluate(mesh, alignedObs, dSimNew);
+                    var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodeCount);
+                    var projectedSimulated = PrepareSimulatedData(dSimNew);
+                    Jtotal += _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
                 }
                 Debug.WriteLine($"Iteration {iter}: total misfit = {Jtotal}");
 

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -1889,6 +1889,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                 ExcitationElectrodeId,
                 GroundElectrodeId,
                 parameters.DrivePattern,
+                parameters.UsePotentialDifferences,
                 parameters.UseOmpParallelization,
                 parameters.UseCudaAcceleration);
 
@@ -2044,6 +2045,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             int ExcitationElectrodeId,
             int GroundElectrodeId,
             DrivePattern DrivePattern,
+            bool UsePotentialDifferences,
             bool UseOmpParallelization,
             bool UseCudaAcceleration);
 

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -166,7 +166,7 @@
                         <Border Grid.Column="1"
                                 Style="{StaticResource PanelSectionBorderStyle}"
                                 BackgroundColor="{AppThemeBinding Light=#25324A, Dark=#25324A}">
-                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
+                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
                                 <Label Grid.Row="0" Text="Parameters" FontSize="Medium" FontAttributes="Bold" Margin="0,0,0,12"/>
                                 <Label Grid.Row="1" HorizontalOptions="Start" Text="Initial Distribution" FontFamily="SF Pro Text" FontAttributes="None"/>
                                 <Picker Grid.Row="2" ItemsSource="{Binding InitialDistributionOptions}" SelectedItem="{Binding ReconstructionParameters.InitialDistributionType}" MaximumWidthRequest="150"/>
@@ -185,10 +185,18 @@
                                        IsEnabled="{Binding IsNoiseAmplitudeEnabled}"/>
                                 <Label Grid.Row="13"
                                        HorizontalOptions="Start"
+                                       Text="Use Potential Differences"
+                                       FontFamily="SF Pro Text"
+                                       FontAttributes="None"/>
+                                <Switch Grid.Row="14"
+                                        IsToggled="{Binding ReconstructionParameters.UsePotentialDifferences}"
+                                        HorizontalOptions="Start"/>
+                                <Label Grid.Row="15"
+                                       HorizontalOptions="Start"
                                        Text="Conductivity Bounds [S]"
                                        FontFamily="SF Pro Text"
                                        FontAttributes="None"/>
-                                <Grid Grid.Row="14" ColumnDefinitions="*, *" ColumnSpacing="8">
+                                <Grid Grid.Row="16" ColumnDefinitions="*, *" ColumnSpacing="8">
                                     <Entry Grid.Column="0"
                                            Placeholder="Min"
                                            Keyboard="Numeric"

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -60,6 +60,7 @@ namespace ServiceLayer
         // ("active") or omit them ("non-active").  This flag is mirrored to the workspace so that
         // the UI can communicate the acquisition mode to the user.
         private ElectrodeMeasurementSetup _measurementSetup = ElectrodeMeasurementSetup.Active;
+        private bool _usePotentialDifferences;
 
         /// <summary>
         /// Raised when a full reconstruction result is available (i.e., at the end of a cycle or batch).
@@ -260,6 +261,7 @@ namespace ServiceLayer
                 // Store noise settings for subsequent simulations/import handling.
                 _measurementNoiseType = parameters.MeasurementNoiseType;
                 _measurementNoiseAmplitude = parameters.MeasurementNoiseAmplitude;
+                _usePotentialDifferences = parameters.UsePotentialDifferences;
 
                 if (_measurementNoiseType == MeasurementNoiseType.None || Math.Abs(_measurementNoiseAmplitude) <= double.Epsilon)
                     Workspace.AddLogMessage("Reconstruction Service", "Measurement noise disabled.");
@@ -277,6 +279,11 @@ namespace ServiceLayer
                     Workspace.AddLogMessage("Reconstruction Service",
                         $"Measurement noise enabled: {_measurementNoiseType} (amplitude {amplitudeDescriptor}).");
                 }
+
+                Workspace.AddLogMessage("Reconstruction Service",
+                    _usePotentialDifferences
+                        ? "Using electrode potential differences for reconstruction misfit evaluation."
+                        : "Using direct electrode potentials for reconstruction misfit evaluation.");
 
                 // Seed measurement source state; we may swap to real measurements later.
                 _measurementSource = Workspace.GetMeasurementSource();
@@ -643,9 +650,13 @@ namespace ServiceLayer
             long totalMeasurements = (long)frameLength * frames.Count;
             long expectedActiveTotal = (long)electrodeCount * electrodeCount;
             long expectedNonActiveTotal = (long)electrodeCount * Math.Max(0, electrodeCount - 3);
+            int expectedDifferenceLength = Math.Max(0, electrodeCount - 1);
 
             bool looksActive = frameLength == electrodeCount || totalMeasurements == expectedActiveTotal;
             bool looksNonActive = !looksActive && (frameLength == Math.Max(0, electrodeCount - 2) || totalMeasurements == expectedNonActiveTotal);
+
+            if (_usePotentialDifferences && frameLength == expectedDifferenceLength)
+                looksActive = true;
 
             _measurementSetup = looksActive ? ElectrodeMeasurementSetup.Active : ElectrodeMeasurementSetup.NonActive;
 

--- a/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
+++ b/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
@@ -34,6 +34,9 @@ namespace Utility.Classes.ReconstructionParameters
         private DrivePattern drivePattern = DrivePattern.Adjecent;
 
         [ObservableProperty]
+        private bool usePotentialDifferences = false;
+
+        [ObservableProperty]
         private bool useOmpParallelization = false;
 
         [ObservableProperty]
@@ -61,6 +64,7 @@ namespace Utility.Classes.ReconstructionParameters
             MeasurementNoiseType = MeasurementNoiseType.None;
             MeasurementNoiseAmplitude = 0.0;
             DrivePattern = DrivePattern.Adjecent;
+            UsePotentialDifferences = false;
             UseOmpParallelization = false;
             UseCudaAcceleration = false;
             Mesh = DiscretizationType.FEM;
@@ -78,7 +82,8 @@ namespace Utility.Classes.ReconstructionParameters
                                            InitialDistributionTypes initialDistributionType = InitialDistributionTypes.SlightlyDiffering,
                                            MeasurementNoiseType measurementNoiseType = MeasurementNoiseType.None,
                                            double measurementNoiseAmplitude = 0.0,
-                                           DrivePattern drivePattern = DrivePattern.Adjecent)
+                                           DrivePattern drivePattern = DrivePattern.Adjecent,
+                                           bool usePotentialDifferences = false)
         {
             DifferentialEquationSolver = differentialEquationSolver;
             RegularizationTechnique = regularizationTechnique;
@@ -89,6 +94,7 @@ namespace Utility.Classes.ReconstructionParameters
             MeasurementNoiseType = measurementNoiseType;
             MeasurementNoiseAmplitude = measurementNoiseAmplitude;
             DrivePattern = drivePattern;
+            UsePotentialDifferences = usePotentialDifferences;
             UseOmpParallelization = false;
             UseCudaAcceleration = false;
 


### PR DESCRIPTION
## Summary
- add a reconstruction parameter that toggles between direct potentials and sequential potential differences
- surface the new option in the reconstruction UI and ensure run signatures react to the selection
- update reconstruction services and persistence so both simulated and real measurements are transformed consistently when potential differences are enabled

## Testing
- not run (dotnet not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68ff4f26e9008333a39e85c5cde03764