### PR TITLE
Align residual metric with electrode RMSE

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -202,7 +202,9 @@ namespace BusinessLayer
                 return new ReconstructionFrame(totalGrad,
                                               frame.CalculatedPotentialDistribution,
                                               frame.CalculatedAdjointDistribution,
-                                              frame.CalculatedRegularization);
+                                              frame.CalculatedRegularization,
+                                              frame.MeasuredElectrodeValues,
+                                              frame.SimulatedElectrodeValues);
             }
             else if (_discretization is LBMGrid lbmGrid)
             {
@@ -223,7 +225,9 @@ namespace BusinessLayer
                 return new ReconstructionFrame(totalGrad,
                                               frame.CalculatedPotentialDistribution,
                                               frame.CalculatedAdjointDistribution,
-                                              frame.CalculatedRegularization);
+                                              frame.CalculatedRegularization,
+                                              frame.MeasuredElectrodeValues,
+                                              frame.SimulatedElectrodeValues);
             }
             else throw new ArgumentOutOfRangeException();
         }
@@ -442,7 +446,12 @@ namespace BusinessLayer
             );
 
             // LBM path in this routine does not compute explicit regularization (left empty)
-            return new ReconstructionFrame(dataGrad, phi, mu, new ConductivityDistribution([]));
+            return new ReconstructionFrame(dataGrad,
+                                          phi,
+                                          mu,
+                                          new ConductivityDistribution([]),
+                                          projection.Measured,
+                                          projection.Simulated);
         }
 
         /// <summary>
@@ -553,7 +562,12 @@ namespace BusinessLayer
             _ = regularizer.EvaluateTerm(mesh, sigma); // evaluate/optionally log; value is not used here
             ConductivityDistribution regularization = regularizer.EvaluateGradient(mesh, sigma);
 
-            return new ReconstructionFrame(dataGrad, phi, mu, regularization);
+            return new ReconstructionFrame(dataGrad,
+                                          phi,
+                                          mu,
+                                          regularization,
+                                          projection.Measured,
+                                          projection.Simulated);
         }
 
         /// <summary>
@@ -1100,7 +1114,12 @@ namespace BusinessLayer
                 )
             );
 
-            return new ReconstructionFrame(dataGrad, phi, mu, new ConductivityDistribution([]));
+            return new ReconstructionFrame(dataGrad,
+                                          phi,
+                                          mu,
+                                          new ConductivityDistribution([]),
+                                          projection.Measured,
+                                          projection.Simulated);
         }
 
         /// <summary>

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -704,16 +704,43 @@ namespace ElectricalImpedanceTomography.ViewModels
             return true;
         }
 
-        private double CalculateResidual(ConductivityDistribution reconstructed, ConductivityDistribution original)
+        private static double CalculateResidual(ReconstructionResult result)
         {
-            double sum = 0.0;
-            foreach (var kv in reconstructed.Conductivities)
+            if (result.Frames.Count == 0)
+                return 0.0;
+
+            double sumSq = 0.0;
+            int sampleCount = 0;
+
+            foreach (var frame in result.Frames)
             {
-                original.Conductivities.TryGetValue(kv.Key, out double origVal);
-                double diff = kv.Value - origVal;
-                sum += diff * diff;
+                var measured = frame.MeasuredElectrodeValues;
+                var simulated = frame.SimulatedElectrodeValues;
+
+                if (measured == null || simulated == null)
+                    continue;
+
+                int length = Math.Min(measured.Length, simulated.Length);
+                for (int i = 0; i < length; i++)
+                {
+                    double measuredValue = measured[i];
+                    double simulatedValue = simulated[i];
+
+                    if (double.IsNaN(measuredValue) || double.IsInfinity(measuredValue))
+                        continue;
+                    if (double.IsNaN(simulatedValue) || double.IsInfinity(simulatedValue))
+                        continue;
+
+                    double diff = simulatedValue - measuredValue;
+                    sumSq += diff * diff;
+                    sampleCount++;
+                }
             }
-            return Math.Sqrt(sum);
+
+            if (sampleCount == 0)
+                return 0.0;
+
+            return Math.Sqrt(sumSq / sampleCount);
         }
 
         private double CalculateCorrelation(ConductivityDistribution reconstructed, ConductivityDistribution original)
@@ -1495,8 +1522,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             var results = Workspace.GetReconstructionResults().ToList();
             var residualHistory = results
-                .Select(r => CalculateResidual(r.ReconstructedConductivityDistribution,
-                                               r.OriginalConductivityDistribution))
+                .Select(CalculateResidual)
                 .ToList();
 
             var distributionSize = ReconstructionVideoRenderer.NormalizeSize(distributionCanvasSize, 250, 250);
