### PR TITLE
Add gradient inspection viewer and history synchronization

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -263,6 +263,13 @@ namespace ElectricalImpedanceTomography.ViewModels
         private ReconstructionResult? _latestResult;
         private ReconstructionFrame? _latestFrame;
         private Dictionary<int, double>? _previousGradientSnapshot;
+        private readonly List<GradientHistorySample> _gradientHistory = new();
+        private List<int>? _gradientElementOrder;
+        private Dictionary<int, int>? _gradientElementIndexMap;
+        private int _selectedGradientIndex = -1;
+        public event EventHandler? GradientHistoryChanged;
+        public event EventHandler<int>? GradientSelectionChanged;
+        public event EventHandler? GradientInspectionRequested;
         private IErrorMetric? _cachedErrorMetric;
         private ErrorMetric _cachedErrorMetricChoice;
 
@@ -501,6 +508,110 @@ namespace ElectricalImpedanceTomography.ViewModels
         public IReadOnlyList<double> GetSelectedTrendHistorySnapshot()
             => GetTrendHistorySnapshot(SelectedTrendMetricKey);
 
+        public IReadOnlyList<GradientHistorySample> GetGradientHistorySnapshot()
+        {
+            lock (_gradientLock)
+            {
+                return _gradientHistory
+                    .Select(sample => new GradientHistorySample(sample.Iteration,
+                                                                  sample.GetVectorCopy(),
+                                                                  sample.Norm,
+                                                                  sample.FrameIndex))
+                    .ToList();
+            }
+        }
+
+        public GradientHistorySample? GetGradientSample(int index)
+        {
+            lock (_gradientLock)
+            {
+                if (index < 0 || index >= _gradientHistory.Count)
+                    return null;
+
+                var sample = _gradientHistory[index];
+                return new GradientHistorySample(sample.Iteration,
+                                                 sample.GetVectorCopy(),
+                                                 sample.Norm,
+                                                 sample.FrameIndex);
+            }
+        }
+
+        public int SelectedGradientIndex
+        {
+            get
+            {
+                lock (_gradientLock)
+                {
+                    return _selectedGradientIndex;
+                }
+            }
+        }
+
+        public int GradientHistoryCount
+        {
+            get
+            {
+                lock (_gradientLock)
+                {
+                    return _gradientHistory.Count;
+                }
+            }
+        }
+
+        public void SetSelectedGradientIndex(int index)
+        {
+            if (index < -1)
+                return;
+
+            bool changed = false;
+            lock (_gradientLock)
+            {
+                if (index >= _gradientHistory.Count)
+                    return;
+
+                if (_selectedGradientIndex == index)
+                    return;
+
+                _selectedGradientIndex = index;
+                changed = true;
+            }
+
+            if (changed)
+                GradientSelectionChanged?.Invoke(this, index);
+        }
+
+        public void SnapGradientSelectionToFrame(int frameIndex)
+        {
+            if (frameIndex < 0)
+                frameIndex = 0;
+
+            int targetIndex;
+            lock (_gradientLock)
+            {
+                if (_gradientHistory.Count == 0)
+                    return;
+
+                targetIndex = -1;
+                for (int i = 0; i < _gradientHistory.Count; i++)
+                {
+                    if (_gradientHistory[i].FrameIndex <= frameIndex)
+                        targetIndex = i;
+                    else
+                        break;
+                }
+
+                if (targetIndex < 0)
+                    targetIndex = 0;
+
+                if (targetIndex == _selectedGradientIndex)
+                    return;
+
+                _selectedGradientIndex = targetIndex;
+            }
+
+            GradientSelectionChanged?.Invoke(this, targetIndex);
+        }
+
         public void ResetReconstructionMetrics()
         {
             ResetMetricsCore();
@@ -550,6 +661,8 @@ namespace ElectricalImpedanceTomography.ViewModels
             _hasPendingTrendUpdate = false;
             _reconstructionStopwatch.Reset();
 
+            ClearGradientHistory();
+
             RaiseSelectedTrendMetricHistoryChanged();
 
             lock (_metricUpdateLock)
@@ -566,6 +679,28 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
 
             ResetDynamicMetrics();
+        }
+
+        private void ClearGradientHistory()
+        {
+            bool hadHistory;
+            int previousIndex;
+            lock (_gradientLock)
+            {
+                hadHistory = _gradientHistory.Count > 0;
+                previousIndex = _selectedGradientIndex;
+                _gradientHistory.Clear();
+                _gradientElementOrder = null;
+                _gradientElementIndexMap = null;
+                _previousGradientSnapshot = null;
+                _selectedGradientIndex = -1;
+            }
+
+            if (hadHistory || previousIndex != -1)
+            {
+                GradientHistoryChanged?.Invoke(this, EventArgs.Empty);
+                GradientSelectionChanged?.Invoke(this, -1);
+            }
         }
 
         private void ResetDynamicMetrics()
