### PR TITLE
Refine measurement pattern handling across services

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -394,17 +394,24 @@ namespace BusinessLayer
                 : _differentialEquationSolver.Solve(mesh, bc, null);
             phi = PotentialClipper.Clip(phi);
 
-            // Extract simulated potentials and project both measured and simulated to the active representation
+            // Extract simulated potentials and project both measured and simulated to the representation
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
-            var projectedMeasurement = PrepareMeasurementData(currentMeasurement, electrodes.Count);
-            var projectedSimulated = PrepareSimulatedData(simulatedPotentials);
+            var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+            var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+            // Normalise Option 1–4 frames (see MeasurementPattern) prior to evaluating the misfit.
+            var projection = MeasurementProjector.Create(electrodeProjectionList,
+                                                         measurementSetup,
+                                                         _usePotentialDifferences,
+                                                         currentMeasurement,
+                                                         simulatedPotentials);
+            Workspace.SetMeasurementPattern(projection.Pattern);
 
-            double currentError = _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
+            double currentError = _errorMetric.Evaluate(mesh, projection.Measured, projection.Simulated);
             _ = currentError; // error value is not stored in this frame, but could be logged if needed
 
             // Error metric based gradient expression
-            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
-            var expandedAdjoint = BuildAdjointSourceVector(adjSrc, electrodes.Count);
+            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projection.Measured, projection.Simulated);
+            var expandedAdjoint = projection.ExpandAdjoint(adjSrc);
             Complex[] adjointSource = ToComplex(expandedAdjoint);
 
             // Adjoint solve using the same boundary condition shape but with source applied
@@ -436,235 +443,6 @@ namespace BusinessLayer
 
             // LBM path in this routine does not compute explicit regularization (left empty)
             return new ReconstructionFrame(dataGrad, phi, mu, new ConductivityDistribution([]));
-        }
-
-        /// <summary>
-        /// Expands a measurement vector to match the FEM electrode list ordering expected by the solver.
-        /// Pads missing entries with NaNs and trims excess if needed. Non-measuring electrodes are ignored.
-        /// </summary>
-        private static int CountMeasuringElectrodes(List<FEMElectrode> electrodes) => electrodes.Count(e => e.IsMeasuring);
-
-        private static List<double> ExtractMeasuringValues(double[] values, List<FEMElectrode> electrodes)
-        {
-            if (values == null || electrodes == null)
-                return new List<double>();
-
-            int limit = Math.Min(values.Length, electrodes.Count);
-            var measuring = new List<double>(limit);
-            for (int i = 0; i < limit; i++)
-            {
-                double sample = values[i];
-                if (double.IsNaN(sample))
-                    continue;
-
-                measuring.Add(sample);
-            }
-
-            for (int i = electrodes.Count; i < values.Length; i++)
-            {
-                double sample = values[i];
-                if (!double.IsNaN(sample))
-                    measuring.Add(sample);
-            }
-
-            return measuring;
-        }
-
-        private bool MeasurementRepresentsDifferences(double[] measurement, List<FEMElectrode> electrodes)
-        {
-            if (!_usePotentialDifferences || measurement == null)
-                return false;
-
-            int measuringElectrodes = CountMeasuringElectrodes(electrodes);
-            int electrodeCount = electrodes.Count;
-
-            int measuringDifference = Math.Max(0, measuringElectrodes - 1);
-            int activeDifference = Math.Max(0, electrodeCount - 1);
-
-            return measurement.Length == measuringDifference || measurement.Length == activeDifference;
-        }
-
-        private static double[] AlignMeasurementVector(double[] measurement, List<FEMElectrode> electrodes, bool measurementIsDifference)
-        {
-            if (measurementIsDifference)
-                return (double[])measurement.Clone();
-
-            // Rebuild a length-M vector compatible with the FEM solver.  Missing entries
-            // from non-active datasets are padded with NaNs so that the misfit ignores
-            // excitation electrodes while preserving index alignment.
-            int electrodeCount = electrodes.Count;
-            if (electrodeCount == 0)
-                return measurement;
-
-            if (measurement.Length == electrodeCount)
-                return measurement;
-
-            if (measurement.Length > electrodeCount)
-                return measurement.Take(electrodeCount).ToArray();
-
-            double[] expanded = Enumerable.Repeat(double.NaN, electrodeCount).ToArray();
-            int measurementIndex = 0;
-            int measuringElectrodes = electrodes.Count(e => e.IsMeasuring);
-
-            for (int i = 0; i < electrodeCount && measurementIndex < measurement.Length; i++)
-            {
-                if (!electrodes[i].IsMeasuring)
-                    continue;
-
-                expanded[i] = measurement[measurementIndex++];
-            }
-
-            if (measurementIndex < measurement.Length)
-                Workspace.AddWarningMessage($"Discarding {measurement.Length - measurementIndex} excess measurement entries that cannot be mapped to electrodes.");
-            else if (measurement.Length < measuringElectrodes)
-            {
-                bool expectedMissing = Workspace.GetElectrodeMeasurementSetup() == ElectrodeMeasurementSetup.NonActive &&
-                                        measurement.Length == Math.Max(0, measuringElectrodes - 1);
-
-                if (!expectedMissing)
-                    Workspace.AddWarningMessage($"Measurement frame supplies only {measurementIndex} of {measuringElectrodes} measuring electrodes. Missing values will be ignored.");
-            }
-
-            return expanded;
-        }
-
-        /// <summary>
-        /// Projects measured data into the configured representation.
-        /// When potential differences are enabled, measurements coming from the measuring-electrode subset are
-        /// transformed into sequential differences; otherwise the values are returned unchanged.
-        /// </summary>
-        private double[] PrepareMeasurementData(double[] measurement, List<FEMElectrode> electrodes, bool measurementIsDifference)
-        {
-            if (!_usePotentialDifferences)
-                return measurement;
-
-            if (measurementIsDifference)
-                return (double[])measurement.Clone();
-
-            var measuringValues = ExtractMeasuringValues(measurement, electrodes);
-            return ComputeSequentialDifferences(measuringValues);
-        }
-
-        private double[] PrepareMeasurementData(double[] measurement, int electrodeCount)
-        {
-            if (!_usePotentialDifferences)
-                return measurement;
-
-            int differenceLength = Math.Max(0, electrodeCount - 1);
-            if (measurement.Length == differenceLength)
-                return (double[])measurement.Clone();
-
-            return ComputeSequentialDifferences(measurement);
-        }
-
-        /// <summary>
-        /// Projects simulated data into the configured representation; symmetric to <see cref="PrepareMeasurementData"/>.
-        /// </summary>
-        private double[] PrepareSimulatedData(double[] simulated, List<FEMElectrode> electrodes)
-        {
-            if (!_usePotentialDifferences)
-                return simulated;
-
-            var measuringValues = ExtractMeasuringValues(simulated, electrodes);
-            return ComputeSequentialDifferences(measuringValues);
-        }
-
-        private double[] PrepareSimulatedData(double[] simulated)
-        {
-            if (!_usePotentialDifferences)
-                return simulated;
-
-            return ComputeSequentialDifferences(simulated);
-        }
-
-        /// <summary>
-        /// Computes first-order forward differences v[i+1]-v[i] while preserving NaNs
-        /// (any pair including a NaN yields NaN at the difference index).
-        /// </summary>
-        private static double[] ComputeSequentialDifferences(IReadOnlyList<double> values)
-        {
-            if (values.Count <= 1)
-                return System.Array.Empty<double>();
-
-            double[] differences = new double[values.Count - 1];
-            for (int i = 0; i < differences.Length; i++)
-            {
-                double a = values[i];
-                double b = values[i + 1];
-                differences[i] = double.IsNaN(a) || double.IsNaN(b) ? double.NaN : b - a;
-            }
-
-            return differences;
-        }
-
-        /// <summary>
-        /// Ensures the adjoint source vector matches the number of electrodes.
-        /// Expands from difference-space to full electrodes if needed and resizes with zero-padding/truncation.
-        /// </summary>
-        private double[] BuildAdjointSourceVector(double[] adjoint, int electrodeCount)
-        {
-            if (electrodeCount <= 0)
-                return Array.Empty<double>();
-
-            double[] values = adjoint;
-
-            if (_usePotentialDifferences)
-                values = ExpandSequentialDifferenceAdjoint(values, electrodeCount);
-
-            if (values.Length == electrodeCount)
-                return values;
-
-            double[] resized = new double[electrodeCount];
-            int copyLength = Math.Min(values.Length, electrodeCount);
-            Array.Copy(values, resized, copyLength);
-
-            if (values.Length > electrodeCount)
-            {
-                Workspace.AddWarningMessage($"Discarding {values.Length - electrodeCount} adjoint source entries that cannot be mapped to electrodes.");
-            }
-            else if (values.Length < electrodeCount)
-            {
-                for (int i = copyLength; i < electrodeCount; i++)
-                    resized[i] = 0.0;
-            }
-
-            return resized;
-        }
-
-        /// <summary>
-        /// Inverse of the difference operator used for potential differences representation.
-        /// Maps an (N-1)-length difference adjoint vector back to an N-length per-electrode vector.
-        /// </summary>
-        private static double[] ExpandSequentialDifferenceAdjoint(double[] adjoint, int electrodeCount)
-        {
-            if (electrodeCount <= 0)
-                return Array.Empty<double>();
-
-            if (adjoint.Length == electrodeCount)
-                return adjoint;
-
-            if (adjoint.Length == 0)
-                return new double[electrodeCount];
-
-            if (adjoint.Length != electrodeCount - 1)
-                return adjoint;
-
-            double[] expanded = new double[electrodeCount];
-
-            if (electrodeCount == 1)
-                return expanded;
-
-            // The adjoint for sequential differences is equivalent to the negative discrete divergence
-            expanded[0] = -adjoint[0];
-            for (int i = 1; i < electrodeCount - 1; i++)
-            {
-                double left = adjoint[i - 1];
-                double right = adjoint[i];
-                expanded[i] = left - right;
-            }
-            expanded[electrodeCount - 1] = adjoint[adjoint.Length - 1];
-
-            return expanded;
         }
 
         /// <summary>
