### PR TITLE
Handle potential difference data in Wasserstein-2 metric

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -1,4 +1,5 @@
 ﻿using DataAccessLayer;
+using System;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
@@ -39,6 +40,7 @@ namespace BusinessLayer
         private InitialDistributionTypes _initialDistributionType = InitialDistributionTypes.SlightlyDiffering;
         private bool _useOmpParallelization = false;
         private bool _useCudaParallelization = false;
+        private bool _usePotentialDifferences = false;
         private NumericSolver _numericSolverChoice = NumericSolver.LU;
         private ErrorMetric _errorMetricChoice = ErrorMetric.L2;
 
@@ -118,6 +120,7 @@ namespace BusinessLayer
                 initSigma = ConductivityClipper.Clip(initSigma);
                 _numericOptimizer = NumericOptimizerFactory.Create(parameters.NumericOptimizer, initSigma);
                 _drivePattern = parameters.DrivePattern;
+                _usePotentialDifferences = parameters.UsePotentialDifferences;
 
                 _inverseModel = InverseModelFactory.Create(_discretization, _numericOptimizer, _regularizer, _errorMetric, _differentialEquationSolver);
 
@@ -323,15 +326,15 @@ namespace BusinessLayer
 
             // Extract simulated potentials
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
+            var projectedMeasurement = PrepareMeasurementData(currentMeasurement, electrodes.Count);
+            var projectedSimulated = PrepareSimulatedData(simulatedPotentials);
 
-            double currentError = _errorMetric.Evaluate(mesh, currentMeasurement, simulatedPotentials);
+            double currentError = _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
 
-            // Error metric based gradeint expression
-            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, currentMeasurement, simulatedPotentials);
-
-            Complex[] adjointSource = new Complex[adjSrc.Length];
-            for (int k = 0; k < adjSrc.Length; k++)
-                adjointSource[k] = adjSrc[k];
+            // Error metric based gradient expression
+            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
+            var expandedAdjoint = BuildAdjointSourceVector(adjSrc, electrodes.Count);
+            Complex[] adjointSource = ToComplex(expandedAdjoint);
 
             var adjointBoundaryCondition = new LBMBoundaryCondition(electrodes);
             Workspace.SetCurrentGlobalLbmBoundaryCondition(adjointBoundaryCondition);
@@ -402,6 +405,112 @@ namespace BusinessLayer
             return expanded;
         }
 