@@ -880,6 +1015,8 @@ namespace ElectricalImpedanceTomography.ViewModels
                             {
                                 _previousGradientSnapshot = fieldMetrics.GradientSnapshot;
                             }
+
+                            RecordGradientSnapshot(fieldMetrics);
                         }
                     }
                 });
@@ -1106,6 +1243,58 @@ namespace ElectricalImpedanceTomography.ViewModels
                                     regularizationRange,
                                     regularizationEnergy,
                                     gradientSnapshot);
+        }
+
+        private void RecordGradientSnapshot(FieldMetrics fieldMetrics)
+        {
+            if (fieldMetrics.GradientSnapshot == null || fieldMetrics.GradientSnapshot.Count == 0)
+                return;
+
+            int selectedIndex;
+
+            lock (_gradientLock)
+            {
+                var snapshot = fieldMetrics.GradientSnapshot;
+
+                if (_gradientElementOrder is null || _gradientElementIndexMap is null)
+                {
+                    _gradientElementOrder = snapshot.Keys.ToList();
+                    _gradientElementIndexMap = new Dictionary<int, int>(_gradientElementOrder.Count);
+                    for (int i = 0; i < _gradientElementOrder.Count; i++)
+                        _gradientElementIndexMap[_gradientElementOrder[i]] = i;
+                }
+                else
+                {
+                    foreach (var key in snapshot.Keys)
+                    {
+                        if (!_gradientElementIndexMap.ContainsKey(key))
+                        {
+                            _gradientElementIndexMap[key] = _gradientElementOrder.Count;
+                            _gradientElementOrder.Add(key);
+                        }
+                    }
+                }
+
+                if (_gradientElementOrder is null)
+                    return;
+
+                double[] vector = new double[_gradientElementOrder.Count];
+                for (int i = 0; i < _gradientElementOrder.Count; i++)
+                {
+                    int key = _gradientElementOrder[i];
+                    snapshot.TryGetValue(key, out double value);
+                    vector[i] = value;
+                }
+
+                int frameIndex = Math.Max(Workspace.GetReconstructionFrames().Count - 1, 0);
+                var sample = new GradientHistorySample(IterationCount, vector, fieldMetrics.GradientNorm, frameIndex);
+                _gradientHistory.Add(sample);
+                _selectedGradientIndex = _gradientHistory.Count - 1;
+                selectedIndex = _selectedGradientIndex;
+            }
+
+            GradientHistoryChanged?.Invoke(this, EventArgs.Empty);
+            GradientSelectionChanged?.Invoke(this, selectedIndex);
         }
 
         private static double ComputeGradientAngle(Dictionary<int, double> previous, Dictionary<int, double> current)
@@ -2055,6 +2244,41 @@ namespace ElectricalImpedanceTomography.ViewModels
                 return;
 
             SelectedTrendMetricKey = metricKey;
