### PR TITLE
Handle active electrode measurements for difference projection

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -444,22 +444,27 @@ namespace BusinessLayer
         /// </summary>
         private static int CountMeasuringElectrodes(List<FEMElectrode> electrodes) => electrodes.Count(e => e.IsMeasuring);
 
-        private static int GetExpectedDifferenceLength(List<FEMElectrode> electrodes)
-        {
-            int measuringElectrodes = CountMeasuringElectrodes(electrodes);
-            return Math.Max(0, measuringElectrodes - 1);
-        }
-
         private static List<double> ExtractMeasuringValues(double[] values, List<FEMElectrode> electrodes)
         {
-            var measuring = new List<double>(CountMeasuringElectrodes(electrodes));
+            if (values == null || electrodes == null)
+                return new List<double>();
+
             int limit = Math.Min(values.Length, electrodes.Count);
+            var measuring = new List<double>(limit);
             for (int i = 0; i < limit; i++)
             {
-                if (!electrodes[i].IsMeasuring)
+                double sample = values[i];
+                if (double.IsNaN(sample))
                     continue;
 
-                measuring.Add(values[i]);
+                measuring.Add(sample);
+            }
+
+            for (int i = electrodes.Count; i < values.Length; i++)
+            {
+                double sample = values[i];
+                if (!double.IsNaN(sample))
+                    measuring.Add(sample);
             }
 
             return measuring;
@@ -470,8 +475,13 @@ namespace BusinessLayer
             if (!_usePotentialDifferences || measurement == null)
                 return false;
 
-            int expected = GetExpectedDifferenceLength(electrodes);
-            return measurement.Length == expected;
+            int measuringElectrodes = CountMeasuringElectrodes(electrodes);
+            int electrodeCount = electrodes.Count;
+
+            int measuringDifference = Math.Max(0, measuringElectrodes - 1);
+            int activeDifference = Math.Max(0, electrodeCount - 1);
+
+            return measurement.Length == measuringDifference || measurement.Length == activeDifference;
         }
 
         private static double[] AlignMeasurementVector(double[] measurement, List<FEMElectrode> electrodes, bool measurementIsDifference)

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -650,13 +650,20 @@ namespace ServiceLayer
             long totalMeasurements = (long)frameLength * frames.Count;
             long expectedActiveTotal = (long)electrodeCount * electrodeCount;
             long expectedNonActiveTotal = (long)electrodeCount * Math.Max(0, electrodeCount - 3);
-            int expectedDifferenceLength = Math.Max(0, electrodeCount - 1);
+            int activeDifferenceLength = Math.Max(0, electrodeCount - 1);
+            int nonActiveDifferenceLength = Math.Max(0, electrodeCount - 3);
 
             bool looksActive = frameLength == electrodeCount || totalMeasurements == expectedActiveTotal;
             bool looksNonActive = !looksActive && (frameLength == Math.Max(0, electrodeCount - 2) || totalMeasurements == expectedNonActiveTotal);
 
-            if (_usePotentialDifferences && frameLength == expectedDifferenceLength)
-                looksActive = true;
+            if (_usePotentialDifferences)
+            {
+                if (frameLength == activeDifferenceLength)
+                    looksActive = true;
+
+                if (!looksActive && frameLength == nonActiveDifferenceLength)
+                    looksNonActive = true;
+            }
 
             _measurementSetup = looksActive ? ElectrodeMeasurementSetup.Active : ElectrodeMeasurementSetup.NonActive;
 
@@ -685,8 +692,9 @@ namespace ServiceLayer
 
             int measuringElectrodeCount = electrodes.Count(e => e.IsMeasuring);
             int expectedDifferenceLength = Math.Max(0, measuringElectrodeCount - 1);
+            int activeDifferenceLength = Math.Max(0, electrodeCount - 1);
 
-            if (_usePotentialDifferences && measurement.Length == expectedDifferenceLength)
+            if (_usePotentialDifferences && (measurement.Length == expectedDifferenceLength || measurement.Length == activeDifferenceLength))
                 return (double[])measurement.Clone();
 
             if (measurement.Length == electrodeCount)


### PR DESCRIPTION
## Summary
- include measured potentials from active drive electrodes when preparing solver inputs
- detect both active and non-active potential-difference frames when importing or aligning measurements

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ffed161558833398acaf6bd3c8bf2f