### PR TITLE
Add reconstruction configuration export snapshot

### DIFF
--- a/DataAccessLayer/IReconstructionExportRepository.cs
+++ b/DataAccessLayer/IReconstructionExportRepository.cs
@@ -18,4 +18,5 @@ public sealed record ReconstructionExportRequest(IDiscretization Discretization,
                                                   PotentialDisplayMode DisplayMode,
                                                   string TargetDirectory,
                                                   ConductivityDistribution InitialDistribution,
-                                                  MeasurementPattern? MeasurementPattern);
+                                                  MeasurementPattern? MeasurementPattern,
+                                                  ReconstructionConfigurationSnapshot Configuration);

--- a/DataAccessLayer/ReconstructionExportRepository.cs
+++ b/DataAccessLayer/ReconstructionExportRepository.cs
@@ -1,6 +1,8 @@
 using SkiaSharp;
 using System.Globalization;
+using System.IO;
 using System.Text;
+using System.Text.Json;
 using Utility.Classes;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Measurement;
@@ -91,6 +93,7 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
             WriteIterationMetricsCsv(request.TargetDirectory, snapshots);
             WriteGradientMetricsCsv(request.TargetDirectory, request.Frames);
+            WriteConfigurationSnapshot(request.TargetDirectory, request.Configuration);
 
             return DataExportResult.CreateSuccess(request.TargetDirectory);
         }
@@ -98,6 +101,21 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
         {
             return DataExportResult.CreateFailure("Export Failed", ex.Message);
         }
+    }
+
+    private static void WriteConfigurationSnapshot(string directory, ReconstructionConfigurationSnapshot configuration)
+    {
+        if (configuration == null)
+            return;
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true
+        };
+
+        string json = JsonSerializer.Serialize(configuration, options);
+        string path = Path.Combine(directory, "reconstruction_configuration.json");
+        File.WriteAllText(path, json);
     }
 
     private static List<ReconstructionIterationSnapshot> CreateIterationSnapshots(IReadOnlyList<ReconstructionResult> results)

--- a/ServiceLayer/ReconstructionExportService.cs
+++ b/ServiceLayer/ReconstructionExportService.cs
@@ -1,5 +1,12 @@
 using DataAccessLayer;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Utility.Classes;
+using Utility.Classes.Discretizer;
+using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Classes.Measurement;
 using Utility.Exports;
 using Utility.Rendering;
 using Workspace = Utility.Classes.Application.Workspace;
@@ -40,6 +47,11 @@ public sealed class ReconstructionExportService : IReconstructionExportService
         var initialDistribution = Workspace.GetInitialConductivityDistribution()
                                    ?? results[0].InitialConductivitiyDistribution;
 
+        var measurementPattern = Workspace.GetMeasurementPattern();
+        var configuration = CreateConfigurationSnapshot(discretization,
+                                                        initialDistribution,
+                                                        measurementPattern);
+
         var request = new ReconstructionExportRequest(discretization,
                                                       frames,
                                                       results,
@@ -47,8 +59,155 @@ public sealed class ReconstructionExportService : IReconstructionExportService
                                                       displayMode,
                                                       directory,
                                                       initialDistribution,
-                                                      Workspace.GetMeasurementPattern());
+                                                      measurementPattern,
+                                                      configuration);
 
         return Task.Run(() => _repository.ExportReconstructionData(request), cancellationToken);