+        private double[] PrepareMeasurementData(double[] measurement, int electrodeCount)
+        {
+            if (!_usePotentialDifferences)
+                return measurement;
+
+            int differenceLength = Math.Max(0, electrodeCount - 1);
+            if (measurement.Length == differenceLength)
+                return measurement;
+
+            return ComputeSequentialDifferences(measurement);
+        }
+
+        private double[] PrepareSimulatedData(double[] simulated)
+        {
+            if (!_usePotentialDifferences)
+                return simulated;
+
+            return ComputeSequentialDifferences(simulated);
+        }
+
+        private static double[] ComputeSequentialDifferences(double[] values)
+        {
+            if (values.Length <= 1)
+                return System.Array.Empty<double>();
+
+            double[] differences = new double[values.Length - 1];
+            for (int i = 0; i < differences.Length; i++)
+            {
+                double a = values[i];
+                double b = values[i + 1];
+                differences[i] = double.IsNaN(a) || double.IsNaN(b) ? double.NaN : b - a;
+            }
+
+            return differences;
+        }
+
+        private double[] BuildAdjointSourceVector(double[] adjoint, int electrodeCount)
+        {
+            if (electrodeCount <= 0)
+                return Array.Empty<double>();
+
+            double[] values = adjoint;
+
+            if (_usePotentialDifferences)
+                values = ExpandSequentialDifferenceAdjoint(values, electrodeCount);
+
+            if (values.Length == electrodeCount)
+                return values;
+
+            double[] resized = new double[electrodeCount];
+            int copyLength = Math.Min(values.Length, electrodeCount);
+            Array.Copy(values, resized, copyLength);
+
+            if (values.Length > electrodeCount)
+            {
+                Workspace.AddWarningMessage($"Discarding {values.Length - electrodeCount} adjoint source entries that cannot be mapped to electrodes.");
+            }
+            else if (values.Length < electrodeCount)
+            {
+                for (int i = copyLength; i < electrodeCount; i++)
+                    resized[i] = 0.0;
+            }
+
+            return resized;
+        }
+
+        private static double[] ExpandSequentialDifferenceAdjoint(double[] adjoint, int electrodeCount)
+        {
+            if (electrodeCount <= 0)
+                return Array.Empty<double>();
+
+            if (adjoint.Length == electrodeCount)
+                return adjoint;
+
+            if (adjoint.Length == 0)
+                return new double[electrodeCount];
+
+            if (adjoint.Length != electrodeCount - 1)
+                return adjoint;
+
+            double[] expanded = new double[electrodeCount];
+
+            if (electrodeCount == 1)
+                return expanded;
+
+            expanded[0] = -adjoint[0];
+            for (int i = 1; i < electrodeCount - 1; i++)
+            {
+                double left = adjoint[i - 1];
+                double right = adjoint[i];
+                expanded[i] = left - right;
+            }
+            expanded[electrodeCount - 1] = adjoint[adjoint.Length - 1];
+
+            return expanded;
+        }
+
+        private static Complex[] ToComplex(double[] values)
+        {
+            Complex[] complex = new Complex[values.Length];
+            for (int i = 0; i < values.Length; i++)
+                complex[i] = values[i];
+
+            return complex;
+        }
+
         private ReconstructionFrame ComputeFemInverseStep(FEMMesh mesh,
                                                           FEMBoundaryCondition bc,
                                                           double[] currentMeasurement,
@@ -440,13 +549,15 @@ namespace BusinessLayer
 
             // Ensure the data vector mirrors the electrode ordering that the solver expects.
             var measurementVector = AlignMeasurementVector(currentMeasurement, electrodes);
+            var projectedMeasurement = PrepareMeasurementData(measurementVector, electrodes.Count);
+
             PotentialDistribution phi = PotentialClipper.Clip(solver.Solve(mesh, bc, null));
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
+            var projectedSimulated = PrepareSimulatedData(simulatedPotentials);
 
-            var adjSrc = errorMetric.EvaluateAdjointSource(mesh, measurementVector, simulatedPotentials);
-            Complex[] adjointSource = new Complex[adjSrc.Length];
-            for (int k = 0; k < adjSrc.Length; k++)
-                adjointSource[k] = adjSrc[k];
+            var adjSrc = errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
+            var expandedAdjoint = BuildAdjointSourceVector(adjSrc, electrodes.Count);
+            Complex[] adjointSource = ToComplex(expandedAdjoint);
 
             var adjointBoundaryCondition = new FEMBoundaryCondition(new List<FEMElectrode>(electrodes));
             if (updateWorkspace)
@@ -933,7 +1044,9 @@ namespace BusinessLayer
                 double[] dObs = simulatedMeasurements[exc];
                 // Compare only the electrodes that are physically measured in the current configuration.
                 var alignedObs = AlignMeasurementVector(dObs, electrodes);
-                Jtotal += _errorMetric.Evaluate(mesh, alignedObs, dSimNew);
+                var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodeCount);
+                var projectedSimulated = PrepareSimulatedData(dSimNew);
+                Jtotal += _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
             }
 
             return Jtotal;
@@ -961,15 +1074,15 @@ namespace BusinessLayer
 
             // Extract simulated potentials
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
+            var projectedMeasurement = PrepareMeasurementData(currentMeasurement, electrodes.Count);
+            var projectedSimulated = PrepareSimulatedData(simulatedPotentials);
 
-            double currentError = _errorMetric.Evaluate(mesh, currentMeasurement, simulatedPotentials);
+            double currentError = _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
 
-            // Error metric based gradeint expression
-            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, currentMeasurement, simulatedPotentials);
-
-            Complex[] adjointSource = new Complex[adjSrc.Length];
-            for (int k = 0; k < adjSrc.Length; k++)
-                adjointSource[k] = adjSrc[k];
+            // Error metric based gradient expression
+            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
+            var expandedAdjoint = BuildAdjointSourceVector(adjSrc, electrodes.Count);
+            Complex[] adjointSource = ToComplex(expandedAdjoint);
 
             var adjointBoundaryCondition = new LBMBoundaryCondition(electrodes);
             Workspace.SetCurrentGlobalLbmBoundaryCondition(adjointBoundaryCondition);
@@ -1215,16 +1328,13 @@ namespace BusinessLayer
 
                     // 4e) Build adjoint source s = EvaluateAdjointSource (L2: residual; W2: Kantorovich φ) 
                     var adjSrc = PotentialClipper.Clip(_errorMetric.EvaluateAdjointSource(mesh, dObs, dSim));