@@ -720,19 +498,23 @@ namespace BusinessLayer
                 elements = mesh.GetElements().Cast<FEMElement>().ToList();
             }
 
-            // Ensure the data vector mirrors the electrode ordering that the solver expects.
-            bool measurementIsDifference = MeasurementRepresentsDifferences(currentMeasurement, electrodes);
-            var measurementVector = AlignMeasurementVector(currentMeasurement, electrodes, measurementIsDifference);
-            var projectedMeasurement = PrepareMeasurementData(measurementVector, electrodes, measurementIsDifference);
-
             // Forward solve: φ
             PotentialDistribution phi = PotentialClipper.Clip(solver.Solve(mesh, bc, null));
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
-            var projectedSimulated = PrepareSimulatedData(simulatedPotentials, electrodes);
+
+            var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+            var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+            // Normalise Option 1–4 frames (see MeasurementPattern) prior to evaluating the misfit.
+            var projection = MeasurementProjector.Create(electrodeProjectionList,
+                                                         measurementSetup,
+                                                         _usePotentialDifferences,
+                                                         currentMeasurement,
+                                                         simulatedPotentials);
+            Workspace.SetMeasurementPattern(projection.Pattern);
 
             // Build adjoint source from error metric and project back to electrode-space
-            var adjSrc = errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
-            var expandedAdjoint = BuildAdjointSourceVector(adjSrc, electrodes.Count);
+            var adjSrc = errorMetric.EvaluateAdjointSource(mesh, projection.Measured, projection.Simulated);
+            var expandedAdjoint = projection.ExpandAdjoint(adjSrc);
             Complex[] adjointSource = ToComplex(expandedAdjoint);
 
             // Adjoint solve: μ
@@ -1229,14 +1011,18 @@ namespace BusinessLayer
                 electrodes[(exc + 1) % electrodeCount].Current = -excitationAmplitude;
 
                 _ = _differentialEquationSolver.Solve(mesh, bc, null);
-                double[] dSimNew = mesh.GetElectrodePotentials();
+                double[] dSimNew = PotentialClipper.Clip(mesh.GetElectrodePotentials());
                 double[] dObs = simulatedMeasurements[exc];
-                bool measurementIsDifference = MeasurementRepresentsDifferences(dObs, electrodes);
-                // Compare only the electrodes that are physically measured in the current configuration.
-                var alignedObs = AlignMeasurementVector(dObs, electrodes, measurementIsDifference);
-                var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodes, measurementIsDifference);
-                var projectedSimulated = PrepareSimulatedData(dSimNew, electrodes);
-                Jtotal += _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
+                var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+                var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+                // Normalise Option 1–4 frames (see MeasurementPattern) prior to evaluating the misfit.
+                var projection = MeasurementProjector.Create(electrodeProjectionList,
+                                                             measurementSetup,
+                                                             _usePotentialDifferences,
+                                                             dObs,
+                                                             dSimNew);
+                Workspace.SetMeasurementPattern(projection.Pattern);
+                Jtotal += _errorMetric.Evaluate(mesh, projection.Measured, projection.Simulated);
             }
 
             return Jtotal;
@@ -1268,15 +1054,21 @@ namespace BusinessLayer
 
             // Extract simulated potentials
             double[] simulatedPotentials = PotentialClipper.Clip(mesh.GetElectrodePotentials());
-            var projectedMeasurement = PrepareMeasurementData(currentMeasurement, electrodes.Count);
-            var projectedSimulated = PrepareSimulatedData(simulatedPotentials);
+            var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+            var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+            var projection = MeasurementProjector.Create(electrodeProjectionList,
+                                                         measurementSetup,
+                                                         _usePotentialDifferences,
+                                                         currentMeasurement,
+                                                         simulatedPotentials);
+            Workspace.SetMeasurementPattern(projection.Pattern);
 
-            double currentError = _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
+            double currentError = _errorMetric.Evaluate(mesh, projection.Measured, projection.Simulated);
             _ = currentError;
 
             // Error metric based gradient expression
-            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projectedMeasurement, projectedSimulated);
-            var expandedAdjoint = BuildAdjointSourceVector(adjSrc, electrodes.Count);
+            var adjSrc = _errorMetric.EvaluateAdjointSource(mesh, projection.Measured, projection.Simulated);
+            var expandedAdjoint = projection.ExpandAdjoint(adjSrc);
             Complex[] adjointSource = ToComplex(expandedAdjoint);
 
             var adjointBoundaryCondition = new LBMBoundaryCondition(electrodes);
@@ -1397,7 +1189,9 @@ namespace BusinessLayer
             var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
             int cycleLength = Math.Max(1, strategy.GetCycleLength(electrodeCount));
 