+        }
+
+        [RelayCommand]
+        private void RequestGradientInspection(string metricKey)
+        {
+            if (string.IsNullOrWhiteSpace(metricKey))
+                return;
+
+            if (metricKey == MetricKeys.GradientNorm
+                || metricKey == MetricKeys.GradientAngleChange
+                || metricKey == MetricKeys.PotentialRange
+                || metricKey == MetricKeys.AdjointRange)
+            {
+                GradientInspectionRequested?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        public sealed class GradientHistorySample
+        {
+            private readonly double[] _vector;
+
+            public GradientHistorySample(int iteration, double[] vector, double norm, int frameIndex)
+            {
+                Iteration = iteration;
+                _vector = vector;
+                Norm = norm;
+                FrameIndex = frameIndex;
+            }
+
+            public int Iteration { get; }
+            public double Norm { get; }
+            public int FrameIndex { get; }
+            public IReadOnlyList<double> Vector => Array.AsReadOnly(_vector);
+
+            internal double[] GetVectorCopy() => (double[])_vector.Clone();
         }
 
         private readonly record struct ReconstructionParametersSnapshot(

--- a/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml
+++ b/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+               xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+               xmlns:skia="clr-namespace:SkiaSharp.Views.Maui.Controls;assembly=SkiaSharp.Views.Maui.Controls"
+               x:Class="ElectricalImpedanceTomography.Views.GradientInspectionPopup"
+               Size="640,480"
+               CanBeDismissedByTappingOutside="True">
+    <Grid RowDefinitions="Auto,*,Auto"
+          BackgroundColor="{AppThemeBinding Light=#1E2A3C, Dark=#0C101A}">
+        <Grid Row="0"
+              ColumnDefinitions="*,Auto"
+              Padding="16"
+              BackgroundColor="{AppThemeBinding Light=#24354F, Dark=#141B2A}">
+            <Label Text="Gradient Trajectory"
+                   FontAttributes="Bold"
+                   FontSize="18"
+                   TextColor="#F0F4FF"
+                   VerticalOptions="Center"/>
+            <HorizontalStackLayout Grid.Column="1"
+                                    Spacing="12"
+                                    VerticalOptions="Center">
+                <Label x:Name="SelectionLabel"
+                       Text="No gradient data yet"
+                       TextColor="#A8B6D6"
+                       VerticalOptions="Center"/>
+                <Button Text="Reset View"
+                        Clicked="OnResetViewClicked"
+                        BackgroundColor="#2C3D59"
+                        TextColor="#E5EEFF"
+                        Padding="16,8"
+                        FontSize="12"
+                        CornerRadius="8"/>
+            </HorizontalStackLayout>
+        </Grid>
+        <Grid Row="1" Padding="16">
+            <Border StrokeShape="RoundRectangle 16"
+                    StrokeThickness="1"
+                    Stroke="#2F405C"
+                    BackgroundColor="{AppThemeBinding Light=#0F1724, Dark=#070B12}">
+                <Grid>
+                    <skia:SKCanvasView x:Name="GradientCanvas"
+                                       PaintSurface="OnGradientCanvasPaintSurface"
+                                       EnableTouchEvents="True"
+                                       Touch="OnGradientCanvasTouch"/>
+                    <Label x:Name="EmptyStateLabel"
+                           Text="Gradient samples will appear here as the reconstruction progresses."
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center"
+                           TextColor="#A8B6D6"
+                           FontSize="14"
+                           HorizontalTextAlignment="Center"
+                           Margin="24"
+                           IsVisible="False"/>
+                </Grid>
+            </Border>
+        </Grid>
+        <Grid Row="2"
+              ColumnDefinitions="Auto,*,Auto"
+              Padding="16,8,16,16"
+              ColumnSpacing="12">
+            <Label Text="Zoom"
+                   TextColor="#F0F4FF"
+                   VerticalOptions="Center"/>
+            <Slider x:Name="ZoomSlider"
+                    Grid.Column="1"
+                    Minimum="1"
+                    Maximum="12"
+                    ValueChanged="OnZoomSliderValueChanged"/>
+            <Label x:Name="ZoomValueLabel"
+                   Grid.Column="2"
+                   Text="1.0×"
+                   TextColor="#A8B6D6"
+                   VerticalOptions="Center"/>
+        </Grid>
+    </Grid>
+</toolkit:Popup>

--- a/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml.cs
@@ -1,0 +1,568 @@
+using CommunityToolkit.Maui.Views;
+using ElectricalImpedanceTomography.ViewModels;
+using Microsoft.Maui.ApplicationModel;
+using SkiaSharp;
+using SkiaSharp.Views.Maui;
+using SkiaSharp.Views.Maui.Controls;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+namespace ElectricalImpedanceTomography.Views;
+
+public partial class GradientInspectionPopup : Popup
+{
+    private readonly ReconstructionPageViewModel _viewModel;
+    private readonly List<ReconstructionPageViewModel.GradientHistorySample> _samples = new();
+    private readonly List<Point3D> _points = new();
+    private readonly List<(int Index, SKPoint Point)> _projectedPoints = new();
+
+    private float _trajectoryRadius = 1f;
+    private float _planeY;
+    private float _cameraDistance;
+    private float _defaultCameraDistance = 5f;
+    private float _yaw = 45f;
+    private float _pitch = 20f;
+    private float _projectionScale = 1f;
+    private bool _isDragging;
+    private SKPoint? _lastDragPoint;
+    private int _selectedIndex = -1;
+
+    private readonly record struct Point3D(float X, float Y, float Z, int Iteration, double Norm);
+
+    public GradientInspectionPopup(ReconstructionPageViewModel viewModel)
+    {
+        InitializeComponent();
+        _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
+
+        LoadData();
+        UpdateSelection(_viewModel.SelectedGradientIndex);
+
+        _viewModel.GradientHistoryChanged += OnGradientHistoryChanged;
+        _viewModel.GradientSelectionChanged += OnExternalSelectionChanged;
+        Closed += OnPopupClosed;
+    }
+
+    private void OnPopupClosed(object? sender, PopupClosedEventArgs e)
+    {
+        Closed -= OnPopupClosed;
+        _viewModel.GradientHistoryChanged -= OnGradientHistoryChanged;
+        _viewModel.GradientSelectionChanged -= OnExternalSelectionChanged;
+    }
+
+    private void OnGradientHistoryChanged(object? sender, EventArgs e)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            LoadData();
+            GradientCanvas.InvalidateSurface();
+        });
+    }
+
+    private void OnExternalSelectionChanged(object? sender, int index)
+    {
+        MainThread.BeginInvokeOnMainThread(() => UpdateSelection(index));
+    }
+
+    private void LoadData()
+    {
+        var history = _viewModel.GetGradientHistorySnapshot();
+        _samples.Clear();
+        _samples.AddRange(history);
+
+        RebuildTrajectory();
+
+        if (_samples.Count == 0)
+        {
+            UpdateSelection(-1);
+        }
+        else
+        {
+            int selected = _viewModel.SelectedGradientIndex;
+            if (selected < 0 || selected >= _samples.Count)
+                selected = _samples.Count - 1;
+            UpdateSelection(selected);
+        }
+    }
+
+    private void RebuildTrajectory()
+    {
+        _points.Clear();
+
+        if (_samples.Count == 0)
+        {
+            EmptyStateLabel.IsVisible = true;
+            _trajectoryRadius = 1f;
+            _planeY = 0f;
+            _cameraDistance = Math.Max(_cameraDistance, _defaultCameraDistance);
+            UpdateZoomSlider();
+            return;
+        }
+
+        EmptyStateLabel.IsVisible = false;
+
+        int dimension = _samples[0].Vector.Count;
+        if (dimension <= 0)
+            dimension = 1;
+
+        var mean = new double[dimension];
+        foreach (var sample in _samples)
+        {
+            int length = Math.Min(sample.Vector.Count, dimension);
+            for (int i = 0; i < length; i++)
+                mean[i] += sample.Vector[i];
+        }
+        for (int i = 0; i < dimension; i++)
+            mean[i] /= _samples.Count;
+
+        var centered = new List<double[]>(_samples.Count);
+        for (int i = 0; i < _samples.Count; i++)
+        {
+            var vec = _samples[i].GetVectorCopy();
+            if (vec.Length < dimension)
+                Array.Resize(ref vec, dimension);
+            for (int j = 0; j < dimension; j++)
+                vec[j] -= mean[j];
+            centered.Add(vec);
+        }
+
+        var basis = BuildOrthonormalBasis(centered, dimension);
+
+        double maxRadius = 0.0;
+        double minY = double.MaxValue;
+
+        for (int i = 0; i < centered.Count; i++)
+        {
+            var c = centered[i];
+            double x = basis.Count > 0 ? Dot(c, basis[0]) : 0.0;
+            double y = basis.Count > 1 ? Dot(c, basis[1]) : 0.0;
+            double z = basis.Count > 2 ? Dot(c, basis[2]) : 0.0;
+
+            var point = new Point3D((float)x, (float)y, (float)z, _samples[i].Iteration, _samples[i].Norm);
+            _points.Add(point);
+
+            double radius = Math.Sqrt(x * x + y * y + z * z);
+            if (radius > maxRadius)
+                maxRadius = radius;
+            if (y < minY)
+                minY = y;
+        }
+
+        _trajectoryRadius = maxRadius > 1e-6 ? (float)maxRadius : 1f;
+        _planeY = (float)(minY - 0.2 * _trajectoryRadius);
+        _defaultCameraDistance = Math.Max(_trajectoryRadius * 3f, 4f);
+        if (_cameraDistance <= 0f)
+            _cameraDistance = _defaultCameraDistance;
+
+        UpdateZoomSlider();
+        GradientCanvas.InvalidateSurface();
+    }
+
+    private void UpdateSelection(int index)
+    {
+        if (index < 0 || index >= _samples.Count)
+        {
+            _selectedIndex = -1;
+            SelectionLabel.Text = _samples.Count == 0
+                ? "No gradient data yet"
+                : "Select a sample to inspect";
+            GradientCanvas.InvalidateSurface();
+            return;
+        }
+
+        if (_selectedIndex == index)
+            return;
+
+        _selectedIndex = index;
+        var sample = _samples[index];
+        SelectionLabel.Text = $"Iteration {sample.Iteration}: ‖∇J‖ = {sample.Norm:F4}";
+        GradientCanvas.InvalidateSurface();
+    }
+
+    private void UpdateZoomSlider()
+    {
+        double minDistance = Math.Max(_trajectoryRadius * 0.8f, 1.0f);
+        double maxDistance = Math.Max(_trajectoryRadius * 8f, minDistance + 0.5f);
+
+        ZoomSlider.Minimum = minDistance;
+        ZoomSlider.Maximum = maxDistance;
+
+        if (_cameraDistance < minDistance || _cameraDistance > maxDistance)
+            _cameraDistance = (float)Math.Clamp(_cameraDistance, minDistance, maxDistance);
+
+        ZoomSlider.Value = _cameraDistance;
+        ZoomSlider.IsEnabled = _samples.Count > 0;
+        UpdateZoomLabel();
+    }
+
+    private void UpdateZoomLabel()
+    {
+        float normalized = _trajectoryRadius > 1e-4f ? _cameraDistance / _trajectoryRadius : _cameraDistance;
+        ZoomValueLabel.Text = $"{normalized:0.0}×";
+    }
+
+    private void OnZoomSliderValueChanged(object? sender, ValueChangedEventArgs e)
+    {
+        _cameraDistance = (float)e.NewValue;
+        UpdateZoomLabel();
+        GradientCanvas.InvalidateSurface();
+    }
+
+    private void OnResetViewClicked(object? sender, EventArgs e)
+    {
+        _yaw = 45f;
+        _pitch = 20f;
+        _cameraDistance = _defaultCameraDistance;
+        UpdateZoomSlider();
+        GradientCanvas.InvalidateSurface();
+    }
+
+    private void OnGradientCanvasPaintSurface(object? sender, SKPaintSurfaceEventArgs e)
+    {
+        var canvas = e.Surface.Canvas;
+        var info = e.Info;
+
+        canvas.Clear(SKColor.Parse("#0B111C"));
+
+        if (_points.Count == 0)
+            return;
+
+        _projectionScale = Math.Min(info.Width, info.Height) * 0.6f;
+
+        var viewport = new SKRect(0, 0, info.Width, info.Height);
+        var (cameraPosition, forward, right, up) = GetCameraFrame();
+
+        DrawGroundPlane(canvas, viewport, cameraPosition, forward, right, up);
+        DrawAxes(canvas, viewport, cameraPosition, forward, right, up);
+
+        _projectedPoints.Clear();
+        using var path = new SKPath();
+        bool started = false;
+
+        var linePaint = new SKPaint
+        {
+            Style = SKPaintStyle.Stroke,
+            Color = SKColor.Parse("#3A9CED"),
+            StrokeWidth = 2f,
+            IsAntialias = true
+        };
+
+        foreach (var point in _points.Select((p, i) => (Index: i, Point: p)))
+        {
+            var projected = ProjectPoint(point.Point, viewport, cameraPosition, forward, right, up);
+            if (projected.HasValue)
+            {
+                var pt = projected.Value;
+                _projectedPoints.Add((point.Index, pt));
+                if (!started)
+                {
+                    path.MoveTo(pt);
+                    started = true;
+                }
+                else
+                {
+                    path.LineTo(pt);
+                }
+            }
+        }
+
+        if (started)
+            canvas.DrawPath(path, linePaint);
+
+        using var pointPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = SKColor.Parse("#E3EDFF"), IsAntialias = true };
+        using var selectedPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = SKColor.Parse("#FFD166"), IsAntialias = true };
+        using var outlinePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = SKColors.White, StrokeWidth = 2f, IsAntialias = true };
+
+        foreach (var (index, pt) in _projectedPoints)
+        {
+            float radius = index == _selectedIndex ? 6f : 4f;
+            canvas.DrawCircle(pt, radius, index == _selectedIndex ? selectedPaint : pointPaint);
+            if (index == _selectedIndex)
+                canvas.DrawCircle(pt, radius + 2f, outlinePaint);
+        }
+    }
+
+    private void OnGradientCanvasTouch(object? sender, SKTouchEventArgs e)
+    {
+        switch (e.ActionType)
+        {
+            case SKTouchAction.Pressed:
+                _isDragging = true;
+                _lastDragPoint = e.Location;
+                e.Handled = true;
+                break;
+            case SKTouchAction.Moved:
+                if (_isDragging && _lastDragPoint.HasValue)
+                {
+                    var delta = e.Location - _lastDragPoint.Value;
+                    _yaw += delta.X * 0.4f;
+                    _pitch = Math.Clamp(_pitch - delta.Y * 0.4f, -80f, 80f);
+                    _lastDragPoint = e.Location;
+                    GradientCanvas.InvalidateSurface();
+                }
+                e.Handled = true;
+                break;
+            case SKTouchAction.Released:
+            case SKTouchAction.Cancelled:
+                if (_isDragging && _lastDragPoint.HasValue)
+                {
+                    var totalDx = e.Location.X - _lastDragPoint.Value.X;
+                    var totalDy = e.Location.Y - _lastDragPoint.Value.Y;
+                    float dragDistance = MathF.Sqrt(totalDx * totalDx + totalDy * totalDy);
+                    if (dragDistance < 12f)
+                        TrySelectPoint(e.Location);
+                }
+                _isDragging = false;
+                _lastDragPoint = null;
+                e.Handled = true;
+                break;
+            case SKTouchAction.WheelChanged:
+                AdjustZoom(1f - (float)e.WheelDelta * 0.1f);
+                e.Handled = true;
+                break;
+        }
+    }
+
+    private void AdjustZoom(float factor)
+    {
+        if (_samples.Count == 0)
+            return;
+
+        float min = (float)ZoomSlider.Minimum;
+        float max = (float)ZoomSlider.Maximum;
+        float newDistance = Math.Clamp(_cameraDistance * factor, min, max);
+        _cameraDistance = newDistance;
+        ZoomSlider.Value = newDistance;
+        UpdateZoomLabel();
+        GradientCanvas.InvalidateSurface();
+    }
+
+    private void TrySelectPoint(SKPoint location)
+    {
+        if (_projectedPoints.Count == 0)
+            return;
+
+        float threshold = 18f;
+        int bestIndex = -1;
+        float bestDistance = float.MaxValue;
+
+        foreach (var (index, point) in _projectedPoints)
+        {
+            float dx = point.X - location.X;
+            float dy = point.Y - location.Y;
+            float dist = MathF.Sqrt(dx * dx + dy * dy);
+            if (dist < bestDistance)
+            {
+                bestDistance = dist;
+                bestIndex = index;
+            }
+        }
+
+        if (bestIndex >= 0 && bestDistance <= threshold)
+            _viewModel.SetSelectedGradientIndex(bestIndex);
+    }
+
+    private (Vector3 Position, Vector3 Forward, Vector3 Right, Vector3 Up) GetCameraFrame()
+    {
+        float yawRad = DegreesToRadians(_yaw);
+        float pitchRad = DegreesToRadians(_pitch);
+        float distance = Math.Max(_cameraDistance, 0.5f);
+
+        var position = new Vector3(
+            distance * MathF.Cos(pitchRad) * MathF.Sin(yawRad),
+            distance * MathF.Sin(pitchRad),
+            distance * MathF.Cos(pitchRad) * MathF.Cos(yawRad));
+
+        var forward = Vector3.Normalize(-position);
+        var right = Vector3.Normalize(Vector3.Cross(forward, Vector3.UnitY));
+        if (right.LengthSquared() < 1e-6f)
+            right = Vector3.UnitX;
+        var up = Vector3.Normalize(Vector3.Cross(right, forward));
+
+        return (position, forward, right, up);
+    }
+
+    private SKPoint? ProjectPoint(Point3D point,
+                                  SKRect viewport,
+                                  Vector3 cameraPosition,
+                                  Vector3 forward,
+                                  Vector3 right,
+                                  Vector3 up)
+    {
+        var world = new Vector3(point.X, point.Y, point.Z);
+        var diff = world - cameraPosition;
+
+        float viewX = Vector3.Dot(diff, right);
+        float viewY = Vector3.Dot(diff, up);
+        float viewZ = Vector3.Dot(diff, forward);
+
+        if (viewZ <= 0.05f)
+            return null;
+
+        float perspective = _projectionScale / viewZ;
+        float screenX = viewport.MidX + viewX * perspective;
+        float screenY = viewport.MidY - viewY * perspective;
+        return new SKPoint(screenX, screenY);
+    }
+
+    private void DrawGroundPlane(SKCanvas canvas,
+                                 SKRect viewport,
+                                 Vector3 cameraPosition,
+                                 Vector3 forward,
+                                 Vector3 right,
+                                 Vector3 up)
+    {
+        float size = Math.Max(_trajectoryRadius * 2.5f, 2f);
+        int divisions = 6;
+
+        using var fillPaint = new SKPaint { Style = SKPaintStyle.Fill, Color = new SKColor(24, 32, 48, 120) };
+        using var strokePaint = new SKPaint { Style = SKPaintStyle.Stroke, Color = new SKColor(64, 82, 110, 120), StrokeWidth = 1f, IsAntialias = true };
+
+        var corners = new[]
+        {
+            ProjectPoint(new Point3D(-size, _planeY, -size, 0, 0), viewport, cameraPosition, forward, right, up),
+            ProjectPoint(new Point3D(size, _planeY, -size, 0, 0), viewport, cameraPosition, forward, right, up),
+            ProjectPoint(new Point3D(size, _planeY, size, 0, 0), viewport, cameraPosition, forward, right, up),
+            ProjectPoint(new Point3D(-size, _planeY, size, 0, 0), viewport, cameraPosition, forward, right, up)
+        };
+
+        if (corners.All(p => p.HasValue))
+        {
+            using var planePath = new SKPath();
+            planePath.MoveTo(corners[0]!.Value);
+            planePath.LineTo(corners[1]!.Value);
+            planePath.LineTo(corners[2]!.Value);
+            planePath.LineTo(corners[3]!.Value);
+            planePath.Close();
+            canvas.DrawPath(planePath, fillPaint);
+            canvas.DrawPath(planePath, strokePaint);
+        }
+
+        for (int i = -divisions; i <= divisions; i++)
+        {
+            float t = size * i / divisions;
+            var startX = ProjectPoint(new Point3D(t, _planeY, -size, 0, 0), viewport, cameraPosition, forward, right, up);
+            var endX = ProjectPoint(new Point3D(t, _planeY, size, 0, 0), viewport, cameraPosition, forward, right, up);
+            if (startX.HasValue && endX.HasValue)
+                canvas.DrawLine(startX.Value, endX.Value, strokePaint);
+
+            var startZ = ProjectPoint(new Point3D(-size, _planeY, t, 0, 0), viewport, cameraPosition, forward, right, up);
+            var endZ = ProjectPoint(new Point3D(size, _planeY, t, 0, 0), viewport, cameraPosition, forward, right, up);
+            if (startZ.HasValue && endZ.HasValue)
+                canvas.DrawLine(startZ.Value, endZ.Value, strokePaint);
+        }
+    }
+
+    private void DrawAxes(SKCanvas canvas,
+                          SKRect viewport,
+                          Vector3 cameraPosition,
+                          Vector3 forward,
+                          Vector3 right,
+                          Vector3 up)
+    {
+        float length = Math.Max(_trajectoryRadius * 1.2f, 1.2f);
+        var origin = ProjectPoint(new Point3D(0, 0, 0, 0, 0), viewport, cameraPosition, forward, right, up);
+        if (!origin.HasValue)
+            return;
+
+        using var axisPaint = new SKPaint { Style = SKPaintStyle.Stroke, StrokeWidth = 2f, IsAntialias = true };
+
+        var axes = new (Point3D Point, SKColor Color)[]
+        {
+            (new Point3D(length, 0, 0, 0, 0), SKColor.Parse("#FF6B6B")),
+            (new Point3D(0, length, 0, 0, 0), SKColor.Parse("#6BFF95")),
+            (new Point3D(0, 0, length, 0, 0), SKColor.Parse("#4D9CFF"))
+        };
+
+        foreach (var (point, color) in axes)
+        {
+            var projected = ProjectPoint(point, viewport, cameraPosition, forward, right, up);
+            if (projected.HasValue)
+            {
+                axisPaint.Color = color;
+                canvas.DrawLine(origin.Value, projected.Value, axisPaint);
+            }
+        }
+    }
+
+    private static List<double[]> BuildOrthonormalBasis(List<double[]> vectors, int dimension)
+    {
+        var basis = new List<double[]>();
+
+        foreach (var vector in vectors)
+        {
+            var residual = (double[])vector.Clone();
+            foreach (var existing in basis)
+                SubtractProjection(residual, existing);
+
+            double norm = Norm(residual);
+            if (norm > 1e-9)
+            {
+                Scale(residual, 1.0 / norm);
+                basis.Add(residual);
+                if (basis.Count == 3)
+                    break;
+            }
+        }
+
+        for (int axis = 0; basis.Count < 3 && axis < dimension; axis++)
+        {
+            var candidate = new double[dimension];
+            candidate[axis] = 1.0;
+            foreach (var existing in basis)
+                SubtractProjection(candidate, existing);
+
+            double norm = Norm(candidate);
+            if (norm > 1e-9)
+            {
+                Scale(candidate, 1.0 / norm);
+                basis.Add(candidate);
+            }
+        }
+
+        while (basis.Count < 3)
+        {
+            var fallback = new double[dimension];
+            if (dimension > 0)
+                fallback[0] = 1.0;
+            basis.Add(fallback);
+        }
+
+        return basis;
+    }
+
+    private static void SubtractProjection(double[] vector, double[] basis)
+    {
+        double dot = Dot(vector, basis);
+        for (int i = 0; i < vector.Length; i++)
+            vector[i] -= dot * basis[i];
+    }
+
+    private static double Norm(double[] vector) => Math.Sqrt(Dot(vector, vector));
+
+    private static void Scale(double[] vector, double factor)
+    {
+        for (int i = 0; i < vector.Length; i++)
+            vector[i] *= factor;
+    }
+
+    private static double Dot(IReadOnlyList<double> a, double[] b)
+    {
+        double sum = 0.0;
+        int length = Math.Min(a.Count, b.Length);
+        for (int i = 0; i < length; i++)
+            sum += a[i] * b[i];
+        return sum;
+    }
+
+    private static double Dot(double[] a, double[] b)
+    {
+        double sum = 0.0;
+        int length = Math.Min(a.Length, b.Length);
+        for (int i = 0; i < length; i++)
+            sum += a[i] * b[i];
+        return sum;
+    }
+
+    private static float DegreesToRadians(float degrees) => (float)(Math.PI / 180.0) * degrees;
+}

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -575,6 +575,9 @@
                                                             <Border.GestureRecognizers>
                                                                 <TapGestureRecognizer Command="{Binding Source={x:Reference ReconstructionPageRoot}, Path=BindingContext.SelectTrendMetricCommand}"
                                                                                       CommandParameter="{Binding Key}"/>