-
-                    Complex[] adjointSource = new Complex[adjSrc.Length];
-                    for(int i = 0; i < adjSrc.Length; i++)
-                        adjointSource[i] = adjSrc[i];
-
+                    var expandedAdjoint = BuildAdjointSourceVector(adjSrc, electrodes.Count);
+                    Complex[] adjointSource = ToComplex(expandedAdjoint);
 
                     // wrap into a PotentialDistribution on electrodes
                     var srcDist = new PotentialDistribution(
-                        Enumerable.Range(0, adjSrc.Length)
-                                  .ToDictionary(i => electrodes[i].Id, i => adjSrc[i])
+                        Enumerable.Range(0, expandedAdjoint.Length)
+                                  .ToDictionary(i => electrodes[i].Id, i => expandedAdjoint[i])
                     );
 
                     // 4f) Adjoint solve μ: same forward‐solver but feed in adjSrc as boundary currents
@@ -1305,7 +1415,9 @@ namespace BusinessLayer
                     double[] dObs = simulatedMeasurements[exc];
                     // Restrict the misfit to the subset of electrodes that produced readings.
                     var alignedObs = AlignMeasurementVector(dObs, electrodes);
-                    Jtotal += _errorMetric.Evaluate(mesh, alignedObs, dSimNew);
+                    var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodeCount);
+                    var projectedSimulated = PrepareSimulatedData(dSimNew);
+                    Jtotal += _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
                 }
                 Debug.WriteLine($"Iteration {iter}: total misfit = {Jtotal}");
 

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -1889,6 +1889,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                 ExcitationElectrodeId,
                 GroundElectrodeId,
                 parameters.DrivePattern,
+                parameters.UsePotentialDifferences,
                 parameters.UseOmpParallelization,
                 parameters.UseCudaAcceleration);
 
@@ -2044,6 +2045,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             int ExcitationElectrodeId,
             int GroundElectrodeId,
             DrivePattern DrivePattern,
+            bool UsePotentialDifferences,
             bool UseOmpParallelization,
             bool UseCudaAcceleration);
 

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -166,7 +166,7 @@
                         <Border Grid.Column="1"
                                 Style="{StaticResource PanelSectionBorderStyle}"
                                 BackgroundColor="{AppThemeBinding Light=#25324A, Dark=#25324A}">
-                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
+                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
                                 <Label Grid.Row="0" Text="Parameters" FontSize="Medium" FontAttributes="Bold" Margin="0,0,0,12"/>
                                 <Label Grid.Row="1" HorizontalOptions="Start" Text="Initial Distribution" FontFamily="SF Pro Text" FontAttributes="None"/>
                                 <Picker Grid.Row="2" ItemsSource="{Binding InitialDistributionOptions}" SelectedItem="{Binding ReconstructionParameters.InitialDistributionType}" MaximumWidthRequest="150"/>
@@ -185,10 +185,18 @@
                                        IsEnabled="{Binding IsNoiseAmplitudeEnabled}"/>
                                 <Label Grid.Row="13"
                                        HorizontalOptions="Start"
+                                       Text="Use Potential Differences"
+                                       FontFamily="SF Pro Text"
+                                       FontAttributes="None"/>
+                                <Switch Grid.Row="14"
+                                        IsToggled="{Binding ReconstructionParameters.UsePotentialDifferences}"
+                                        HorizontalOptions="Start"/>
+                                <Label Grid.Row="15"
+                                       HorizontalOptions="Start"
                                        Text="Conductivity Bounds [S]"
                                        FontFamily="SF Pro Text"
                                        FontAttributes="None"/>
-                                <Grid Grid.Row="14" ColumnDefinitions="*, *" ColumnSpacing="8">
+                                <Grid Grid.Row="16" ColumnDefinitions="*, *" ColumnSpacing="8">
                                     <Entry Grid.Column="0"
                                            Placeholder="Min"
                                            Keyboard="Numeric"

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -60,6 +60,7 @@ namespace ServiceLayer
         // ("active") or omit them ("non-active").  This flag is mirrored to the workspace so that
         // the UI can communicate the acquisition mode to the user.
         private ElectrodeMeasurementSetup _measurementSetup = ElectrodeMeasurementSetup.Active;
+        private bool _usePotentialDifferences;
 
         /// <summary>
         /// Raised when a full reconstruction result is available (i.e., at the end of a cycle or batch).