-            double[,] measurementFrames = new double[cycleLength, electrodeCount];
+            var frames = new List<double[]>(cycleLength);
+
+            MeasurementPattern? referencePattern = null;
 
             for (int i = 0; i < cycleLength; i++)
             {
@@ -1425,13 +1219,18 @@ namespace BusinessLayer
 
                 _ = _differentialEquationSolver.Solve(deepCopy, boundaryCondition, null);
 
-                double[] electrodePotentials = deepCopy.GetElectrodePotentials();
-
-                for (int j = 0; j < electrodeCount; j++)
-                    measurementFrames[i, j] = electrodePotentials[j];
+                double[] electrodePotentials = PotentialClipper.Clip(deepCopy.GetElectrodePotentials());
+                var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+                var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+                var pattern = MeasurementPatternBuilder.Build(electrodeProjectionList,
+                                                              measurementSetup,
+                                                              _usePotentialDifferences);
+                referencePattern ??= pattern;
+                frames.Add(pattern.ExtractRawMeasurement(electrodePotentials));
             }
 
-            return new EITMeasurement(measurementFrames);
+            Workspace.SetMeasurementPattern(referencePattern);
+            return new EITMeasurement(frames, referencePattern);
         }
 
         #endregion
@@ -1625,12 +1424,16 @@ namespace BusinessLayer
                     var phiNew = PotentialClipper.Clip(_differentialEquationSolver.Solve(mesh, bc, null));
                     double[] dSimNew = PotentialClipper.Clip(mesh.GetElectrodePotentials());
                     double[] dObs = simulatedMeasurements[exc];
-                    bool measurementIsDifference = MeasurementRepresentsDifferences(dObs, electrodes);
-                    // Restrict the misfit to the subset of electrodes that produced readings.
-                    var alignedObs = AlignMeasurementVector(dObs, electrodes, measurementIsDifference);
-                    var projectedMeasurement = PrepareMeasurementData(alignedObs, electrodes, measurementIsDifference);
-                    var projectedSimulated = PrepareSimulatedData(dSimNew, electrodes);
-                    Jtotal += _errorMetric.Evaluate(mesh, projectedMeasurement, projectedSimulated);
+                    var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+                    var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+                    // Normalise Option 1–4 frames (see MeasurementPattern) prior to evaluating the misfit.
+                    var projection = MeasurementProjector.Create(electrodeProjectionList,
+                                                                 measurementSetup,
+                                                                 _usePotentialDifferences,
+                                                                 dObs,
+                                                                 dSimNew);
+                    Workspace.SetMeasurementPattern(projection.Pattern);
+                    Jtotal += _errorMetric.Evaluate(mesh, projection.Measured, projection.Simulated);
                 }
                 Debug.WriteLine($"Iteration {iter}: total misfit = {Jtotal}");
 
@@ -1673,6 +1476,8 @@ namespace BusinessLayer
             var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
             int cycleLength = Math.Max(1, strategy.GetCycleLength(electrodeCount));
 
+            MeasurementPattern? referencePattern = null;
+
             for (int i = 0; i < cycleLength; i++)
             {
                 // Clear electrode status
@@ -1696,9 +1501,17 @@ namespace BusinessLayer
 
                 FEMMesh result = SolveFemForward(deepCopy);
 
-                measurements.Add(PotentialClipper.Clip(result.GetElectrodePotentials()));
+                double[] potentials = PotentialClipper.Clip(result.GetElectrodePotentials());
+                var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+                var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+                var pattern = MeasurementPatternBuilder.Build(electrodeProjectionList,
+                                                              measurementSetup,
+                                                              _usePotentialDifferences);
+                referencePattern ??= pattern;
+                measurements.Add(pattern.ExtractRawMeasurement(potentials));
             }
 
+            Workspace.SetMeasurementPattern(referencePattern);
             return measurements;
         }
 

--- a/DataAccessLayer/IReconstructionExportRepository.cs
+++ b/DataAccessLayer/IReconstructionExportRepository.cs
@@ -2,6 +2,7 @@ using Utility.Exports;
 using Utility.Rendering;
 using Utility.Classes;
 using Utility.Classes.Discretizer;
+using Utility.Classes.Measurement;
 
 namespace DataAccessLayer;
 
@@ -16,4 +17,5 @@ public sealed record ReconstructionExportRequest(IDiscretization Discretization,
                                                   ReconstructionFrame RenderFrame,
                                                   PotentialDisplayMode DisplayMode,
                                                   string TargetDirectory,
-                                                  ConductivityDistribution InitialDistribution);
+                                                  ConductivityDistribution InitialDistribution,
+                                                  MeasurementPattern? MeasurementPattern);

--- a/DataAccessLayer/ReconstructionExportRepository.cs
+++ b/DataAccessLayer/ReconstructionExportRepository.cs
@@ -49,6 +49,7 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
                 initialMetadata.Add(("MAE", FormatDouble(metrics.Mae)));
                 initialMetadata.Add(("RMSE", FormatDouble(metrics.Rmse)));
             }
+            initialMetadata.Add(("Measurement Mode", DescribeMeasurementPattern(request.MeasurementPattern)));
 
             ReconstructionVideoRenderer.SaveDistributionSnapshot(request.TargetDirectory,
                                      "initial_distribution.png",
@@ -71,6 +72,7 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
                 finalMetadata.Add(("SSIM", FormatDouble(metrics.Ssim)));
             }
             finalMetadata.Add(("Correlation", FormatDouble(latestSnapshot.Correlation)));
+            finalMetadata.Add(("Measurement Mode", DescribeMeasurementPattern(request.MeasurementPattern)));
 
             ReconstructionVideoRenderer.SaveDistributionSnapshot(request.TargetDirectory,
                                      "reconstructed_distribution_latest.png",
@@ -352,6 +354,21 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
             ("Maximum σ", FormatNullableDouble(stats.Max)),
             ("Mean σ", FormatNullableDouble(stats.Mean))
         };
+    }
+
+    private static string DescribeMeasurementPattern(MeasurementPattern? pattern)
+    {
+        if (pattern == null)
+            return "Unknown";
+
+        string representation = pattern.Representation == MeasurementRepresentation.PotentialDifference
+            ? "Potential difference"
+            : "Amplitude";
+        string setup = pattern.MeasurementSetup == ElectrodeMeasurementSetup.NonActive
+            ? "non-active electrodes"
+            : "active electrodes";
+
+        return $"{representation} - {setup}";
     }
 
     private static string FormatCsvValue(double value)

--- a/ServiceLayer/ReconstructionExportService.cs
+++ b/ServiceLayer/ReconstructionExportService.cs
@@ -46,7 +46,8 @@ public sealed class ReconstructionExportService : IReconstructionExportService
                                                       renderFrame,
                                                       displayMode,
                                                       directory,
-                                                      initialDistribution);
+                                                      initialDistribution,
+                                                      Workspace.GetMeasurementPattern());
 
         return Task.Run(() => _repository.ExportReconstructionData(request), cancellationToken);
     }

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -1,5 +1,6 @@
 ﻿using BusinessLayer;
 using System.Diagnostics;
+using System.Linq;
 using Utility.Classes;
 using Utility.Classes.Measurement;
 using Utility.Classes.Discretizer;
@@ -61,6 +62,7 @@ namespace ServiceLayer
         // the UI can communicate the acquisition mode to the user.
         private ElectrodeMeasurementSetup _measurementSetup = ElectrodeMeasurementSetup.Active;
         private bool _usePotentialDifferences;
+        private MeasurementPattern? _measurementPattern;
 
         /// <summary>
         /// Raised when a full reconstruction result is available (i.e., at the end of a cycle or batch).
