### PR TITLE
Add measurement pattern support for all measurement modes

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -394,17 +394,23 @@ namespace BusinessLayer
                 : _differentialEquationSolver.Solve(mesh, bc, null);
             phi = PotentialClipper.Clip(phi);
 
-            // Extract simulated potentials and project both measured and simulated to the active representation
+            // Extract simulated potentials and project both measured and simulated to the representation
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
-            var projectedMeasurement = PrepareMeasurementData(currentMeasurement, electrodes.Count);
-            var projectedSimulated = PrepareSimulatedData(simulatedPotentials);
+            var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+            var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+            // Normalise Option 1–4 frames (see MeasurementPattern) prior to evaluating the misfit.
+            var projection = MeasurementProjector.Create(electrodeProjectionList,
+                                                         measurementSetup,
+                                                         _usePotentialDifferences,
+                                                         currentMeasurement,
+                                                         simulatedPotentials);
 
-            double currentError = _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
+            double currentError = _errorMetric.Evaluate(mesh, projection.Measured, projection.Simulated);
             _ = currentError; // error value is not stored in this frame, but could be logged if needed
 
             // Error metric based gradient expression
-            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
-            var expandedAdjoint = BuildAdjointSourceVector(adjSrc, electrodes.Count);
+            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projection.Measured, projection.Simulated);
+            var expandedAdjoint = projection.ExpandAdjoint(adjSrc);
             Complex[] adjointSource = ToComplex(expandedAdjoint);
 
             // Adjoint solve using the same boundary condition shape but with source applied
@@ -436,235 +442,6 @@ namespace BusinessLayer
 
             // LBM path in this routine does not compute explicit regularization (left empty)
             return new ReconstructionFrame(dataGrad, phi, mu, new ConductivityDistribution([]));
