### PR TITLE
Use left electrode geometry for difference OT supports

### DIFF
--- a/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
@@ -327,12 +327,8 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 if (right < 0 || right >= electrodes.Count)
                     continue;
 
-                var leftCoord = getCoord(electrodes[left]);
-                var rightCoord = getCoord(electrodes[right]);
-                var midpoint = ((leftCoord.x + rightCoord.x) * 0.5, (leftCoord.y + rightCoord.y) * 0.5);
-
                 vals.Add(v);
-                coords.Add(midpoint);
+                coords.Add(getCoord(electrodes[left]));
                 map.Add((vals.Count - 1, diffIdx));
             }
 


### PR DESCRIPTION
## Summary
- use the first electrode coordinate as the support location for potential-difference channels in the Wasserstein-2 error metric
- remove midpoint averaging when constructing the OT support list

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6900c6c71eec83338979e06b60745a44