@@ -188,7 +190,8 @@ namespace ServiceLayer
                 var noisyMeasurement = new EITMeasurement(noisyFrames,
                     measurement.CurrentAmplitude ?? excitaionAmplitude)
                 {
-                    FrameSize = measurement.FrameSize
+                    FrameSize = measurement.FrameSize,
+                    Pattern = measurement.Pattern
                 };
 
                 return noisyMeasurement;
@@ -248,6 +251,8 @@ namespace ServiceLayer
                 // Default to active measurement setup (frames include driven electrodes), unless we learn otherwise later.
                 _measurementSetup = ElectrodeMeasurementSetup.Active;
                 Workspace.SetElectrodeMeasurementSetup(ElectrodeMeasurementSetup.Active);
+                _measurementPattern = null;
+                Workspace.SetMeasurementPattern(null);
 
                 // Configure drive pattern and potential parallelization flag (consumed in persistence layer).
                 _drivePattern = parameters.DrivePattern;
@@ -373,7 +378,7 @@ namespace ServiceLayer
                              ?? throw new ArgumentException("Boundary condition must be FEMBoundaryCondition", nameof(boundaryCondition));
 
                 // Ensure the measurement vector respects the per-electrode measuring/drive state encoded in the boundary condition.
-                var preparedMeasurement = PrepareMeasurementFrame(measurement, femBc.GetElectrodes());
+                var preparedMeasurement = PrepareMeasurementFrame(measurement, femBc.GetElectrodes().Cast<Electrode>().ToList());
 
                 ReconstructionFrame frame = _reconstructionPersistence.InverseSolveStepFem(mesh, femBc, preparedMeasurement, stepSize);
 
@@ -519,6 +524,8 @@ namespace ServiceLayer
             _realMeasurementAmplitude = null;
             _measurementSetup = ElectrodeMeasurementSetup.Active;
             Workspace.SetElectrodeMeasurementSetup(ElectrodeMeasurementSetup.Active);
+            _measurementPattern = null;
+            Workspace.SetMeasurementPattern(null);
         }
 
         /// <summary>
@@ -548,8 +555,7 @@ namespace ServiceLayer
                     _simulatedMeasurements = measurement.Frames.Select(frame => (double[])frame.Clone()).ToList();
                     _realMeasurementAmplitude = measurement.CurrentAmplitude;
 
-                    // Mirror inferred active/non-active mode to the workspace/UI.
-                    UpdateMeasurementSetupFromFrames(electrodeCount, _simulatedMeasurements);
+                    AdoptMeasurementMetadata(measurement.Pattern, _simulatedMeasurements, electrodeCount);
                     return;
                 }
 
@@ -568,15 +574,14 @@ namespace ServiceLayer
                 _simulatedMeasurements = CloneMeasurementsWithNoise(frames, _measurementNoiseType, _measurementNoiseAmplitude);
                 _realMeasurementAmplitude = null;
 