-        }
-
-        /// <summary>
-        /// Expands a measurement vector to match the FEM electrode list ordering expected by the solver.
-        /// Pads missing entries with NaNs and trims excess if needed. Non-measuring electrodes are ignored.
-        /// </summary>
-        private static int CountMeasuringElectrodes(List<FEMElectrode> electrodes) => electrodes.Count(e => e.IsMeasuring);
-
-        private static List<double> ExtractMeasuringValues(double[] values, List<FEMElectrode> electrodes)
-        {
-            if (values == null || electrodes == null)
-                return new List<double>();
-
-            int limit = Math.Min(values.Length, electrodes.Count);
-            var measuring = new List<double>(limit);
-            for (int i = 0; i < limit; i++)
-            {
-                double sample = values[i];
-                if (double.IsNaN(sample))
-                    continue;
-
-                measuring.Add(sample);
-            }
-
-            for (int i = electrodes.Count; i < values.Length; i++)
-            {
-                double sample = values[i];
-                if (!double.IsNaN(sample))
-                    measuring.Add(sample);
-            }
-
-            return measuring;
-        }
-
-        private bool MeasurementRepresentsDifferences(double[] measurement, List<FEMElectrode> electrodes)
-        {
-            if (!_usePotentialDifferences || measurement == null)
-                return false;
-
-            int measuringElectrodes = CountMeasuringElectrodes(electrodes);
-            int electrodeCount = electrodes.Count;
-
-            int measuringDifference = Math.Max(0, measuringElectrodes - 1);
-            int activeDifference = Math.Max(0, electrodeCount - 1);
-
-            return measurement.Length == measuringDifference || measurement.Length == activeDifference;
-        }
-
-        private static double[] AlignMeasurementVector(double[] measurement, List<FEMElectrode> electrodes, bool measurementIsDifference)
-        {
-            if (measurementIsDifference)
-                return (double[])measurement.Clone();
-
-            // Rebuild a length-M vector compatible with the FEM solver.  Missing entries
-            // from non-active datasets are padded with NaNs so that the misfit ignores
-            // excitation electrodes while preserving index alignment.
-            int electrodeCount = electrodes.Count;
-            if (electrodeCount == 0)
-                return measurement;
-
-            if (measurement.Length == electrodeCount)
-                return measurement;
-
-            if (measurement.Length > electrodeCount)
-                return measurement.Take(electrodeCount).ToArray();
-
-            double[] expanded = Enumerable.Repeat(double.NaN, electrodeCount).ToArray();
-            int measurementIndex = 0;
-            int measuringElectrodes = electrodes.Count(e => e.IsMeasuring);
-
-            for (int i = 0; i < electrodeCount && measurementIndex < measurement.Length; i++)
-            {
-                if (!electrodes[i].IsMeasuring)
-                    continue;
-
-                expanded[i] = measurement[measurementIndex++];
-            }
-
-            if (measurementIndex < measurement.Length)
-                Workspace.AddWarningMessage($"Discarding {measurement.Length - measurementIndex} excess measurement entries that cannot be mapped to electrodes.");
-            else if (measurement.Length < measuringElectrodes)
-            {
-                bool expectedMissing = Workspace.GetElectrodeMeasurementSetup() == ElectrodeMeasurementSetup.NonActive &&
-                                        measurement.Length == Math.Max(0, measuringElectrodes - 1);
-
-                if (!expectedMissing)
-                    Workspace.AddWarningMessage($"Measurement frame supplies only {measurementIndex} of {measuringElectrodes} measuring electrodes. Missing values will be ignored.");
-            }
-
-            return expanded;
-        }
-
-        /// <summary>
-        /// Projects measured data into the configured representation.
-        /// When potential differences are enabled, measurements coming from the measuring-electrode subset are
-        /// transformed into sequential differences; otherwise the values are returned unchanged.
-        /// </summary>
-        private double[] PrepareMeasurementData(double[] measurement, List<FEMElectrode> electrodes, bool measurementIsDifference)
-        {
-            if (!_usePotentialDifferences)
-                return measurement;
-
-            if (measurementIsDifference)
-                return (double[])measurement.Clone();
-
-            var measuringValues = ExtractMeasuringValues(measurement, electrodes);
-            return ComputeSequentialDifferences(measuringValues);
-        }
-
-        private double[] PrepareMeasurementData(double[] measurement, int electrodeCount)
-        {
-            if (!_usePotentialDifferences)
-                return measurement;
-
-            int differenceLength = Math.Max(0, electrodeCount - 1);
-            if (measurement.Length == differenceLength)
-                return (double[])measurement.Clone();
-
-            return ComputeSequentialDifferences(measurement);
-        }
-
-        /// <summary>
-        /// Projects simulated data into the configured representation; symmetric to <see cref="PrepareMeasurementData"/>.
-        /// </summary>
-        private double[] PrepareSimulatedData(double[] simulated, List<FEMElectrode> electrodes)
-        {
-            if (!_usePotentialDifferences)
-                return simulated;
-
-            var measuringValues = ExtractMeasuringValues(simulated, electrodes);
-            return ComputeSequentialDifferences(measuringValues);
-        }
-
-        private double[] PrepareSimulatedData(double[] simulated)
-        {
-            if (!_usePotentialDifferences)
-                return simulated;
-
-            return ComputeSequentialDifferences(simulated);
-        }
-
-        /// <summary>
-        /// Computes first-order forward differences v[i+1]-v[i] while preserving NaNs
-        /// (any pair including a NaN yields NaN at the difference index).
-        /// </summary>
-        private static double[] ComputeSequentialDifferences(IReadOnlyList<double> values)
-        {
-            if (values.Count <= 1)
-                return System.Array.Empty<double>();
-
-            double[] differences = new double[values.Count - 1];
-            for (int i = 0; i < differences.Length; i++)
-            {
-                double a = values[i];
-                double b = values[i + 1];
-                differences[i] = double.IsNaN(a) || double.IsNaN(b) ? double.NaN : b - a;
-            }
-
-            return differences;
-        }
-
-        /// <summary>
-        /// Ensures the adjoint source vector matches the number of electrodes.
-        /// Expands from difference-space to full electrodes if needed and resizes with zero-padding/truncation.
-        /// </summary>
-        private double[] BuildAdjointSourceVector(double[] adjoint, int electrodeCount)
-        {
-            if (electrodeCount <= 0)
-                return Array.Empty<double>();
-
-            double[] values = adjoint;
-
-            if (_usePotentialDifferences)
-                values = ExpandSequentialDifferenceAdjoint(values, electrodeCount);
-
-            if (values.Length == electrodeCount)
-                return values;
-
-            double[] resized = new double[electrodeCount];
-            int copyLength = Math.Min(values.Length, electrodeCount);
-            Array.Copy(values, resized, copyLength);
-
-            if (values.Length > electrodeCount)
-            {
-                Workspace.AddWarningMessage($"Discarding {values.Length - electrodeCount} adjoint source entries that cannot be mapped to electrodes.");
-            }
-            else if (values.Length < electrodeCount)
-            {
-                for (int i = copyLength; i < electrodeCount; i++)
-                    resized[i] = 0.0;
-            }
-
-            return resized;
-        }
-
-        /// <summary>
-        /// Inverse of the difference operator used for potential differences representation.
-        /// Maps an (N-1)-length difference adjoint vector back to an N-length per-electrode vector.
-        /// </summary>
-        private static double[] ExpandSequentialDifferenceAdjoint(double[] adjoint, int electrodeCount)
-        {
-            if (electrodeCount <= 0)
-                return Array.Empty<double>();
-
-            if (adjoint.Length == electrodeCount)
-                return adjoint;
-
-            if (adjoint.Length == 0)
-                return new double[electrodeCount];
-
-            if (adjoint.Length != electrodeCount - 1)
-                return adjoint;
-
-            double[] expanded = new double[electrodeCount];
-
-            if (electrodeCount == 1)
-                return expanded;
-
-            // The adjoint for sequential differences is equivalent to the negative discrete divergence
-            expanded[0] = -adjoint[0];
-            for (int i = 1; i < electrodeCount - 1; i++)
-            {
-                double left = adjoint[i - 1];
-                double right = adjoint[i];
-                expanded[i] = left - right;
-            }
-            expanded[electrodeCount - 1] = adjoint[adjoint.Length - 1];
-
-            return expanded;
         }
 
         /// <summary>