@@ -260,6 +261,7 @@ namespace ServiceLayer
                 // Store noise settings for subsequent simulations/import handling.
                 _measurementNoiseType = parameters.MeasurementNoiseType;
                 _measurementNoiseAmplitude = parameters.MeasurementNoiseAmplitude;
+                _usePotentialDifferences = parameters.UsePotentialDifferences;
 
                 if (_measurementNoiseType == MeasurementNoiseType.None || Math.Abs(_measurementNoiseAmplitude) <= double.Epsilon)
                     Workspace.AddLogMessage("Reconstruction Service", "Measurement noise disabled.");
@@ -277,6 +279,11 @@ namespace ServiceLayer
                     Workspace.AddLogMessage("Reconstruction Service",
                         $"Measurement noise enabled: {_measurementNoiseType} (amplitude {amplitudeDescriptor}).");
                 }
+
+                Workspace.AddLogMessage("Reconstruction Service",
+                    _usePotentialDifferences
+                        ? "Using electrode potential differences for reconstruction misfit evaluation."
+                        : "Using direct electrode potentials for reconstruction misfit evaluation.");
 
                 // Seed measurement source state; we may swap to real measurements later.
                 _measurementSource = Workspace.GetMeasurementSource();
@@ -643,9 +650,13 @@ namespace ServiceLayer
             long totalMeasurements = (long)frameLength * frames.Count;
             long expectedActiveTotal = (long)electrodeCount * electrodeCount;
             long expectedNonActiveTotal = (long)electrodeCount * Math.Max(0, electrodeCount - 3);
+            int expectedDifferenceLength = Math.Max(0, electrodeCount - 1);
 
             bool looksActive = frameLength == electrodeCount || totalMeasurements == expectedActiveTotal;
             bool looksNonActive = !looksActive && (frameLength == Math.Max(0, electrodeCount - 2) || totalMeasurements == expectedNonActiveTotal);
+
+            if (_usePotentialDifferences && frameLength == expectedDifferenceLength)
+                looksActive = true;
 
             _measurementSetup = looksActive ? ElectrodeMeasurementSetup.Active : ElectrodeMeasurementSetup.NonActive;
 

--- a/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
@@ -178,10 +178,6 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
 
         private OptimalTransportResult SolveOT(IDiscretization discretization, double[] measured, double[] simulated)
         {
-            var all = discretization.GetElectrodes().OrderBy(e => e.Id).ToList();
-            if (all.Count != measured.Length || all.Count != simulated.Length)
-                throw new ArgumentException("Electrode count must match data length.");
-
             Func<Electrode, (double x, double y)> coord;
             if (discretization is LBMGrid lbm)
                 coord = e => { var le = (LBMElectrode)e; return ToXY(lbm, le.GridId); };
@@ -189,6 +185,17 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 coord = e => { var fe = (FEMElectrode)e; return GetCoord(fem, fe); };
             else
                 throw new ArgumentException("Wasserstein-2 currently implemented for LBMGrid or FEMMesh because it needs electrode coordinates.");
+
+            var all = discretization.GetElectrodes().OrderBy(e => e.Id).ToList();
+            bool usingDifferences = all.Count > 0 &&
+                                    measured.Length == all.Count - 1 &&
+                                    simulated.Length == all.Count - 1;
+
+            if (usingDifferences)
+                return SolveDifferenceOT(measured, simulated, all, coord);
+
+            if (all.Count != measured.Length || all.Count != simulated.Length)
+                throw new ArgumentException("Electrode count must match data length when using direct potentials.");
 
             // Determine which electrodes carry valid measurements.  Include
             // an electrode if the corresponding measured value is finite,
@@ -214,6 +221,33 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return new OptimalTransportResult(measured, simulated, res.Cost, gradFull);
         }
 
+        private OptimalTransportResult SolveDifferenceOT(double[] measured, double[] simulated,
+            List<Electrode> electrodes, Func<Electrode, (double x, double y)> getCoord)
+        {
+            if (measured.Length != simulated.Length)
+                throw new ArgumentException("Measured and simulated difference arrays must have identical length.");
+
+            int differenceCount = measured.Length;
+            var include = new List<int>();
+            for (int i = 0; i < differenceCount; i++)
+                if (double.IsFinite(measured[i]) && double.IsFinite(simulated[i]))
+                    include.Add(i);
+
+            var (aRaw, aLoc, aMap) = BuildDifferenceDistribution(simulated, electrodes, getCoord, include);
+            var (bRaw, bLoc, _) = BuildDifferenceDistribution(measured, electrodes, getCoord, include);
+
+            if (aRaw.Length == 0 || bRaw.Length == 0)
+                return new OptimalTransportResult(measured, simulated, 0.0, new double[differenceCount]);
+
+            var res = w2_misfit_and_grad(aRaw, bRaw, aLoc, bLoc);
+
+            var grad = new double[differenceCount];
+            foreach (var (srcIdx, diffIdx) in aMap)
+                grad[diffIdx] = res.Grad[srcIdx];
+
+            return new OptimalTransportResult(measured, simulated, res.Cost, grad);
+        }
+
         private static (double[] raw, (double x, double y)[] loc, List<(int srcIdx, int electrodeIdx)> indexMap)
             BuildDistribution(double[] raw, List<Electrode> electrodes,
                 Func<Electrode, (double x, double y)> getCoord, List<int> include)