-                // Simulations currently emit active frames, but we still record the mode to keep the UI consistent.
-                UpdateMeasurementSetupFromFrames(electrodeCount, _simulatedMeasurements);
+                AdoptMeasurementMetadata(Workspace.GetMeasurementPattern(), _simulatedMeasurements, electrodeCount);
             }
             else if (_discretization is LBMGrid && original is LBMGrid lbmOrig)
             {
                 var measurement = _reconstructionPersistence.SimulateLbmMeasurements(lbmOrig, _excitationAmplitude, _drivePattern);
                 _simulatedMeasurements = CloneMeasurementsWithNoise(measurement.Frames, _measurementNoiseType, _measurementNoiseAmplitude);
                 _realMeasurementAmplitude = null;
-                UpdateMeasurementSetupFromFrames(electrodeCount, _simulatedMeasurements);
+                AdoptMeasurementMetadata(measurement.Pattern, _simulatedMeasurements, electrodeCount);
             }
             else
             {
@@ -633,12 +638,10 @@ namespace ServiceLayer
         /// Inspects frame dimensions to infer whether the samples include driven electrodes (active) or
         /// exclude them (non-active). This is mirrored to the workspace for UI and solver decisions.
         /// </summary>
-        private void UpdateMeasurementSetupFromFrames(int electrodeCount, IReadOnlyList<double[]> frames)
+        private void UpdateMeasurementOptionsFromFrames(int electrodeCount, IReadOnlyList<double[]> frames)
         {
-            // Measurements originating from an active setup deliver M readings per frame
-            // (yielding M×M values over a full cycle).  Non-active instrumentation omits the
-            // two driven contacts per frame, resulting in M×(M-3) total samples.  We derive the
-            // acquisition mode from these counts so both the solver and the UI can react accordingly.
+            // Guard clauses: fall back to the default "active" interpretation when
+            // insufficient context is available.
             if (electrodeCount <= 0 || frames == null || frames.Count == 0)
             {
                 _measurementSetup = ElectrodeMeasurementSetup.Active;
@@ -650,20 +653,11 @@ namespace ServiceLayer
             long totalMeasurements = (long)frameLength * frames.Count;
             long expectedActiveTotal = (long)electrodeCount * electrodeCount;
             long expectedNonActiveTotal = (long)electrodeCount * Math.Max(0, electrodeCount - 3);
-            int activeDifferenceLength = Math.Max(0, electrodeCount - 1);
+            int nonActiveAmplitudeLength = Math.Max(0, electrodeCount - 2);
             int nonActiveDifferenceLength = Math.Max(0, electrodeCount - 3);
 
             bool looksActive = frameLength == electrodeCount || totalMeasurements == expectedActiveTotal;
-            bool looksNonActive = !looksActive && (frameLength == Math.Max(0, electrodeCount - 2) || totalMeasurements == expectedNonActiveTotal);
-
-            if (_usePotentialDifferences)
-            {
-                if (frameLength == activeDifferenceLength)
-                    looksActive = true;
-
-                if (!looksActive && frameLength == nonActiveDifferenceLength)
-                    looksNonActive = true;
-            }
+            bool looksNonActive = !looksActive && (frameLength == nonActiveAmplitudeLength || totalMeasurements == expectedNonActiveTotal);
 
             _measurementSetup = looksActive ? ElectrodeMeasurementSetup.Active : ElectrodeMeasurementSetup.NonActive;
 
@@ -673,6 +667,113 @@ namespace ServiceLayer
             }
 
             Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
+
+            bool inferredDifferences = InferPotentialDifferenceMode(electrodeCount, frames);
+            ApplyUsePotentialDifferenceSetting(inferredDifferences,
+                inferredDifferences
+                    ? "Detected potential-difference measurements from frame statistics."
+                    : "Detected amplitude measurements from frame statistics.");
+        }
+
+        private bool InferPotentialDifferenceMode(int electrodeCount, IReadOnlyList<double[]> frames)
+        {
+            if (frames == null || frames.Count == 0)
+                return _usePotentialDifferences;
+
+            int frameLength = frames[0].Length;
+            int nonActiveAmplitudeLength = Math.Max(0, electrodeCount - 2);
+            int nonActiveDifferenceLength = Math.Max(0, electrodeCount - 3);
+
+            if (_measurementSetup == ElectrodeMeasurementSetup.NonActive)
+            {
+                if (frameLength == nonActiveDifferenceLength)
+                    return true;
+                if (frameLength == nonActiveAmplitudeLength)
+                    return false;
+            }
+            else if (frameLength == nonActiveDifferenceLength)
+            {
+                // Degenerate case where frames mimic the non-active difference size even though
+                // the instrumentation was configured as "active". Treat as difference data.
+                return true;
+            }
+
+            if (frameLength != electrodeCount)
+                return _usePotentialDifferences;
+
+            int framesToInspect = Math.Min(frames.Count, 5);
+            int zeroLikeFrames = 0;
+            int finiteFrames = 0;
+
+            for (int i = 0; i < framesToInspect; i++)
+            {
+                var frame = frames[i];
+                double sum = 0.0;
+                double maxAbs = 0.0;
+                int finiteCount = 0;
+
+                foreach (var sample in frame)
+                {
+                    if (!double.IsFinite(sample))
+                        continue;
+
+                    sum += sample;
+                    finiteCount++;
+                    double abs = Math.Abs(sample);
+                    if (abs > maxAbs)
+                        maxAbs = abs;
+                }
+
+                if (finiteCount == 0)
+                    continue;
+
+                finiteFrames++;
+                double tolerance = Math.Max(1e-6, maxAbs * 1e-3);
+                if (Math.Abs(sum) <= tolerance)
+                    zeroLikeFrames++;
+            }
+
+            return finiteFrames > 0 && zeroLikeFrames == finiteFrames;
+        }
+
+        private void ApplyUsePotentialDifferenceSetting(bool enabled, string reason)
+        {
+            if (_usePotentialDifferences == enabled)
+                return;
+
+            _usePotentialDifferences = enabled;
+
+            var parameters = Workspace.GetReconstructionParameters();
+            if (parameters.UsePotentialDifferences != enabled)
+                parameters.UsePotentialDifferences = enabled;
+
+            Workspace.AddLogMessage("Reconstruction Service", reason);
+            _measurementPattern = null;
+            Workspace.SetMeasurementPattern(null);
+        }
+
+        private void AdoptMeasurementMetadata(MeasurementPattern? pattern, IReadOnlyList<double[]> frames, int electrodeCount)
+        {
+            if (pattern != null)
+            {
+                if (_measurementSetup != pattern.MeasurementSetup)
+                {
+                    _measurementSetup = pattern.MeasurementSetup;
+                    Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
+                }
+
+                bool useDifferences = pattern.Representation == MeasurementRepresentation.PotentialDifference;
+                ApplyUsePotentialDifferenceSetting(useDifferences,
+                    useDifferences
+                        ? "Adopting potential-difference mode from provided measurement pattern."
+                        : "Adopting amplitude mode from provided measurement pattern.");
+
+                _measurementPattern = pattern;
+                Workspace.SetMeasurementPattern(pattern);
+                return;
+            }
+
+            UpdateMeasurementOptionsFromFrames(electrodeCount, frames);
         }
 
         /// <summary>
@@ -680,57 +781,30 @@ namespace ServiceLayer
         /// driven electrodes (non-active mode), NaN placeholders are injected for those positions so that solver
         /// residuals can ignore them. Excess values are truncated with a warning.
         /// </summary>
-        private double[] PrepareMeasurementFrame(double[] measurement, List<FEMElectrode> electrodes)
+        private double[] PrepareMeasurementFrame(double[] measurement, IReadOnlyList<Electrode> electrodes)
         {
-            // Map the supplied measurement vector to the solver ordering.
-            // When non-active data is provided only the measuring electrodes
-            // are present, so the remaining entries are padded with NaN to
-            // ensure the residual ignores the driven electrodes.
-            int electrodeCount = electrodes.Count;
-            if (electrodeCount == 0)
+            if (measurement == null)
+                throw new ArgumentNullException(nameof(measurement));
+            if (electrodes == null)
+                throw new ArgumentNullException(nameof(electrodes));
+
+            if (electrodes.Count == 0)
                 return measurement;
 
-            int measuringElectrodeCount = electrodes.Count(e => e.IsMeasuring);
-            int expectedDifferenceLength = Math.Max(0, measuringElectrodeCount - 1);
-            int activeDifferenceLength = Math.Max(0, electrodeCount - 1);
+            // Build the measurement pattern for the current electrode roles so
+            // that the sanitiser knows which entries to retain (Options 1 & 4)
+            // or which potential differences to form (Options 2 & 3).
+            var electrodeProjection = electrodes.ToList();
+            var pattern = MeasurementPatternBuilder.Build(electrodeProjection,
+                                                          Workspace.GetElectrodeMeasurementSetup(),
+                                                          _usePotentialDifferences);
+            _measurementPattern = pattern;
+            Workspace.SetMeasurementPattern(pattern);
 
-            if (_usePotentialDifferences && (measurement.Length == expectedDifferenceLength || measurement.Length == activeDifferenceLength))
-                return (double[])measurement.Clone();
-
-            if (measurement.Length == electrodeCount)
-                return measurement; // Already in full active form
-
-            if (measurement.Length > electrodeCount)
-            {
-                Workspace.AddWarningMessage($"Measurement frame has {measurement.Length} values but only {electrodeCount} electrodes. Truncating to match electrode count.");
-                return measurement.Take(electrodeCount).ToArray();
-            }
-
-            // Allocate full frame and fill measuring positions sequentially from the provided data.
-            double[] prepared = Enumerable.Repeat(double.NaN, electrodeCount).ToArray();
-            int measurementIndex = 0;
-
-            for (int i = 0; i < electrodeCount; i++)
-            {
-                if (!electrodes[i].IsMeasuring)
-                    continue;
-
-                if (measurementIndex < measurement.Length)
-                    prepared[i] = measurement[measurementIndex++];
-            }
-
-            if (measurementIndex < measurement.Length)
-                Workspace.AddWarningMessage($"Discarded {measurement.Length - measurementIndex} surplus measurement values that could not be mapped to measuring electrodes.");
-            else if (measurement.Length < measuringElectrodeCount)
-            {
-                bool expectedMissing = Workspace.GetElectrodeMeasurementSetup() == ElectrodeMeasurementSetup.NonActive &&
-                                        measurement.Length == Math.Max(0, measuringElectrodeCount - 1);
-
-                if (!expectedMissing)
-                    Workspace.AddWarningMessage($"Measurement frame provides only {measurementIndex} values for {measuringElectrodeCount} measuring electrodes. Missing entries will be ignored during reconstruction.");
-            }
-
-            return prepared;
+            // MapMeasurement() injects NaNs for channels that should not
+            // contribute to the residual (e.g. driven electrodes in non-active
+            // modes) so downstream metrics can ignore them naturally.
+            return pattern.MapMeasurement(measurement);
         }
 
         /// <summary>
@@ -778,7 +852,7 @@ namespace ServiceLayer
 
                 var bc = new FEMBoundaryCondition(electrodes);
                 // Expand the raw measurement vector to match the solver ordering (injecting NaNs for excluded electrodes).
-                var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes);
+                var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
 
                 // Delegate one optimization step to the persistence layer.
                 var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
@@ -824,7 +898,8 @@ namespace ServiceLayer
 
                 var bc = new LBMBoundaryCondition(electrodes);
                 double[] measurement = _simulatedMeasurements[stepIndex];
-                var frame = _reconstructionPersistence.Step(measurement, bc, _stepSize, _regularizationWeight);
+                var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
+                var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
                 _simMeasurementIndex++;
                 Workspace.AddReconstructionFrameToWorkspace(frame);
@@ -953,7 +1028,7 @@ namespace ServiceLayer
                         var bc = new FEMBoundaryCondition(electrodes);
                         var measurement = _simulatedMeasurements[i];
                         // Convert the measurement snapshot to the solver layout for the current electrode roles.
