### PR TITLE
Handle potential-difference frames in W2 error metric

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -442,8 +442,43 @@ namespace BusinessLayer
         /// Expands a measurement vector to match the FEM electrode list ordering expected by the solver.
         /// Pads missing entries with NaNs and trims excess if needed. Non-measuring electrodes are ignored.
         /// </summary>
-        private static double[] AlignMeasurementVector(double[] measurement, List<FEMElectrode> electrodes)
+        private static int CountMeasuringElectrodes(List<FEMElectrode> electrodes) => electrodes.Count(e => e.IsMeasuring);
+
+        private static int GetExpectedDifferenceLength(List<FEMElectrode> electrodes)
         {
+            int measuringElectrodes = CountMeasuringElectrodes(electrodes);
+            return Math.Max(0, measuringElectrodes - 1);
+        }
+
+        private static List<double> ExtractMeasuringValues(double[] values, List<FEMElectrode> electrodes)
+        {
+            var measuring = new List<double>(CountMeasuringElectrodes(electrodes));
+            int limit = Math.Min(values.Length, electrodes.Count);
+            for (int i = 0; i < limit; i++)
+            {
+                if (!electrodes[i].IsMeasuring)
+                    continue;
+
+                measuring.Add(values[i]);
+            }
+
+            return measuring;
+        }
+
+        private bool MeasurementRepresentsDifferences(double[] measurement, List<FEMElectrode> electrodes)
+        {
+            if (!_usePotentialDifferences || measurement == null)
+                return false;
+
+            int expected = GetExpectedDifferenceLength(electrodes);
+            return measurement.Length == expected;
+        }
+
+        private static double[] AlignMeasurementVector(double[] measurement, List<FEMElectrode> electrodes, bool measurementIsDifference)
+        {
+            if (measurementIsDifference)
+                return (double[])measurement.Clone();
+
             // Rebuild a length-M vector compatible with the FEM solver.  Missing entries
             // from non-active datasets are padded with NaNs so that the misfit ignores
             // excitation electrodes while preserving index alignment.
@@ -485,9 +520,21 @@ namespace BusinessLayer
 
         /// <summary>
         /// Projects measured data into the configured representation.
-        /// If <see cref="_usePotentialDifferences"/> is enabled, returns sequential differences; otherwise returns as-is.
-        /// The <paramref name="electrodeCount"/> is used to infer expected difference vector length.
+        /// When potential differences are enabled, measurements coming from the measuring-electrode subset are
+        /// transformed into sequential differences; otherwise the values are returned unchanged.
         /// </summary>
+        private double[] PrepareMeasurementData(double[] measurement, List<FEMElectrode> electrodes, bool measurementIsDifference)
+        {
+            if (!_usePotentialDifferences)
+                return measurement;
+
+            if (measurementIsDifference)
+                return (double[])measurement.Clone();
+
+            var measuringValues = ExtractMeasuringValues(measurement, electrodes);
+            return ComputeSequentialDifferences(measuringValues);
+        }
+
         private double[] PrepareMeasurementData(double[] measurement, int electrodeCount)
         {
             if (!_usePotentialDifferences)
@@ -495,7 +542,7 @@ namespace BusinessLayer
 
             int differenceLength = Math.Max(0, electrodeCount - 1);
             if (measurement.Length == differenceLength)
-                return measurement;
+                return (double[])measurement.Clone();
 
             return ComputeSequentialDifferences(measurement);
         }
@@ -503,6 +550,15 @@ namespace BusinessLayer
         /// <summary>
         /// Projects simulated data into the configured representation; symmetric to <see cref="PrepareMeasurementData"/>.
         /// </summary>
+        private double[] PrepareSimulatedData(double[] simulated, List<FEMElectrode> electrodes)
+        {
+            if (!_usePotentialDifferences)
+                return simulated;
+
+            var measuringValues = ExtractMeasuringValues(simulated, electrodes);
+            return ComputeSequentialDifferences(measuringValues);
+        }
+
         private double[] PrepareSimulatedData(double[] simulated)
         {
             if (!_usePotentialDifferences)
@@ -515,12 +571,12 @@ namespace BusinessLayer
         /// Computes first-order forward differences v[i+1]-v[i] while preserving NaNs
         /// (any pair including a NaN yields NaN at the difference index).
         /// </summary>
-        private static double[] ComputeSequentialDifferences(double[] values)
+        private static double[] ComputeSequentialDifferences(IReadOnlyList<double> values)
         {
-            if (values.Length <= 1)
+            if (values.Count <= 1)
                 return System.Array.Empty<double>();
 
-            double[] differences = new double[values.Length - 1];
+            double[] differences = new double[values.Count - 1];
             for (int i = 0; i < differences.Length; i++)
             {
                 double a = values[i];
@@ -655,13 +711,14 @@ namespace BusinessLayer
             }
 
             // Ensure the data vector mirrors the electrode ordering that the solver expects.
-            var measurementVector = AlignMeasurementVector(currentMeasurement, electrodes);
-            var projectedMeasurement = PrepareMeasurementData(measurementVector, electrodes.Count);
+            bool measurementIsDifference = MeasurementRepresentsDifferences(currentMeasurement, electrodes);
+            var measurementVector = AlignMeasurementVector(currentMeasurement, electrodes, measurementIsDifference);
+            var projectedMeasurement = PrepareMeasurementData(measurementVector, electrodes, measurementIsDifference);
 
             // Forward solve: φ
             PotentialDistribution phi = PotentialClipper.Clip(solver.Solve(mesh, bc, null));
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
-            var projectedSimulated = PrepareSimulatedData(simulatedPotentials);
+            var projectedSimulated = PrepareSimulatedData(simulatedPotentials, electrodes);
 
             // Build adjoint source from error metric and project back to electrode-space
             var adjSrc = errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
@@ -1164,10 +1221,11 @@ namespace BusinessLayer
                 _ = _differentialEquationSolver.Solve(mesh, bc, null);
                 double[] dSimNew = mesh.GetElectrodePotentials();
                 double[] dObs = simulatedMeasurements[exc];
+                bool measurementIsDifference = MeasurementRepresentsDifferences(dObs, electrodes);
                 // Compare only the electrodes that are physically measured in the current configuration.
-                var alignedObs = AlignMeasurementVector(dObs, electrodes);
-                var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodeCount);
-                var projectedSimulated = PrepareSimulatedData(dSimNew);
+                var alignedObs = AlignMeasurementVector(dObs, electrodes, measurementIsDifference);
+                var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodes, measurementIsDifference);
+                var projectedSimulated = PrepareSimulatedData(dSimNew, electrodes);
                 Jtotal += _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
             }
 