+                                                                <TapGestureRecognizer NumberOfTapsRequired="2"
+                                                                                      Command="{Binding Source={x:Reference ReconstructionPageRoot}, Path=BindingContext.RequestGradientInspectionCommand}"
+                                                                                      CommandParameter="{Binding Key}"/>
                                                             </Border.GestureRecognizers>
                                                             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
                                                                 <Label Text="{Binding Name}" FontAttributes="Italic" FontSize="12" TextColor="#9DAAD3">

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -28,6 +28,7 @@ public partial class ReconstructionPage : ContentPage
 
     private ReconstructionResult? _currentResult;
     private ReconstructionFrame? _currentFrame;
+    private GradientInspectionPopup? _gradientPopup;
 
     // FEM transform helpers
     private float _scale, _marginX, _marginY, _meshWidth, _meshHeight, _minX, _minY, _canvasHeight;
@@ -114,6 +115,8 @@ public partial class ReconstructionPage : ContentPage
         _viewModel.ReconstructionUpdated += OnReconstructionUpdated;
         _viewModel.ReconstructionFrameUpdated += OnReconstructionFrameUpdated;
         _viewModel.SelectedTrendMetricHistoryChanged += OnSelectedTrendMetricHistoryChanged;
+        _viewModel.GradientInspectionRequested += OnGradientInspectionRequested;
+        _viewModel.GradientSelectionChanged += OnGradientSelectionChanged;
 
         StepButton.IsEnabled = false;
         PlayButton.IsVisible = true;