-                        var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes);
+                        var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
 
                         var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
@@ -1007,7 +1082,8 @@ namespace ServiceLayer
                         var bc = new LBMBoundaryCondition(electrodes);
 
                         var measurement = _simulatedMeasurements[i];
-                        var frame = _reconstructionPersistence.Step(measurement, bc, _stepSize, _regularizationWeight);
+                        var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
+                        var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
                         Workspace.AddReconstructionFrameToWorkspace(frame);
                         _currentCycleFrames.Add(frame);

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -48,6 +48,7 @@ namespace Utility.Classes.Application
         private static string? _importedMeasurementLabel;
         private static MeasurementSourceOption _measurementSource = MeasurementSourceOption.Simulated;
         private static ElectrodeMeasurementSetup _electrodeMeasurementSetup = ElectrodeMeasurementSetup.Active;
+        private static MeasurementPattern? _measurementPattern;
 
         public static event Action<ElectrodeMeasurementSetup>? ElectrodeMeasurementSetupChanged;
 
@@ -193,6 +194,21 @@ namespace Utility.Classes.Application
 
             _measurementSource = source;
         }
+
+        /// <summary>
+        /// Retrieves the most recently configured measurement pattern.  The
+        /// pattern captures which electrodes contribute to the sanitised
+        /// measurement vector and how potential differences are assembled.
+        /// </summary>
+        public static MeasurementPattern? GetMeasurementPattern() => _measurementPattern;
+
+        /// <summary>
+        /// Stores the active measurement pattern so that services, error
+        /// metrics, and export routines can share a consistent description of
+        /// the acquisition layout.
+        /// </summary>
+        public static void SetMeasurementPattern(MeasurementPattern? pattern)
+            => _measurementPattern = pattern;
 
         public static int MaxIterationCount
         {

--- a/Utility/Classes/Measurement/EITMeasurement.cs
+++ b/Utility/Classes/Measurement/EITMeasurement.cs
@@ -13,7 +13,9 @@
 
         public static int currentFrameIndex = 0;
 
-        public EITMeasurement(List<double[]> frames)
+        public MeasurementPattern? Pattern { get; set; }
+
+        public EITMeasurement(List<double[]> frames, MeasurementPattern? pattern = null)
         {
             Frames = frames;
 
@@ -23,6 +25,7 @@
                     throw new ArgumentOutOfRangeException("All measurement frames should be of the same size!");
 
             FrameSize = Frames[0].Length;
+            Pattern = pattern;
         }
 
         public EITMeasurement(double[,] measurementFrames)
@@ -39,7 +42,7 @@
         }
 
 
-        public EITMeasurement(List<double[]> frames, double currentAmplitude)
+        public EITMeasurement(List<double[]> frames, double currentAmplitude, MeasurementPattern? pattern = null)
         {
             Frames = frames;
 
@@ -50,6 +53,7 @@
 
             FrameSize = Frames[0].Length;
             CurrentAmplitude = currentAmplitude;
+            Pattern = pattern;
         }
 
         public double[] GetNextFrame()