@@ -1557,10 +1615,11 @@ namespace BusinessLayer
                     var phiNew = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, bc, null));
                     double[] dSimNew = PotentialClipper.Clip(mesh.GetElectrodePotentials());
                     double[] dObs = simulatedMeasurements[exc];
+                    bool measurementIsDifference = MeasurementRepresentsDifferences(dObs, electrodes);
                     // Restrict the misfit to the subset of electrodes that produced readings.
-                    var alignedObs = AlignMeasurementVector(dObs, electrodes);
-                    var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodeCount);
-                    var projectedSimulated = PrepareSimulatedData(dSimNew);
+                    var alignedObs = AlignMeasurementVector(dObs, electrodes, measurementIsDifference);
+                    var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodes, measurementIsDifference);
+                    var projectedSimulated = PrepareSimulatedData(dSimNew, electrodes);
                     Jtotal += _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
                 }
                 Debug.WriteLine($"Iteration {iter}: total misfit = {Jtotal}");

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -673,7 +673,7 @@ namespace ServiceLayer
         /// driven electrodes (non-active mode), NaN placeholders are injected for those positions so that solver
         /// residuals can ignore them. Excess values are truncated with a warning.
         /// </summary>
-        private static double[] PrepareMeasurementFrame(double[] measurement, List<FEMElectrode> electrodes)
+        private double[] PrepareMeasurementFrame(double[] measurement, List<FEMElectrode> electrodes)
         {
             // Map the supplied measurement vector to the solver ordering.
             // When non-active data is provided only the measuring electrodes
@@ -682,6 +682,12 @@ namespace ServiceLayer
             int electrodeCount = electrodes.Count;
             if (electrodeCount == 0)
                 return measurement;
+
+            int measuringElectrodeCount = electrodes.Count(e => e.IsMeasuring);
+            int expectedDifferenceLength = Math.Max(0, measuringElectrodeCount - 1);
+
+            if (_usePotentialDifferences && measurement.Length == expectedDifferenceLength)
+                return (double[])measurement.Clone();
 
             if (measurement.Length == electrodeCount)
                 return measurement; // Already in full active form
@@ -695,7 +701,6 @@ namespace ServiceLayer
             // Allocate full frame and fill measuring positions sequentially from the provided data.
             double[] prepared = Enumerable.Repeat(double.NaN, electrodeCount).ToArray();
             int measurementIndex = 0;
-            int measuringElectrodeCount = electrodes.Count(e => e.IsMeasuring);
 
             for (int i = 0; i < electrodeCount; i++)
             {

--- a/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
@@ -187,12 +187,15 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 throw new ArgumentException("Wasserstein-2 currently implemented for LBMGrid or FEMMesh because it needs electrode coordinates.");
 
             var all = discretization.GetElectrodes().OrderBy(e => e.Id).ToList();
-            bool usingDifferences = all.Count > 0 &&
-                                    measured.Length == all.Count - 1 &&
-                                    simulated.Length == all.Count - 1;
+            var measuring = all.Where(e => e.IsMeasuring).OrderBy(e => e.Id).ToList();
+            var differenceElectrodes = measuring.Count > 0 ? (IReadOnlyList<Electrode>)measuring : all;
+
+            int expectedDifferenceLength = Math.Max(0, differenceElectrodes.Count - 1);
+            bool usingDifferences = measured.Length == expectedDifferenceLength &&
+                                    simulated.Length == expectedDifferenceLength;
 
             if (usingDifferences)
-                return SolveDifferenceOT(measured, simulated, all, coord);
+                return SolveDifferenceOT(measured, simulated, differenceElectrodes, coord);
 
             if (all.Count != measured.Length || all.Count != simulated.Length)
                 throw new ArgumentException("Electrode count must match data length when using direct potentials.");
@@ -222,7 +225,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         }
 
         private OptimalTransportResult SolveDifferenceOT(double[] measured, double[] simulated,
-            List<Electrode> electrodes, Func<Electrode, (double x, double y)> getCoord)
+            IReadOnlyList<Electrode> electrodes, Func<Electrode, (double x, double y)> getCoord)
         {
             if (measured.Length != simulated.Length)
                 throw new ArgumentException("Measured and simulated difference arrays must have identical length.");
@@ -271,7 +274,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         }
 
         private static (double[] raw, (double x, double y)[] loc, List<(int srcIdx, int diffIdx)> indexMap)
-            BuildDifferenceDistribution(double[] raw, List<Electrode> electrodes,
+            BuildDifferenceDistribution(double[] raw, IReadOnlyList<Electrode> electrodes,
                 Func<Electrode, (double x, double y)> getCoord, List<int> include)
         {
             var vals = new List<double>(include.Count);


### PR DESCRIPTION
## Summary
- detect potential-difference datasets using the measuring-electrode subset expected by FEM workflows
- map Wasserstein-2 difference entries through the same ordered measuring electrodes when computing transport supports
- keep gradient lengths aligned with sequential differences so reconstructions can enable W2 on difference data

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffdbc39d9883338e83a1dbc7cc520b