@@ -720,19 +497,22 @@ namespace BusinessLayer
                 elements = mesh.GetElements().Cast<FEMElement>().ToList();
             }
 
-            // Ensure the data vector mirrors the electrode ordering that the solver expects.
-            bool measurementIsDifference = MeasurementRepresentsDifferences(currentMeasurement, electrodes);
-            var measurementVector = AlignMeasurementVector(currentMeasurement, electrodes, measurementIsDifference);
-            var projectedMeasurement = PrepareMeasurementData(measurementVector, electrodes, measurementIsDifference);
-
             // Forward solve: φ
             PotentialDistribution phi = PotentialClipper.Clip(solver.Solve(mesh, bc, null));
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
-            var projectedSimulated = PrepareSimulatedData(simulatedPotentials, electrodes);
+
+            var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+            var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+            // Normalise Option 1–4 frames (see MeasurementPattern) prior to evaluating the misfit.
+            var projection = MeasurementProjector.Create(electrodeProjectionList,
+                                                         measurementSetup,
+                                                         _usePotentialDifferences,
+                                                         currentMeasurement,
+                                                         simulatedPotentials);
 
             // Build adjoint source from error metric and project back to electrode-space
-            var adjSrc = errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
-            var expandedAdjoint = BuildAdjointSourceVector(adjSrc, electrodes.Count);
+            var adjSrc = errorMetric.EvaluateAdjointSource(mesh, projection.Measured, projection.Simulated);
+            var expandedAdjoint = projection.ExpandAdjoint(adjSrc);
             Complex[] adjointSource = ToComplex(expandedAdjoint);
 
             // Adjoint solve: μ
@@ -1229,14 +1009,17 @@ namespace BusinessLayer
                 electrodes[(exc + 1) % electrodeCount].Current = -excitationAmplitude;
 
                 _ = _differentialEquationSolver.Solve(mesh, bc, null);
-                double[] dSimNew = mesh.GetElectrodePotentials();
+                double[] dSimNew = PotentialClipper.Clip(mesh.GetElectrodePotentials());
                 double[] dObs = simulatedMeasurements[exc];
-                bool measurementIsDifference = MeasurementRepresentsDifferences(dObs, electrodes);
-                // Compare only the electrodes that are physically measured in the current configuration.
-                var alignedObs = AlignMeasurementVector(dObs, electrodes, measurementIsDifference);
-                var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodes, measurementIsDifference);
-                var projectedSimulated = PrepareSimulatedData(dSimNew, electrodes);
-                Jtotal += _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
+                var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+                var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+                // Normalise Option 1–4 frames (see MeasurementPattern) prior to evaluating the misfit.
+                var projection = MeasurementProjector.Create(electrodeProjectionList,
+                                                             measurementSetup,
+                                                             _usePotentialDifferences,
+                                                             dObs,
+                                                             dSimNew);
+                Jtotal += _errorMetric.Evaluate(mesh, projection.Measured, projection.Simulated);
             }
 
             return Jtotal;