--- a/Utility/Classes/Measurement/MeasurementPattern.cs
+++ b/Utility/Classes/Measurement/MeasurementPattern.cs
@@ -1,0 +1,358 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Utility.Classes.Application;
+using Utility.Classes.Discretizer;
+
+namespace Utility.Classes.Measurement
+{
+    /// <summary>
+    /// Describes how a single measurement frame should be interpreted by the
+    /// reconstruction pipeline.  A pattern captures the relationship between
+    /// raw measurement entries and electrode indices and enables the solver to
+    /// remap values for the four supported acquisition modes:
+    /// <list type="number">
+    /// <item><description>
+    /// Option 1 – active electrodes, absolute amplitudes: every electrode
+    /// contributes a single entry that maps directly onto its potential.
+    /// </description></item>
+    /// <item><description>
+    /// Option 2 – active electrodes, potential differences: the frame stores
+    /// consecutive differences V_i − V_{i+1} (including the wrap-around term).
+    /// </description></item>
+    /// <item><description>
+    /// Option 3 – non-active electrodes, potential differences: only the
+    /// differences that do not touch the driven electrodes remain and the
+    /// absent pairs are represented as NaNs during sanitisation.
+    /// </description></item>
+    /// <item><description>
+    /// Option 4 – non-active electrodes, amplitudes: only measuring electrodes
+    /// provide values and driven contacts are ignored via NaN placeholders.
+    /// </description></item>
+    /// </list>
+    /// </summary>
+    public sealed class MeasurementPattern
+    {
+        private readonly ReadOnlyCollection<MeasurementChannel> _channels;
+        private readonly Dictionary<int, MeasurementChannel> _channelByTargetIndex;
+
+        internal MeasurementPattern(MeasurementRepresentation representation,
+                                    ElectrodeMeasurementSetup measurementSetup,
+                                    int sanitizedLength,
+                                    IList<MeasurementChannel> channels)
+        {
+            Representation = representation;
+            MeasurementSetup = measurementSetup;
+            SanitizedLength = sanitizedLength;
+            _channels = new ReadOnlyCollection<MeasurementChannel>(channels.ToList());
+            _channelByTargetIndex = channels.ToDictionary(c => c.TargetIndex);
+        }
+
+        /// <summary>
+        /// Describes whether the pattern represents direct amplitudes or
+        /// potential differences.
+        /// </summary>
+        public MeasurementRepresentation Representation { get; }
+
+        /// <summary>
+        /// Identifies whether the underlying acquisition provided data on all
+        /// electrodes (<see cref="ElectrodeMeasurementSetup.Active"/>) or
+        /// omitted the currently driven contacts
+        /// (<see cref="ElectrodeMeasurementSetup.NonActive"/>).
+        /// </summary>
+        public ElectrodeMeasurementSetup MeasurementSetup { get; }
+
+        /// <summary>
+        /// The length of the sanitised vectors forwarded to the error metrics
+        /// (always equal to the electrode count for the associated mesh).
+        /// </summary>
+        public int SanitizedLength { get; }
+
+        /// <summary>Channels that are populated by the provided measurements.</summary>
+        public IReadOnlyList<MeasurementChannel> Channels => _channels;
+
+        internal bool TryGetChannel(int targetIndex, out MeasurementChannel channel)
+            => _channelByTargetIndex.TryGetValue(targetIndex, out channel);
+
+        /// <summary>
+        /// Converts raw measurement frames into solver-aligned vectors.  The
+        /// caller supplies either a short frame that contains only the active
+        /// channels (Options 3 &amp; 4) or a full frame (Options 1 &amp; 2).  Missing
+        /// entries are padded with NaNs so that residuals ignore them.
+        /// </summary>
+        public double[] MapMeasurement(double[] measurement)
+        {
+            double[] sanitized = Enumerable.Repeat(double.NaN, SanitizedLength).ToArray();
+            if (measurement.Length == SanitizedLength)
+            {
+                Array.Copy(measurement, sanitized, SanitizedLength);
+                return sanitized;
+            }
+
+            int cursor = 0;
+            foreach (var channel in _channels)
+            {
+                if (cursor >= measurement.Length)
+                {
+                    Workspace.AddWarningMessage(
+                        $"Measurement frame missing entries for target index {channel.TargetIndex}. Remaining slots will be ignored.");
+                    break;
+                }
+
+                sanitized[channel.TargetIndex] = measurement[cursor++];
+            }
+
+            if (measurement.Length > _channels.Count)
+            {
+                Workspace.AddWarningMessage(
+                    $"Discarding {measurement.Length - _channels.Count} surplus measurement values that do not map to the current pattern.");
+            }
+
+            return sanitized;
+        }
+
+        /// <summary>
+        /// Projects simulated electrode potentials into the representation
+        /// dictated by the pattern.  Missing channels (e.g. driven electrodes in
+        /// Option 3 and Option 4) are padded with NaN so error metrics skip them.
+        /// </summary>
+        public double[] ProjectSimulated(double[] potentials)
+        {
+            if (potentials.Length != SanitizedLength)
+                throw new ArgumentException("Simulated potential vector length does not match the pattern.", nameof(potentials));
+
+            double[] projected = Enumerable.Repeat(double.NaN, SanitizedLength).ToArray();
+
+            if (Representation == MeasurementRepresentation.Amplitude)
+            {
+                foreach (var channel in _channels)
+                {
+                    int idx = channel.FirstElectrodeIndex;
+                    if (idx < 0 || idx >= potentials.Length)
+                        continue;
+
+                    projected[channel.TargetIndex] = potentials[idx];
+                }
+            }
+            else
+            {
+                foreach (var channel in _channels)
+                {
+                    int left = channel.FirstElectrodeIndex;
+                    int right = channel.SecondElectrodeIndex;
+                    if (left < 0 || left >= potentials.Length)
+                        continue;
+                    if (right < 0 || right >= potentials.Length)
+                        continue;
+
+                    double a = potentials[left];
+                    double b = potentials[right];
+                    projected[channel.TargetIndex] = double.IsNaN(a) || double.IsNaN(b) ? double.NaN : a - b;
+                }
+            }
+
+            return projected;
+        }
+
+        /// <summary>
+        /// Extracts a raw measurement frame (without NaN padding) from a
+        /// simulated potential vector.  This mirrors what the instrumentation
+        /// would deliver for each of the four options.
+        /// </summary>
+        public double[] ExtractRawMeasurement(double[] potentials)
+        {
+            double[] frame = new double[_channels.Count];
+            for (int i = 0; i < _channels.Count; i++)
+            {
+                var channel = _channels[i];
+                if (Representation == MeasurementRepresentation.Amplitude)
+                {
+                    frame[i] = potentials[channel.FirstElectrodeIndex];
+                }
+                else
+                {
+                    double left = potentials[channel.FirstElectrodeIndex];
+                    double right = potentials[channel.SecondElectrodeIndex];
+                    frame[i] = double.IsNaN(left) || double.IsNaN(right) ? double.NaN : left - right;
+                }
+            }
+
+            return frame;
+        }
+    }
+
+    /// <summary>
+    /// A single measurement channel mapping a raw frame entry to a concrete
+    /// electrode index (amplitude mode) or electrode pair (difference mode).
+    /// </summary>
+    public sealed record MeasurementChannel(int TargetIndex, int FirstElectrodeIndex, int SecondElectrodeIndex);
+
+    public enum MeasurementRepresentation
+    {
+        Amplitude,
+        PotentialDifference
+    }
+
+    public static class MeasurementPatternBuilder
+    {
+        public static MeasurementPattern Build(IReadOnlyList<Electrode> electrodes,
+                                               ElectrodeMeasurementSetup setup,
+                                               bool usePotentialDifferences)
+        {
+            if (electrodes == null)
+                throw new ArgumentNullException(nameof(electrodes));
+
+            int electrodeCount = electrodes.Count;
+            if (electrodeCount == 0)
+                return new MeasurementPattern(MeasurementRepresentation.Amplitude,
+                                              ElectrodeMeasurementSetup.Active,
+                                              0,
+                                              []);
+
+            if (!usePotentialDifferences)
+                return BuildAmplitudePattern(electrodes, setup);
+
+            return BuildDifferencePattern(electrodes, setup);
+        }
+
+        private static MeasurementPattern BuildAmplitudePattern(IReadOnlyList<Electrode> electrodes,
+                                                                ElectrodeMeasurementSetup setup)
+        {
+            int electrodeCount = electrodes.Count;
+            var channels = new List<MeasurementChannel>(electrodeCount);
+
+            for (int i = 0; i < electrodeCount; i++)
+            {
+                bool include = setup == ElectrodeMeasurementSetup.Active || electrodes[i].IsMeasuring;
+                if (!include)
+                    continue;
+
+                channels.Add(new MeasurementChannel(i, i, i));
+            }
+
+            if (channels.Count == 0)
+                Workspace.AddWarningMessage("Amplitude measurement pattern contains no measuring electrodes.");
+
+            return new MeasurementPattern(MeasurementRepresentation.Amplitude,
+                                          setup,
+                                          electrodeCount,
+                                          channels);
+        }
+
+        private static MeasurementPattern BuildDifferencePattern(IReadOnlyList<Electrode> electrodes,
+                                                                 ElectrodeMeasurementSetup setup)
+        {
+            int electrodeCount = electrodes.Count;
+            var channels = new List<MeasurementChannel>(electrodeCount);
+            var skipped = new HashSet<int>();
+
+            if (setup == ElectrodeMeasurementSetup.NonActive)
+            {
+                for (int i = 0; i < electrodeCount; i++)
+                {
+                    if (electrodes[i].IsMeasuring)
+                        continue;
+
+                    skipped.Add(i);
+                    skipped.Add((i - 1 + electrodeCount) % electrodeCount);
+                }
+            }
+
+            for (int i = 0; i < electrodeCount; i++)
+            {
+                if (skipped.Contains(i))
+                    continue;
+
+                int next = (i + 1) % electrodeCount;
+                channels.Add(new MeasurementChannel(i, i, next));
+            }
+
+            if (channels.Count == 0)
+                Workspace.AddWarningMessage("Potential-difference measurement pattern contains no valid channels.");
+
+            return new MeasurementPattern(MeasurementRepresentation.PotentialDifference,
+                                          setup,
+                                          electrodeCount,
+                                          channels);
+        }
+    }
+
+    /// <summary>
+    /// Bundles the sanitised measurement vectors and the pattern that produced
+    /// them.  The projection handles the adjoint back-projection so that error
+    /// metrics remain agnostic of the acquisition mode.
+    /// </summary>
+    public sealed class MeasurementProjection
+    {
+        private readonly MeasurementPattern _pattern;
+
+        internal MeasurementProjection(MeasurementPattern pattern, double[] measured, double[] simulated)
+        {
+            _pattern = pattern;
+            Measured = measured;
+            Simulated = simulated;
+        }
+
+        public MeasurementPattern Pattern => _pattern;
+        public double[] Measured { get; }
+        public double[] Simulated { get; }
+
+        /// <summary>
+        /// Expands an adjoint vector defined in measurement space back onto the
+        /// per-electrode representation expected by the solvers.
+        /// </summary>
+        public double[] ExpandAdjoint(double[] adjoint)
+        {
+            double[] expanded = new double[_pattern.SanitizedLength];
+
+            if (_pattern.Representation == MeasurementRepresentation.Amplitude)
+            {
+                foreach (var channel in _pattern.Channels)
+                {
+                    if (channel.TargetIndex < 0 || channel.TargetIndex >= adjoint.Length)
+                        continue;
+
+                    expanded[channel.FirstElectrodeIndex] = adjoint[channel.TargetIndex];
+                }
+            }
+            else
+            {
+                foreach (var channel in _pattern.Channels)
+                {
+                    if (channel.TargetIndex < 0 || channel.TargetIndex >= adjoint.Length)
+                        continue;
+
+                    double value = adjoint[channel.TargetIndex];
+                    if (!double.IsFinite(value))
+                        continue;
+
+                    expanded[channel.FirstElectrodeIndex] += value;
+                    expanded[channel.SecondElectrodeIndex] -= value;
+                }
+            }
+
+            return expanded;
+        }
+    }
+
+    /// <summary>
+    /// Convenience factory that produces measurement projections for measured
+    /// and simulated frames.  The factory ensures both vectors share the same
+    /// sanitised layout before the error metrics are invoked.
+    /// </summary>
+    public static class MeasurementProjector
+    {
+        public static MeasurementProjection Create(IReadOnlyList<Electrode> electrodes,
+                                                   ElectrodeMeasurementSetup setup,
+                                                   bool usePotentialDifferences,
+                                                   double[] measurement,
+                                                   double[] simulated)
+        {
+            var pattern = MeasurementPatternBuilder.Build(electrodes, setup, usePotentialDifferences);
+            var measured = pattern.MapMeasurement(measurement);
+            var projectedSimulated = pattern.ProjectSimulated(simulated);
+            return new MeasurementProjection(pattern, measured, projectedSimulated);
+        }
+    }
+}

