### PR TITLE
Use accumulated gradients in viewer and simplify dense history rendering

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -959,7 +959,8 @@ namespace ElectricalImpedanceTomography.ViewModels
                 token.ThrowIfCancellationRequested();
 
                 frame ??= result?.Frames.LastOrDefault();
-                var fieldMetrics = ComputeFieldMetrics(frame, token);
+                var aggregatedGradient = result != null ? ComputeCycleGradient(result) : null;
+                var fieldMetrics = ComputeFieldMetrics(frame, aggregatedGradient, token);
 
                 token.ThrowIfCancellationRequested();
 
@@ -1204,12 +1205,17 @@ namespace ElectricalImpedanceTomography.ViewModels
             return new MeasurementMetrics(rmse, mae, mape, misfit);
         }
 
-        private FieldMetrics ComputeFieldMetrics(ReconstructionFrame? frame, CancellationToken token)
+        private FieldMetrics ComputeFieldMetrics(ReconstructionFrame? frame,
+                                                 Dictionary<int, double>? aggregatedGradient,
+                                                 CancellationToken token)
         {
             if (frame == null)
                 return FieldMetrics.Empty;
 
-            var gradient = frame.ConductivityGradient.Conductivities;
+            var gradient = aggregatedGradient ?? frame.ConductivityGradient.Conductivities;
+            if (gradient == null || gradient.Count == 0)
+                return FieldMetrics.Empty;
+
             double gradientNorm = 0.0;
             foreach (var kv in gradient)
             {
@@ -1219,15 +1225,16 @@ namespace ElectricalImpedanceTomography.ViewModels
             gradientNorm = Math.Sqrt(gradientNorm);
 
             double? gradientAngle = null;
-            Dictionary<int, double>? previous;
-            lock (_gradientLock)
+            if (aggregatedGradient != null)
             {
-                previous = _previousGradientSnapshot;
-            }
+                Dictionary<int, double>? previous;
+                lock (_gradientLock)
+                {
+                    previous = _previousGradientSnapshot;
+                }
 
-            if (previous != null && previous.Count > 0 && gradient.Count > 0)
-            {
-                gradientAngle = ComputeGradientAngle(previous, gradient);
+                if (previous != null && previous.Count > 0 && gradient.Count > 0)
+                    gradientAngle = ComputeGradientAngle(previous, gradient);
             }
 
             var potentialRange = ComputeRange(frame.CalculatedPotentialDistribution?.Potentials);
@@ -1235,7 +1242,9 @@ namespace ElectricalImpedanceTomography.ViewModels
             var regularizationRange = ComputeRange(frame.CalculatedRegularization?.Conductivities);
             double regularizationEnergy = ComputeRegularizationEnergy(frame.CalculatedRegularization?.Conductivities, token);
 
-            var gradientSnapshot = new Dictionary<int, double>(gradient);
+            var gradientSnapshot = aggregatedGradient != null
+                ? new Dictionary<int, double>(aggregatedGradient)
+                : null;
 
             return new FieldMetrics(true,
                                     gradientNorm,
@@ -1245,6 +1254,42 @@ namespace ElectricalImpedanceTomography.ViewModels
                                     regularizationRange,
                                     regularizationEnergy,
                                     gradientSnapshot);
+        }
+
+        private static Dictionary<int, double>? ComputeCycleGradient(ReconstructionResult result)
+        {
+            if (result.Frames.Count == 0)
+                return null;
+
+            var accumulator = new Dictionary<int, double>();
+            int contributingFrames = 0;
+
+            foreach (var frame in result.Frames)
+            {
+                var gradient = frame.ConductivityGradient?.Conductivities;
+                if (gradient == null || gradient.Count == 0)
+                    continue;
+
+                contributingFrames++;
+
+                foreach (var kvp in gradient)
+                {
+                    if (accumulator.TryGetValue(kvp.Key, out double existing))
+                        accumulator[kvp.Key] = existing + kvp.Value;
+                    else
+                        accumulator[kvp.Key] = kvp.Value;
+                }
+            }
+
+            if (accumulator.Count == 0 || contributingFrames == 0)
+                return null;
+
+            double scale = 1.0 / contributingFrames;
+            var keys = accumulator.Keys.ToArray();
+            foreach (var key in keys)
+                accumulator[key] *= scale;
+
+            return accumulator;
         }
 
         private void RecordGradientSnapshot(FieldMetrics fieldMetrics)

--- a/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml.cs
@@ -14,6 +14,7 @@ namespace ElectricalImpedanceTomography.Views;
 
 public partial class GradientInspectionPopup : Popup
 {
+    private const int SimplifiedArrowThreshold = 1000;
     private readonly ReconstructionPageViewModel _viewModel;
     private readonly List<ReconstructionPageViewModel.GradientHistorySample> _samples = new();
     private readonly List<Point3D> _points = new();
@@ -748,6 +749,12 @@ public partial class GradientInspectionPopup : Popup
         if (visibleLastIndex <= 0)
             return;
 
+        if (visibleLastIndex + 1 > SimplifiedArrowThreshold)
+        {
+            DrawSimplifiedGradientPath(canvas, projections, visibleLastIndex);
+            return;
+        }
+
         using var strokePaint = new SKPaint
         {
             Style = SKPaintStyle.Stroke,
@@ -804,6 +811,41 @@ public partial class GradientInspectionPopup : Popup
             headPaint.Color = color.WithAlpha(210);
             canvas.DrawPath(headPath, headPaint);
         }
+    }
+
+    private void DrawSimplifiedGradientPath(SKCanvas canvas,
+                                            IReadOnlyDictionary<int, SKPoint> projections,
+                                            int visibleLastIndex)
+    {
+        using var pathPaint = new SKPaint
+        {
+            Style = SKPaintStyle.Stroke,
+            IsAntialias = true,
+            StrokeWidth = 2.5f,
+            Color = AngleNeutralColor.WithAlpha(200)
+        };
+
+        using var path = new SKPath();
+        bool hasPoint = false;
+
+        for (int i = 0; i <= visibleLastIndex; i++)
+        {
+            if (!projections.TryGetValue(i, out var point))
+                continue;
+
+            if (!hasPoint)
+            {
+                path.MoveTo(point);
+                hasPoint = true;
+            }
+            else
+            {
+                path.LineTo(point);
+            }
+        }
+
+        if (hasPoint)
+            canvas.DrawPath(path, pathPaint);
     }
 
     private void DrawErrorValley(SKCanvas canvas,

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -29,6 +29,7 @@ public partial class ReconstructionPage : ContentPage
 
     private ReconstructionResult? _currentResult;
     private ReconstructionFrame? _currentFrame;
+    private ConductivityDistribution? _currentAggregatedGradient;
     private GradientInspectionPopup? _gradientPopup;
 
     // FEM transform helpers
@@ -283,6 +284,7 @@ public partial class ReconstructionPage : ContentPage
     {
         _currentResult = result;
         _currentFrame = result.Frames.LastOrDefault();
+        UpdateAggregatedGradient(result);
         var frames = Workspace.GetReconstructionFrames();
         Dispatcher.Dispatch(() =>
         {
@@ -995,7 +997,7 @@ public partial class ReconstructionPage : ContentPage
     private void OnGradientCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
         var discretization = GetDiscretization();
-        var cd = _currentFrame?.ConductivityGradient;
+        var cd = GetActiveGradientDistribution();
         if (discretization is FEMMesh fem && cd != null)
             DrawFemConductivity(e.Surface.Canvas, e.Info, fem, cd, _hoverGradientLines, _hoverGradientPt);
         else if (discretization is LBMGrid lbm && cd != null)
@@ -1098,7 +1100,7 @@ public partial class ReconstructionPage : ContentPage
 
     private void OnGradientColorbarPaintSurface(object sender, SKPaintSurfaceEventArgs e)
     {
-        var cd = _currentFrame?.ConductivityGradient;
+        var cd = GetActiveGradientDistribution();
         if (cd != null)
         {
             var discretization = GetDiscretization();
@@ -1334,7 +1336,7 @@ public partial class ReconstructionPage : ContentPage
             { _hoverGradientLines = null; _hoverGradientPt = null; view.InvalidateSurface(); e.Handled = true; return; }
             ComputeFemTransform(fem, new SKImageInfo((int)view.CanvasSize.Width, (int)view.CanvasSize.Height));
             _hoverGradientLines = null;
-            var cd = _currentFrame?.ConductivityGradient;
+            var cd = GetActiveGradientDistribution();
             if (cd != null)
             {
                 foreach (var elem in fem.GetElements().Cast<FEMElement>())
@@ -1361,7 +1363,7 @@ public partial class ReconstructionPage : ContentPage
             if (e.ActionType == SKTouchAction.Released)
             { _hoverGradientLines = null; _hoverGradientPt = null; view.InvalidateSurface(); e.Handled = true; return; }
             var el = lbm.GetElementAt(col, row);
-            var cd = _currentFrame?.ConductivityGradient;
+            var cd = GetActiveGradientDistribution();
             if (cd != null)
             {
                 double val = cd.Conductivities[el.Id];
@@ -1379,6 +1381,52 @@ public partial class ReconstructionPage : ContentPage
             Enum.GetNames(typeof(PotentialDisplayMode)));
         if (Enum.TryParse(choice, out PotentialDisplayMode mode))
             PotentialModePicker.SelectedIndex = (int)mode;
+    }
+
+    private void UpdateAggregatedGradient(ReconstructionResult? result)
+    {
+        _currentAggregatedGradient = BuildAggregatedGradient(result);
+    }
+
+    private static ConductivityDistribution? BuildAggregatedGradient(ReconstructionResult? result)
+    {
+        if (result == null || result.Frames.Count == 0)
+            return null;
+
+        var accumulator = new Dictionary<int, double>();
+        int contributingFrames = 0;
+
+        foreach (var frame in result.Frames)
+        {
+            var gradient = frame.ConductivityGradient?.Conductivities;
+            if (gradient == null || gradient.Count == 0)
+                continue;
+
+            contributingFrames++;
+
+            foreach (var kvp in gradient)
+            {
+                if (accumulator.TryGetValue(kvp.Key, out double existing))
+                    accumulator[kvp.Key] = existing + kvp.Value;
+                else
+                    accumulator[kvp.Key] = kvp.Value;
+            }
+        }
+
+        if (accumulator.Count == 0 || contributingFrames == 0)
+            return null;
+
+        double scale = 1.0 / contributingFrames;
+        var keys = accumulator.Keys.ToList();
+        foreach (var key in keys)
+            accumulator[key] *= scale;
+
+        return new ConductivityDistribution(accumulator);
+    }
+
+    private ConductivityDistribution? GetActiveGradientDistribution()
+    {
+        return _currentAggregatedGradient ?? _currentFrame?.ConductivityGradient;
     }
 
     private void InvalidateAll()
@@ -1526,6 +1574,7 @@ public partial class ReconstructionPage : ContentPage
             var frames = Workspace.GetReconstructionFrames();
 
             _currentFrame = frames.LastOrDefault();
+            UpdateAggregatedGradient(_currentResult);
 
             PlaybackSlider.Maximum = frames.Count > 0 ? frames.Count - 1 : 0;
             PlaybackSlider.Value = PlaybackSlider.Maximum;
@@ -1589,6 +1638,7 @@ public partial class ReconstructionPage : ContentPage
                 _currentResult = res;
                 _viewModel.IterationCount = iter;
                 _viewModel.Residual = CalculateResidual(res);
+                UpdateAggregatedGradient(res);
             }
             Dispatcher.Dispatch(() => { InvalidateAll(); UpdatePlaybackLabel(); });
 
@@ -1700,6 +1750,7 @@ public partial class ReconstructionPage : ContentPage
         // Clear current visuals to initial state
         _currentResult = null;
         _currentFrame = null;
+        _currentAggregatedGradient = null;
         PlaybackSlider.Maximum = 0;
         PlaybackSlider.Value = 0;
         UpdatePlaybackLabel();


### PR DESCRIPTION
## Summary
- compute per-iteration gradient averages for metrics and history instead of storing each frame sub-gradient
- update the reconstruction page to display the aggregated gradient across canvases, color bars, and hover details
- switch the gradient inspection popup to a lightweight polyline when more than 1000 steps are visible to avoid rendering hundreds of arrowheads

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_6903a257a2a4833393464dc6953cb28a