@@ -323,6 +326,48 @@ public partial class ReconstructionPage : ContentPage
 
     private void OnSelectedTrendMetricHistoryChanged(object? sender, EventArgs e)
         => MainThread.BeginInvokeOnMainThread(() => MetricTrendCanvas.InvalidateSurface());
+
+    private async void OnGradientInspectionRequested(object? sender, EventArgs e)
+    {
+        if (_gradientPopup != null)
+            return;
+
+        var popup = new GradientInspectionPopup(_viewModel);
+        _gradientPopup = popup;
+        popup.Closed += OnGradientPopupClosed;
+        await this.ShowPopupAsync(popup);
+    }
+
+    private void OnGradientPopupClosed(object? sender, PopupClosedEventArgs e)
+    {
+        if (_gradientPopup is GradientInspectionPopup popup)
+        {
+            popup.Closed -= OnGradientPopupClosed;
+            _gradientPopup = null;
+        }
+    }
+
+    private void OnGradientSelectionChanged(object? sender, int index)
+    {
+        if (index < 0)
+            return;
+
+        var sample = _viewModel.GetGradientSample(index);
+        if (sample is null)
+            return;
+
+        Dispatcher.Dispatch(() =>
+        {
+            double target = sample.FrameIndex;
+            if (Math.Abs(PlaybackSlider.Value - target) < 0.01)
+                return;
+
+            _sliderChanging = true;
+            PlaybackSlider.Value = Math.Clamp(target, PlaybackSlider.Minimum, PlaybackSlider.Maximum);
+            _sliderChanging = false;
+            UpdatePlaybackLabel();
+        });
+    }
 
     #region Drawing helpers
     private void ComputeFemTransform(FEMMesh mesh, SKImageInfo info)
@@ -1545,6 +1590,8 @@ public partial class ReconstructionPage : ContentPage
                 _viewModel.Residual = CalculateResidual(res);
             }
             Dispatcher.Dispatch(() => { InvalidateAll(); UpdatePlaybackLabel(); });
+
+            _viewModel.SnapGradientSelectionToFrame(index);
         }
     }
 


### PR DESCRIPTION
## Summary
- track gradient history and expose selection events/commands in the reconstruction view model so the inspector can stay in sync
- wire the statistics panel to open a gradient inspector on double-tap and keep the playback slider aligned with gradient selections
- add a GradientInspectionPopup with an interactive 3D trajectory view, zoom controls, and synchronized sample highlighting

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69036ea6688c83339d6afb242dbd8866