--- a/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
@@ -372,7 +372,13 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             {
                 double rawVal = raw[i];
                 if (!double.IsFinite(rawVal))
-                    rawVal = min;
+                {
+                    shifted[i] = 0.0;
+                    softplus[i] = 0.0;
+                    sigmoid[i] = 0.0;
+                    normalized[i] = 0.0;
+                    continue;
+                }
                 double val = rawVal - min;
                 shifted[i] = val;
                 double kx = kappa * val;
@@ -386,7 +392,10 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             }
 
             if (sum <= 0.0)
-                throw new InvalidOperationException("Normalisation resulted in zero total mass.");
+            {
+                Array.Clear(normalized, 0, normalized.Length);
+                return new NormalizationCache(raw, shifted, softplus, sigmoid, normalized, minIdx, 0.0);
+            }
 
             for (int i = 0; i < normalized.Length; i++)
                 normalized[i] /= sum;
@@ -419,6 +428,8 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             meanWeighted *= cache.Sum;
 
             double sum = cache.Sum;
+            if (sum <= 0.0)
+                return result;
             int minIdx = cache.MinIndex;
 
             for (int k = 0; k < n; k++)

--- a/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
@@ -1,7 +1,9 @@
 ﻿using Google.OrTools.LinearSolver;
+using Utility.Classes.Application;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Classes.Measurement;
 using Utility.Classes.ReconstructionParameters;
 
 namespace Utility.Classes.Reconstruction.ErrorMetrics
@@ -188,14 +190,19 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
 
             var all = discretization.GetElectrodes().OrderBy(e => e.Id).ToList();
             var measuring = all.Where(e => e.IsMeasuring).OrderBy(e => e.Id).ToList();
-            var differenceElectrodes = measuring.Count > 0 ? (IReadOnlyList<Electrode>)measuring : all;
+            var pattern = Workspace.GetMeasurementPattern();
+            bool usingDifferences = pattern?.Representation == MeasurementRepresentation.PotentialDifference;
 
-            int expectedDifferenceLength = Math.Max(0, differenceElectrodes.Count - 1);
-            bool usingDifferences = measured.Length == expectedDifferenceLength &&
+            if (!usingDifferences)
+            {
+                var differenceElectrodes = measuring.Count > 0 ? (IReadOnlyList<Electrode>)measuring : all;
+                int expectedDifferenceLength = Math.Max(0, differenceElectrodes.Count - 1);
+                usingDifferences = measured.Length == expectedDifferenceLength &&
                                     simulated.Length == expectedDifferenceLength;
+            }
 
             if (usingDifferences)
-                return SolveDifferenceOT(measured, simulated, differenceElectrodes, coord);
+                return SolveDifferenceOT(measured, simulated, all, coord, pattern);
 
             if (all.Count != measured.Length || all.Count != simulated.Length)
                 throw new ArgumentException("Electrode count must match data length when using direct potentials.");
@@ -225,7 +232,9 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         }
 
         private OptimalTransportResult SolveDifferenceOT(double[] measured, double[] simulated,
-            IReadOnlyList<Electrode> electrodes, Func<Electrode, (double x, double y)> getCoord)
+            IReadOnlyList<Electrode> electrodes,
+            Func<Electrode, (double x, double y)> getCoord,
+            MeasurementPattern? pattern)
         {
             if (measured.Length != simulated.Length)
                 throw new ArgumentException("Measured and simulated difference arrays must have identical length.");
@@ -236,8 +245,15 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 if (double.IsFinite(measured[i]) && double.IsFinite(simulated[i]))
                     include.Add(i);
 
-            var (aRaw, aLoc, aMap) = BuildDifferenceDistribution(simulated, electrodes, getCoord, include);
-            var (bRaw, bLoc, _) = BuildDifferenceDistribution(measured, electrodes, getCoord, include);
+            if (include.Count == 0)
+                return new OptimalTransportResult(measured, simulated, 0.0, new double[differenceCount]);
+
+            var activePattern = pattern != null && pattern.SanitizedLength == differenceCount
+                ? pattern
+                : null;
+
+            var (aRaw, aLoc, aMap) = BuildDifferenceDistribution(simulated, electrodes, getCoord, include, activePattern);
+            var (bRaw, bLoc, _) = BuildDifferenceDistribution(measured, electrodes, getCoord, include, activePattern);
 
             if (aRaw.Length == 0 || bRaw.Length == 0)
                 return new OptimalTransportResult(measured, simulated, 0.0, new double[differenceCount]);
@@ -274,8 +290,11 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         }
 
         private static (double[] raw, (double x, double y)[] loc, List<(int srcIdx, int diffIdx)> indexMap)
-            BuildDifferenceDistribution(double[] raw, IReadOnlyList<Electrode> electrodes,
-                Func<Electrode, (double x, double y)> getCoord, List<int> include)
+            BuildDifferenceDistribution(double[] raw,
+                                        IReadOnlyList<Electrode> electrodes,
+                                        Func<Electrode, (double x, double y)> getCoord,
+                                        List<int> include,
+                                        MeasurementPattern? pattern)
         {
             var vals = new List<double>(include.Count);
             var coords = new List<(double, double)>(include.Count);
@@ -290,9 +309,22 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 if (!double.IsFinite(v))
                     continue;
 
-                int left = diffIdx;
-                int right = diffIdx + 1;
-                if (left < 0 || right >= electrodes.Count)
+                int left;
+                int right;
+                if (pattern != null && pattern.TryGetChannel(diffIdx, out var channel))
+                {
+                    left = channel.FirstElectrodeIndex;
+                    right = channel.SecondElectrodeIndex;
+                }
+                else
+                {
+                    left = diffIdx % electrodes.Count;
+                    right = (diffIdx + 1) % electrodes.Count;
+                }
+
+                if (left < 0 || left >= electrodes.Count)
+                    continue;
+                if (right < 0 || right >= electrodes.Count)
                     continue;
 
                 var leftCoord = getCoord(electrodes[left]);


### PR DESCRIPTION
## Summary
- wire the reusable measurement pattern through persistence, service, and export layers so every inverse step shares the same sanitised measurement description
- auto-detect active/non-active and amplitude/difference modes when importing or simulating frames and update workspace/UI state accordingly
- harden Wasserstein-based error metrics against NaNs/differences and include measurement mode metadata in reconstruction exports

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69001bf129a0833388ad194af7b9453a