@@ -1268,15 +1051,20 @@ namespace BusinessLayer
 
             // Extract simulated potentials
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
-            var projectedMeasurement = PrepareMeasurementData(currentMeasurement, electrodes.Count);
-            var projectedSimulated = PrepareSimulatedData(simulatedPotentials);
+            var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+            var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+            var projection = MeasurementProjector.Create(electrodeProjectionList,
+                                                         measurementSetup,
+                                                         _usePotentialDifferences,
+                                                         currentMeasurement,
+                                                         simulatedPotentials);
 
-            double currentError = _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
+            double currentError = _errorMetric.Evaluate(mesh, projection.Measured, projection.Simulated);
             _ = currentError;
 
             // Error metric based gradient expression
-            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
-            var expandedAdjoint = BuildAdjointSourceVector(adjSrc, electrodes.Count);
+            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projection.Measured, projection.Simulated);
+            var expandedAdjoint = projection.ExpandAdjoint(adjSrc);
             Complex[] adjointSource = ToComplex(expandedAdjoint);
 
             var adjointBoundaryCondition = new LBMBoundaryCondition(electrodes);
@@ -1397,7 +1185,7 @@ namespace BusinessLayer
             var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
             int cycleLength = Math.Max(1, strategy.GetCycleLength(electrodeCount));
 
-            double[,] measurementFrames = new double[cycleLength, electrodeCount];
+            var frames = new List<double[]>(cycleLength);
 
             for (int i = 0; i < cycleLength; i++)
             {
@@ -1425,13 +1213,16 @@ namespace BusinessLayer
 
                 _ = _differentialEquationSolver.Solve(deepCopy, boundaryCondition, null);
 
-                double[] electrodePotentials = deepCopy.GetElectrodePotentials();
-
-                for (int j = 0; j < electrodeCount; j++)
-                    measurementFrames[i, j] = electrodePotentials[j];
+                double[] electrodePotentials = PotentialClipper.Clip(deepCopy.GetElectrodePotentials());
+                var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+                var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+                var pattern = MeasurementPatternBuilder.Build(electrodeProjectionList,
+                                                              measurementSetup,
+                                                              _usePotentialDifferences);
+                frames.Add(pattern.ExtractRawMeasurement(electrodePotentials));
             }
 
-            return new EITMeasurement(measurementFrames);
+            return new EITMeasurement(frames);
         }
 
         #endregion
@@ -1625,12 +1416,15 @@ namespace BusinessLayer
                     var phiNew = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, bc, null));
                     double[] dSimNew = PotentialClipper.Clip(mesh.GetElectrodePotentials());
                     double[] dObs = simulatedMeasurements[exc];
-                    bool measurementIsDifference = MeasurementRepresentsDifferences(dObs, electrodes);
-                    // Restrict the misfit to the subset of electrodes that produced readings.
-                    var alignedObs = AlignMeasurementVector(dObs, electrodes, measurementIsDifference);
-                    var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodes, measurementIsDifference);
-                    var projectedSimulated = PrepareSimulatedData(dSimNew, electrodes);
-                    Jtotal += _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
+                    var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+                    var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+                    // Normalise Option 1–4 frames (see MeasurementPattern) prior to evaluating the misfit.
+                    var projection = MeasurementProjector.Create(electrodeProjectionList,
+                                                                 measurementSetup,
+                                                                 _usePotentialDifferences,
+                                                                 dObs,
+                                                                 dSimNew);
+                    Jtotal += _errorMetric.Evaluate(mesh, projection.Measured, projection.Simulated);
                 }
                 Debug.WriteLine($"Iteration {iter}: total misfit = {Jtotal}");
 
@@ -1696,7 +1490,13 @@ namespace BusinessLayer
 
                 FEMMesh result = SolveFemForward(deepCopy);
 
-                measurements.Add(PotentialClipper.Clip(result.GetElectrodePotentials()));
+                double[] potentials = PotentialClipper.Clip(result.GetElectrodePotentials());
+                var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+                var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+                var pattern = MeasurementPatternBuilder.Build(electrodeProjectionList,
+                                                              measurementSetup,
+                                                              _usePotentialDifferences);
+                measurements.Add(pattern.ExtractRawMeasurement(potentials));
             }
 
             return measurements;