@@ -233,6 +267,40 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 coords.Add(getCoord(e));
                 map.Add((vals.Count - 1, i));
             }
+            return (vals.ToArray(), coords.ToArray(), map);
+        }
+
+        private static (double[] raw, (double x, double y)[] loc, List<(int srcIdx, int diffIdx)> indexMap)
+            BuildDifferenceDistribution(double[] raw, List<Electrode> electrodes,
+                Func<Electrode, (double x, double y)> getCoord, List<int> include)
+        {
+            var vals = new List<double>(include.Count);
+            var coords = new List<(double, double)>(include.Count);
+            var map = new List<(int, int)>(include.Count);
+
+            foreach (int diffIdx in include)
+            {
+                if (diffIdx < 0 || diffIdx >= raw.Length)
+                    continue;
+
+                double v = raw[diffIdx];
+                if (!double.IsFinite(v))
+                    continue;
+
+                int left = diffIdx;
+                int right = diffIdx + 1;
+                if (left < 0 || right >= electrodes.Count)
+                    continue;
+
+                var leftCoord = getCoord(electrodes[left]);
+                var rightCoord = getCoord(electrodes[right]);
+                var midpoint = ((leftCoord.x + rightCoord.x) * 0.5, (leftCoord.y + rightCoord.y) * 0.5);
+
+                vals.Add(v);
+                coords.Add(midpoint);
+                map.Add((vals.Count - 1, diffIdx));
+            }
+
             return (vals.ToArray(), coords.ToArray(), map);
         }
 

--- a/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
+++ b/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
@@ -34,6 +34,9 @@ namespace Utility.Classes.ReconstructionParameters
         private DrivePattern drivePattern = DrivePattern.Adjecent;
 
         [ObservableProperty]
+        private bool usePotentialDifferences = false;
+
+        [ObservableProperty]
         private bool useOmpParallelization = false;
 
         [ObservableProperty]
@@ -61,6 +64,7 @@ namespace Utility.Classes.ReconstructionParameters
             MeasurementNoiseType = MeasurementNoiseType.None;
             MeasurementNoiseAmplitude = 0.0;
             DrivePattern = DrivePattern.Adjecent;
+            UsePotentialDifferences = false;
             UseOmpParallelization = false;
             UseCudaAcceleration = false;
             Mesh = DiscretizationType.FEM;
@@ -78,7 +82,8 @@ namespace Utility.Classes.ReconstructionParameters
                                            InitialDistributionTypes initialDistributionType = InitialDistributionTypes.SlightlyDiffering,
                                            MeasurementNoiseType measurementNoiseType = MeasurementNoiseType.None,
                                            double measurementNoiseAmplitude = 0.0,
-                                           DrivePattern drivePattern = DrivePattern.Adjecent)
+                                           DrivePattern drivePattern = DrivePattern.Adjecent,
+                                           bool usePotentialDifferences = false)
         {
             DifferentialEquationSolver = differentialEquationSolver;
             RegularizationTechnique = regularizationTechnique;
@@ -89,6 +94,7 @@ namespace Utility.Classes.ReconstructionParameters
             MeasurementNoiseType = measurementNoiseType;
             MeasurementNoiseAmplitude = measurementNoiseAmplitude;
             DrivePattern = drivePattern;
+            UsePotentialDifferences = usePotentialDifferences;
             UseOmpParallelization = false;
             UseCudaAcceleration = false;
 


### PR DESCRIPTION
## Summary
- allow the Wasserstein-2 error metric to operate on sequential potential difference data by mapping differences to midpoint coordinates
- return gradients with the same length as the incoming difference vectors and validate mixed-length inputs

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ff4f26e9008333a39e85c5cde03764