@@ -1936,8 +1962,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             try
             {
                 var token = cts.Token;
-                double residual = CalculateResidual(result.ReconstructedConductivityDistribution,
-                                                    result.OriginalConductivityDistribution);
+                double residual = CalculateResidual(result);
                 token.ThrowIfCancellationRequested();
 
                 double correlation = CalculateCorrelation(result.ReconstructedConductivityDistribution,

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -1351,16 +1351,43 @@ public partial class ReconstructionPage : ContentPage
         GradientColorbarCanvas.InvalidateSurface();
     }
 
-    private static double CalculateResidual(ConductivityDistribution reconstructed, ConductivityDistribution original)
+    private static double CalculateResidual(ReconstructionResult result)
     {
-        double sum = 0.0;
-        foreach (var kv in reconstructed.Conductivities)
+        if (result.Frames.Count == 0)
+            return 0.0;
+
+        double sumSq = 0.0;
+        int sampleCount = 0;
+
+        foreach (var frame in result.Frames)
         {
-            original.Conductivities.TryGetValue(kv.Key, out double origVal);
-            double diff = kv.Value - origVal;
-            sum += diff * diff;
+            var measured = frame.MeasuredElectrodeValues;
+            var simulated = frame.SimulatedElectrodeValues;
+
+            if (measured == null || simulated == null)
+                continue;
+
+            int length = Math.Min(measured.Length, simulated.Length);
+            for (int i = 0; i < length; i++)
+            {
+                double measuredValue = measured[i];
+                double simulatedValue = simulated[i];
+
+                if (double.IsNaN(measuredValue) || double.IsInfinity(measuredValue))
+                    continue;
+                if (double.IsNaN(simulatedValue) || double.IsInfinity(simulatedValue))
+                    continue;
+
+                double diff = simulatedValue - measuredValue;
+                sumSq += diff * diff;
+                sampleCount++;
+            }
         }
-        return Math.Sqrt(sum);
+
+        if (sampleCount == 0)
+            return 0.0;
+
+        return Math.Sqrt(sumSq / sampleCount);
     }
 
     private async void OnExportClicked(object sender, EventArgs e)
@@ -1460,8 +1487,7 @@ public partial class ReconstructionPage : ContentPage
             if (_currentResult != null)
             {
                 _viewModel.IterationCount = results.Count;
-                _viewModel.Residual = CalculateResidual(_currentResult.ReconstructedConductivityDistribution,
-                                                       _currentResult.OriginalConductivityDistribution);
+                _viewModel.Residual = CalculateResidual(_currentResult);
             }
             Dispatcher.Dispatch(() =>
             {
@@ -1516,8 +1542,7 @@ public partial class ReconstructionPage : ContentPage
             {
                 _currentResult = res;
                 _viewModel.IterationCount = iter;
-                _viewModel.Residual = CalculateResidual(res.ReconstructedConductivityDistribution,
-                                                       res.OriginalConductivityDistribution);
+                _viewModel.Residual = CalculateResidual(res);
             }
             Dispatcher.Dispatch(() => { InvalidateAll(); UpdatePlaybackLabel(); });
         }

--- a/Utility/Classes/ReconstructionFrame.cs
+++ b/Utility/Classes/ReconstructionFrame.cs
@@ -1,4 +1,5 @@
-﻿using Utility.Classes.Discretizer;
+﻿using System;
+using Utility.Classes.Discretizer;
 
 namespace Utility.Classes
 {
@@ -9,16 +10,22 @@ namespace Utility.Classes
         public PotentialDistribution CalculatedPotentialDistribution;   // The current calculated potential distribution of the model
         public PotentialDistribution CalculatedAdjointDistribution;     // The current adjoin (\mu) field calculated by the model which is somewhat a potential distribution
         public ConductivityDistribution CalculatedRegularization;
+        public double[] MeasuredElectrodeValues { get; }                // Sanitized measurements used for this frame
+        public double[] SimulatedElectrodeValues { get; }               // Sanitized simulated values for this frame
 
-        public ReconstructionFrame(ConductivityDistribution conductivityGradient, 
+        public ReconstructionFrame(ConductivityDistribution conductivityGradient,
                                    PotentialDistribution calculatedPotentialDistribution,
                                    PotentialDistribution calculatedAdjointDistribution,
-                                   ConductivityDistribution calculatedRegularization)
+                                   ConductivityDistribution calculatedRegularization,
+                                   double[]? measuredElectrodeValues = null,
+                                   double[]? simulatedElectrodeValues = null)
         {
             ConductivityGradient = conductivityGradient;
             CalculatedPotentialDistribution = calculatedPotentialDistribution;
             CalculatedAdjointDistribution = calculatedAdjointDistribution;
             CalculatedRegularization = calculatedRegularization;
+            MeasuredElectrodeValues = measuredElectrodeValues ?? Array.Empty<double>();
+            SimulatedElectrodeValues = simulatedElectrodeValues ?? Array.Empty<double>();
         }
     }
 }


### PR DESCRIPTION
## Summary
- capture sanitized measurement and simulated electrode values in each reconstruction frame
- compute residuals as the RMSE between measured and simulated electrode data throughout reconstruction workflows
- update the reconstruction page to display the new residual metric

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_6901fe441750833380da683129c7246f