--- a/Utility/Classes/Measurement/MeasurementPattern.cs
+++ b/Utility/Classes/Measurement/MeasurementPattern.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Utility.Classes.Application;
+using Utility.Classes.Discretizer;
+
+namespace Utility.Classes.Measurement
+{
+    /// <summary>
+    /// Describes how a single measurement frame should be interpreted by the
+    /// reconstruction pipeline.  A pattern captures the relationship between
+    /// raw measurement entries and electrode indices and enables the solver to
+    /// remap values for the four supported acquisition modes:
+    /// <list type="number">
+    /// <item><description>
+    /// Option 1 – active electrodes, absolute amplitudes: every electrode
+    /// contributes a single entry that maps directly onto its potential.
+    /// </description></item>
+    /// <item><description>
+    /// Option 2 – active electrodes, potential differences: the frame stores
+    /// consecutive differences V_i − V_{i+1} (including the wrap-around term).
+    /// </description></item>
+    /// <item><description>
+    /// Option 3 – non-active electrodes, potential differences: only the
+    /// differences that do not touch the driven electrodes remain and the
+    /// absent pairs are represented as NaNs during sanitisation.
+    /// </description></item>
+    /// <item><description>
+    /// Option 4 – non-active electrodes, amplitudes: only measuring electrodes
+    /// provide values and driven contacts are ignored via NaN placeholders.
+    /// </description></item>
+    /// </list>
+    /// </summary>
+    public sealed class MeasurementPattern
+    {
+        private readonly ReadOnlyCollection<MeasurementChannel> _channels;
+        private readonly Dictionary<int, MeasurementChannel> _channelByTargetIndex;
+
+        internal MeasurementPattern(MeasurementRepresentation representation,
+                                    int sanitizedLength,
+                                    IList<MeasurementChannel> channels)
+        {
+            Representation = representation;
+            SanitizedLength = sanitizedLength;
+            _channels = new ReadOnlyCollection<MeasurementChannel>(channels.ToList());
+            _channelByTargetIndex = channels.ToDictionary(c => c.TargetIndex);
+        }
+
+        /// <summary>
+        /// Describes whether the pattern represents direct amplitudes or
+        /// potential differences.
+        /// </summary>
+        public MeasurementRepresentation Representation { get; }
+
+        /// <summary>
+        /// The length of the sanitised vectors forwarded to the error metrics
+        /// (always equal to the electrode count for the associated mesh).
+        /// </summary>
+        public int SanitizedLength { get; }
+
+        /// <summary>Channels that are populated by the provided measurements.</summary>
+        public IReadOnlyList<MeasurementChannel> Channels => _channels;
+
+        internal bool TryGetChannel(int targetIndex, out MeasurementChannel channel)
+            => _channelByTargetIndex.TryGetValue(targetIndex, out channel);
+
+        /// <summary>
+        /// Converts raw measurement frames into solver-aligned vectors.  The
+        /// caller supplies either a short frame that contains only the active
+        /// channels (Options 3 &amp; 4) or a full frame (Options 1 &amp; 2).  Missing
+        /// entries are padded with NaNs so that residuals ignore them.
+        /// </summary>
+        public double[] MapMeasurement(double[] measurement)
+        {
+            double[] sanitized = Enumerable.Repeat(double.NaN, SanitizedLength).ToArray();
+            if (measurement.Length == SanitizedLength)
+            {
+                Array.Copy(measurement, sanitized, SanitizedLength);
+                return sanitized;
+            }
+
+            int cursor = 0;
+            foreach (var channel in _channels)
+            {
+                if (cursor >= measurement.Length)
+                {
+                    Workspace.AddWarningMessage(
+                        $"Measurement frame missing entries for target index {channel.TargetIndex}. Remaining slots will be ignored.");
+                    break;
+                }
+
+                sanitized[channel.TargetIndex] = measurement[cursor++];
+            }
+
+            if (measurement.Length > _channels.Count)
+            {
+                Workspace.AddWarningMessage(
+                    $"Discarding {measurement.Length - _channels.Count} surplus measurement values that do not map to the current pattern.");
+            }
+
+            return sanitized;
+        }
+
+        /// <summary>
+        /// Projects simulated electrode potentials into the representation
+        /// dictated by the pattern.  Missing channels (e.g. driven electrodes in
+        /// Option 3 and Option 4) are padded with NaN so error metrics skip them.
+        /// </summary>
+        public double[] ProjectSimulated(double[] potentials)
+        {
+            if (potentials.Length != SanitizedLength)
+                throw new ArgumentException("Simulated potential vector length does not match the pattern.", nameof(potentials));
+
+            double[] projected = Enumerable.Repeat(double.NaN, SanitizedLength).ToArray();
+
+            if (Representation == MeasurementRepresentation.Amplitude)
+            {
+                foreach (var channel in _channels)
+                {
+                    int idx = channel.FirstElectrodeIndex;
+                    if (idx < 0 || idx >= potentials.Length)
+                        continue;
+
+                    projected[channel.TargetIndex] = potentials[idx];
+                }
+            }
+            else
+            {
+                foreach (var channel in _channels)
+                {
+                    int left = channel.FirstElectrodeIndex;
+                    int right = channel.SecondElectrodeIndex;
+                    if (left < 0 || left >= potentials.Length)
+                        continue;
+                    if (right < 0 || right >= potentials.Length)
+                        continue;
+
+                    double a = potentials[left];
+                    double b = potentials[right];
+                    projected[channel.TargetIndex] = double.IsNaN(a) || double.IsNaN(b) ? double.NaN : a - b;
+                }
+            }
+
+            return projected;
+        }
+
+        /// <summary>
+        /// Extracts a raw measurement frame (without NaN padding) from a
+        /// simulated potential vector.  This mirrors what the instrumentation
+        /// would deliver for each of the four options.
+        /// </summary>
+        public double[] ExtractRawMeasurement(double[] potentials)
+        {
+            double[] frame = new double[_channels.Count];
+            for (int i = 0; i < _channels.Count; i++)
+            {
+                var channel = _channels[i];
+                if (Representation == MeasurementRepresentation.Amplitude)
+                {
+                    frame[i] = potentials[channel.FirstElectrodeIndex];
+                }
+                else
+                {
+                    double left = potentials[channel.FirstElectrodeIndex];
+                    double right = potentials[channel.SecondElectrodeIndex];
+                    frame[i] = double.IsNaN(left) || double.IsNaN(right) ? double.NaN : left - right;
+                }
+            }
+
+            return frame;
+        }
+    }
+
+    /// <summary>
+    /// A single measurement channel mapping a raw frame entry to a concrete
+    /// electrode index (amplitude mode) or electrode pair (difference mode).
+    /// </summary>
+    public sealed record MeasurementChannel(int TargetIndex, int FirstElectrodeIndex, int SecondElectrodeIndex);
+
+    public enum MeasurementRepresentation
+    {
+        Amplitude,
+        PotentialDifference
+    }
+
+    public static class MeasurementPatternBuilder
+    {
+        public static MeasurementPattern Build(IReadOnlyList<Electrode> electrodes,
+                                               ElectrodeMeasurementSetup setup,
+                                               bool usePotentialDifferences)
+        {
+            if (electrodes == null)
+                throw new ArgumentNullException(nameof(electrodes));
+
+            int electrodeCount = electrodes.Count;
+            if (electrodeCount == 0)
+                return new MeasurementPattern(MeasurementRepresentation.Amplitude, 0, []);
+
+            if (!usePotentialDifferences)
+                return BuildAmplitudePattern(electrodes, setup);
+
+            return BuildDifferencePattern(electrodes, setup);
+        }
+
+        private static MeasurementPattern BuildAmplitudePattern(IReadOnlyList<Electrode> electrodes,
+                                                                ElectrodeMeasurementSetup setup)
+        {
+            int electrodeCount = electrodes.Count;
+            var channels = new List<MeasurementChannel>(electrodeCount);
+
+            for (int i = 0; i < electrodeCount; i++)
+            {
+                bool include = setup == ElectrodeMeasurementSetup.Active || electrodes[i].IsMeasuring;
+                if (!include)
+                    continue;
+
+                channels.Add(new MeasurementChannel(i, i, i));
+            }
+
+            if (channels.Count == 0)
+                Workspace.AddWarningMessage("Amplitude measurement pattern contains no measuring electrodes.");
+
+            return new MeasurementPattern(MeasurementRepresentation.Amplitude, electrodeCount, channels);
+        }
+
+        private static MeasurementPattern BuildDifferencePattern(IReadOnlyList<Electrode> electrodes,
+                                                                 ElectrodeMeasurementSetup setup)
+        {
+            int electrodeCount = electrodes.Count;
+            var channels = new List<MeasurementChannel>(electrodeCount);
+            var skipped = new HashSet<int>();
+
+            if (setup == ElectrodeMeasurementSetup.NonActive)
+            {
+                for (int i = 0; i < electrodeCount; i++)
+                {
+                    if (electrodes[i].IsMeasuring)
+                        continue;
+
+                    skipped.Add(i);
+                    skipped.Add((i - 1 + electrodeCount) % electrodeCount);
+                }
+            }
+
+            for (int i = 0; i < electrodeCount; i++)
+            {
+                if (skipped.Contains(i))
+                    continue;
+
+                int next = (i + 1) % electrodeCount;
+                channels.Add(new MeasurementChannel(i, i, next));
+            }
+
+            if (channels.Count == 0)
+                Workspace.AddWarningMessage("Potential-difference measurement pattern contains no valid channels.");
+
+            return new MeasurementPattern(MeasurementRepresentation.PotentialDifference, electrodeCount, channels);
+        }
+    }
+
+    /// <summary>
+    /// Bundles the sanitised measurement vectors and the pattern that produced
+    /// them.  The projection handles the adjoint back-projection so that error
+    /// metrics remain agnostic of the acquisition mode.
+    /// </summary>
+    public sealed class MeasurementProjection
+    {
+        private readonly MeasurementPattern _pattern;
+
+        internal MeasurementProjection(MeasurementPattern pattern, double[] measured, double[] simulated)
+        {
+            _pattern = pattern;
+            Measured = measured;
+            Simulated = simulated;
+        }
+
+        public MeasurementPattern Pattern => _pattern;
+        public double[] Measured { get; }
+        public double[] Simulated { get; }
+
+        /// <summary>
+        /// Expands an adjoint vector defined in measurement space back onto the
+        /// per-electrode representation expected by the solvers.
+        /// </summary>
+        public double[] ExpandAdjoint(double[] adjoint)
+        {
+            double[] expanded = new double[_pattern.SanitizedLength];
+
+            if (_pattern.Representation == MeasurementRepresentation.Amplitude)
+            {
+                foreach (var channel in _pattern.Channels)
+                {
+                    if (channel.TargetIndex < 0 || channel.TargetIndex >= adjoint.Length)
+                        continue;
+
+                    expanded[channel.FirstElectrodeIndex] = adjoint[channel.TargetIndex];
+                }
+            }
+            else
+            {
+                foreach (var channel in _pattern.Channels)
+                {
+                    if (channel.TargetIndex < 0 || channel.TargetIndex >= adjoint.Length)
+                        continue;
+
+                    double value = adjoint[channel.TargetIndex];
+                    if (!double.IsFinite(value))
+                        continue;
+
+                    expanded[channel.FirstElectrodeIndex] += value;
+                    expanded[channel.SecondElectrodeIndex] -= value;
+                }
+            }
+
+            return expanded;
+        }
+    }
+
+    /// <summary>
+    /// Convenience factory that produces measurement projections for measured
+    /// and simulated frames.  The factory ensures both vectors share the same
+    /// sanitised layout before the error metrics are invoked.
+    /// </summary>
+    public static class MeasurementProjector
+    {
+        public static MeasurementProjection Create(IReadOnlyList<Electrode> electrodes,
+                                                   ElectrodeMeasurementSetup setup,
+                                                   bool usePotentialDifferences,
+                                                   double[] measurement,
+                                                   double[] simulated)
+        {
+            var pattern = MeasurementPatternBuilder.Build(electrodes, setup, usePotentialDifferences);
+            var measured = pattern.MapMeasurement(measurement);
+            var projectedSimulated = pattern.ProjectSimulated(simulated);
+            return new MeasurementProjection(pattern, measured, projectedSimulated);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable measurement pattern and projection layer so the solver can normalise amplitude and potential-difference frames across the four supported options
- refactor FEM/LBM persistence to rely on the new projector, simplifying adjoint expansion and removing bespoke difference helpers
- update simulated measurement generation to emit frames that match the selected acquisition mode

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_69001bf129a0833388ad194af7b9453a