+    }
+
+    private static ReconstructionConfigurationSnapshot CreateConfigurationSnapshot(IDiscretization discretization,
+                                                                                   ConductivityDistribution initialDistribution,
+                                                                                   MeasurementPattern? measurementPattern)
+    {
+        var parameters = Workspace.GetReconstructionParameters();
+        var measurementSource = Workspace.GetMeasurementSource();
+        var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+        var measurementLabel = Workspace.GetImportedMeasurementLabel();
+
+        var channelSnapshots = measurementPattern?.Channels
+            .Select(c => new MeasurementChannelSnapshot(c.TargetIndex, c.FirstElectrodeIndex, c.SecondElectrodeIndex))
+            .ToList() ?? new List<MeasurementChannelSnapshot>();
+
+        var measurementSnapshot = new MeasurementConfigurationSnapshot(
+            measurementSource.ToString(),
+            measurementSetup.ToString(),
+            measurementLabel,
+            parameters.UsePotentialDifferences,
+            measurementPattern is not null,
+            measurementPattern?.Representation.ToString(),
+            measurementPattern?.SanitizedLength,
+            channelSnapshots.Count,
+            channelSnapshots);
+
+        var reconstructionSection = new ReconstructionParameterSection(
+            parameters.DifferentialEquationSolver.ToString(),
+            parameters.RegularizationTechnique.ToString(),
+            parameters.ErrorMetric.ToString(),
+            parameters.NumericSolver.ToString(),
+            parameters.NumericOptimizer.ToString(),
+            parameters.DrivePattern.ToString(),
+            parameters.UsePotentialDifferences,
+            parameters.UseOmpParallelization,
+            parameters.UseCudaAcceleration,
+            parameters.MeasurementNoiseType.ToString(),
+            parameters.MeasurementNoiseAmplitude);
+
+        var workspaceSection = new WorkspaceParameterSection(
+            Workspace.MaxIterationCount,
+            Workspace.StepSize,
+            Workspace.RegularizationWeight,
+            Workspace.ConductivityMinimumBound,
+            Workspace.ConductivityMaximumBound);
+
+        var meshSnapshot = CreateMeshSnapshot(discretization);
+        var initialSnapshot = CreateInitialDistributionSnapshot(parameters.InitialDistributionType.ToString(), initialDistribution);
+
+        return new ReconstructionConfigurationSnapshot(
+            DateTime.UtcNow,
+            reconstructionSection,
+            workspaceSection,
+            measurementSnapshot,
+            meshSnapshot,
+            initialSnapshot);
+    }
+
+    private static MeshConfigurationSnapshot CreateMeshSnapshot(IDiscretization discretization)
+    {
+        var metadata = discretization.Metadata ?? new DiscretizationMetaData();
+        var parameterCopy = metadata.Parameters != null
+            ? new Dictionary<string, string>(metadata.Parameters)
+            : new Dictionary<string, string>();
+
+        string meshType = discretization switch
+        {
+            FEMMesh => "FEM",
+            LBMGrid => "LBM",
+            _ => discretization.GetType().Name
+        };
+
+        string? sourceFile = InferMeshSourceFile(parameterCopy);
+
+        int elementCount = metadata.ElementCount > 0
+            ? metadata.ElementCount
+            : discretization.GetElements().Count;
+
+        int electrodeCount = discretization.GetElectrodes().Count;
+
+        return new MeshConfigurationSnapshot(
+            meshType,
+            metadata.Generator ?? string.Empty,
+            elementCount,
+            electrodeCount,
+            metadata.CreatedOn,
+            sourceFile,
+            parameterCopy);
+    }
+
+    private static string? InferMeshSourceFile(IReadOnlyDictionary<string, string> parameters)
+    {
+        foreach (var kvp in parameters)
+        {
+            if (kvp.Key.Contains("file", StringComparison.OrdinalIgnoreCase) ||
+                kvp.Key.Contains("path", StringComparison.OrdinalIgnoreCase))
+            {
+                return kvp.Value;
+            }
+        }
+
+        return null;
+    }
+
+    private static InitialDistributionSnapshot CreateInitialDistributionSnapshot(string initialDistributionType,
+                                                                                ConductivityDistribution? distribution)
+    {
+        if (distribution?.Conductivities == null || distribution.Conductivities.Count == 0)
+        {
+            return new InitialDistributionSnapshot(initialDistributionType,
+                                                   false,
+                                                   distribution?.Conductivities.Count ?? 0,
+                                                   double.NaN,
+                                                   double.NaN,
+                                                   double.NaN,
+                                                   double.NaN);
+        }
+
+        var validValues = distribution.Conductivities.Values
+            .Where(v => !double.IsNaN(v) && !double.IsInfinity(v))
+            .ToList();
+
+        if (validValues.Count == 0)
+        {
+            return new InitialDistributionSnapshot(initialDistributionType,
+                                                   false,
+                                                   distribution.Conductivities.Count,
+                                                   double.NaN,
+                                                   double.NaN,
+                                                   double.NaN,
+                                                   double.NaN);
+        }
+
+        double min = validValues.Min();
+        double max = validValues.Max();
+        double mean = validValues.Average();
+        double variance = validValues.Sum(v => (v - mean) * (v - mean)) / validValues.Count;
+        double stdDev = Math.Sqrt(variance);
+
+        return new InitialDistributionSnapshot(initialDistributionType,
+                                               true,
+                                               distribution.Conductivities.Count,
+                                               min,
+                                               max,
+                                               mean,
+                                               stdDev);
     }
 }

--- a/Utility/Exports/ReconstructionConfigurationSnapshot.cs
+++ b/Utility/Exports/ReconstructionConfigurationSnapshot.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace Utility.Exports;
+
+public sealed record ReconstructionConfigurationSnapshot(
+    DateTime ExportedOn,
+    ReconstructionParameterSection Reconstruction,
+    WorkspaceParameterSection Workspace,
+    MeasurementConfigurationSnapshot Measurement,
+    MeshConfigurationSnapshot Mesh,
+    InitialDistributionSnapshot InitialDistribution);
+
+public sealed record ReconstructionParameterSection(
+    string DifferentialEquationSolver,
+    string RegularizationTechnique,
+    string ErrorMetric,
+    string NumericSolver,
+    string NumericOptimizer,
+    string DrivePattern,
+    bool UsePotentialDifferences,
+    bool UseOmpParallelization,
+    bool UseCudaAcceleration,
+    string MeasurementNoiseType,
+    double MeasurementNoiseAmplitude);
+
+public sealed record WorkspaceParameterSection(
+    int MaxIterationCount,
+    double StepSize,
+    double RegularizationWeight,
+    double ConductivityMinimumBound,
+    double ConductivityMaximumBound);
+
+public sealed record MeasurementConfigurationSnapshot(
+    string MeasurementSource,
+    string ElectrodeMeasurementSetup,
+    string? MeasurementLabel,
+    bool UsePotentialDifferences,
+    bool HasPattern,
+    string? Representation,
+    int? SanitizedLength,
+    int ChannelCount,
+    IReadOnlyList<MeasurementChannelSnapshot> Channels);
+
+public sealed record MeasurementChannelSnapshot(int TargetIndex, int FirstElectrodeIndex, int SecondElectrodeIndex);
+
+public sealed record MeshConfigurationSnapshot(
+    string MeshType,
+    string Generator,
+    int ElementCount,
+    int ElectrodeCount,
+    DateTime CreatedOn,
+    string? SourceFileName,
+    IReadOnlyDictionary<string, string> Parameters);
+
+public sealed record InitialDistributionSnapshot(
+    string InitialDistributionType,
+    bool HasDistribution,
+    int SampleCount,
+    double Minimum,
+    double Maximum,
+    double Mean,
+    double StandardDeviation);


### PR DESCRIPTION
## Summary
- capture the active reconstruction, workspace, measurement, and mesh settings when starting an export
- include the configuration snapshot in the export request and write it alongside existing CSV outputs
- define strongly typed snapshot records for structured JSON serialization

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6902aa69e1c48333a446fdf9090d5a16