### PR TITLE
Aggregate gradient step rendering in inspection popup

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -264,6 +264,10 @@ namespace ElectricalImpedanceTomography.ViewModels
         private ReconstructionFrame? _latestFrame;
         private Dictionary<int, double>? _previousGradientSnapshot;
         private readonly List<GradientHistorySample> _gradientHistory = new();
+        private readonly List<(int FirstRawIndex, int LastRawIndex)> _collapsedGradientGroups = new();
+        private readonly List<int> _rawToCollapsedIndex = new();
+        private bool _collapsedGradientHistoryDirty = true;
+        private const double CollapsedGradientAngleToleranceDegrees = 12.0;
         private List<int>? _gradientElementOrder;
         private Dictionary<int, int>? _gradientElementIndexMap;
         private int _selectedGradientIndex = -1;
@@ -512,13 +516,25 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             lock (_gradientLock)
             {
-                return _gradientHistory
-                    .Select(sample => new GradientHistorySample(sample.Iteration,
-                                                                  sample.GetVectorCopy(),
-                                                                  sample.Norm,
-                                                                  sample.FrameIndex,
-                                                                  sample.Angle))
-                    .ToList();
+                EnsureCollapsedGradientHistoryLocked();
+
+                var collapsed = new List<GradientHistorySample>(_collapsedGradientGroups.Count);
+                foreach (var group in _collapsedGradientGroups)
+                {
+                    var first = _gradientHistory[group.FirstRawIndex];
+                    var last = _gradientHistory[group.LastRawIndex];
+                    int collapsedCount = group.LastRawIndex - group.FirstRawIndex + 1;
+
+                    collapsed.Add(new GradientHistorySample(last.Iteration,
+                                                             last.GetVectorCopy(),
+                                                             last.Norm,
+                                                             last.FrameIndex,
+                                                             last.Angle,
+                                                             first.Iteration,
+                                                             collapsedCount));
+                }
+
+                return collapsed;
             }
         }
 
@@ -526,15 +542,23 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             lock (_gradientLock)
             {
-                if (index < 0 || index >= _gradientHistory.Count)
+                EnsureCollapsedGradientHistoryLocked();
+
+                if (index < 0 || index >= _collapsedGradientGroups.Count)
                     return null;
 
-                var sample = _gradientHistory[index];
-                return new GradientHistorySample(sample.Iteration,
-                                                 sample.GetVectorCopy(),
-                                                 sample.Norm,
-                                                 sample.FrameIndex,
-                                                 sample.Angle);
+                var group = _collapsedGradientGroups[index];
+                var first = _gradientHistory[group.FirstRawIndex];
+                var last = _gradientHistory[group.LastRawIndex];
+                int collapsedCount = group.LastRawIndex - group.FirstRawIndex + 1;
+
+                return new GradientHistorySample(last.Iteration,
+                                                 last.GetVectorCopy(),
+                                                 last.Norm,
+                                                 last.FrameIndex,
+                                                 last.Angle,
+                                                 first.Iteration,
+                                                 collapsedCount);
             }
         }
 
@@ -555,7 +579,8 @@ namespace ElectricalImpedanceTomography.ViewModels
             {
                 lock (_gradientLock)
                 {
-                    return _gradientHistory.Count;
+                    EnsureCollapsedGradientHistoryLocked();
+                    return _collapsedGradientGroups.Count;
                 }
             }
         }
@@ -568,7 +593,9 @@ namespace ElectricalImpedanceTomography.ViewModels
             bool changed = false;
             lock (_gradientLock)
             {
-                if (index >= _gradientHistory.Count)
+                EnsureCollapsedGradientHistoryLocked();
+
+                if (index >= _collapsedGradientGroups.Count)
                     return;
 
                 if (_selectedGradientIndex == index)
@@ -593,17 +620,23 @@ namespace ElectricalImpedanceTomography.ViewModels
                 if (_gradientHistory.Count == 0)
                     return;
 
-                targetIndex = -1;
+                EnsureCollapsedGradientHistoryLocked();
+
+                int rawTarget = -1;
                 for (int i = 0; i < _gradientHistory.Count; i++)
                 {
                     if (_gradientHistory[i].FrameIndex <= frameIndex)
-                        targetIndex = i;
+                        rawTarget = i;
                     else
                         break;
                 }
 
-                if (targetIndex < 0)
-                    targetIndex = 0;
+                if (rawTarget < 0)
+                    rawTarget = 0;
+
+                targetIndex = rawTarget < _rawToCollapsedIndex.Count
+                    ? _rawToCollapsedIndex[rawTarget]
+                    : 0;
 
                 if (targetIndex == _selectedGradientIndex)
                     return;
@@ -612,6 +645,87 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
 
             GradientSelectionChanged?.Invoke(this, targetIndex);
+        }
+
+        private void EnsureCollapsedGradientHistoryLocked()
+        {
+            if (!_collapsedGradientHistoryDirty && _collapsedGradientGroups.Count > 0)
+            {
+                if (_rawToCollapsedIndex.Count == _gradientHistory.Count)
+                    return;
+            }
+
+            _collapsedGradientGroups.Clear();
+            _rawToCollapsedIndex.Clear();
+
+            if (_gradientHistory.Count == 0)
+            {
+                _collapsedGradientHistoryDirty = false;
+                return;
+            }
+
+            int groupStart = 0;
+            for (int i = 1; i < _gradientHistory.Count; i++)
+            {
+                var previous = _gradientHistory[i - 1];
+                var current = _gradientHistory[i];
+                double angle = ComputeGradientAngle(previous.Vector, current.Vector);
+                if (!double.IsFinite(angle))
+                    angle = 0.0;
+
+                if (angle > CollapsedGradientAngleToleranceDegrees)
+                {
+                    _collapsedGradientGroups.Add((groupStart, i - 1));
+                    groupStart = i;
+                }
+            }
+
+            _collapsedGradientGroups.Add((groupStart, _gradientHistory.Count - 1));
+
+            if (_rawToCollapsedIndex.Capacity < _gradientHistory.Count)
+                _rawToCollapsedIndex.Capacity = _gradientHistory.Count;
+
+            for (int i = 0; i < _gradientHistory.Count; i++)
+                _rawToCollapsedIndex.Add(-1);
+
+            for (int collapsedIndex = 0; collapsedIndex < _collapsedGradientGroups.Count; collapsedIndex++)
+            {
+                var group = _collapsedGradientGroups[collapsedIndex];
+                for (int rawIndex = group.FirstRawIndex; rawIndex <= group.LastRawIndex; rawIndex++)
+                    _rawToCollapsedIndex[rawIndex] = collapsedIndex;
+            }
+
+            _collapsedGradientHistoryDirty = false;
+        }
+
+        private static double ComputeGradientAngle(IReadOnlyList<double> previous, IReadOnlyList<double> current)
+        {
+            if (previous.Count == 0 || current.Count == 0)
+                return 0.0;
+
+            int length = Math.Min(previous.Count, current.Count);
+            double dot = 0.0;
+            double prevNorm = 0.0;
+            double currNorm = 0.0;
+
+            for (int i = 0; i < length; i++)
+            {
+                double a = previous[i];
+                double b = current[i];
+                dot += a * b;
+                prevNorm += a * a;
+                currNorm += b * b;
+            }
+
+            if (prevNorm <= double.Epsilon || currNorm <= double.Epsilon)
+                return 0.0;
+
+            double magnitude = Math.Sqrt(prevNorm * currNorm);
+            if (magnitude <= double.Epsilon)
+                return 0.0;
+
+            double cosine = Math.Clamp(dot / magnitude, -1.0, 1.0);
+            return Math.Acos(cosine) * (180.0 / Math.PI);
         }
 
         public void ResetReconstructionMetrics()
@@ -692,6 +806,9 @@ namespace ElectricalImpedanceTomography.ViewModels
                 hadHistory = _gradientHistory.Count > 0;
                 previousIndex = _selectedGradientIndex;
                 _gradientHistory.Clear();
+                _collapsedGradientGroups.Clear();
+                _rawToCollapsedIndex.Clear();
+                _collapsedGradientHistoryDirty = true;
                 _gradientElementOrder = null;
                 _gradientElementIndexMap = null;
                 _previousGradientSnapshot = null;
@@ -1293,9 +1410,13 @@ namespace ElectricalImpedanceTomography.ViewModels
                                                        vector,
                                                        fieldMetrics.GradientNorm,
                                                        frameIndex,
-                                                       fieldMetrics.GradientAngle);
+                                                       fieldMetrics.GradientAngle,
+                                                       IterationCount,
+                                                       1);
                 _gradientHistory.Add(sample);
-                _selectedGradientIndex = _gradientHistory.Count - 1;
+                _collapsedGradientHistoryDirty = true;
+                EnsureCollapsedGradientHistoryLocked();
+                _selectedGradientIndex = _collapsedGradientGroups.Count - 1;
                 selectedIndex = _selectedGradientIndex;
             }
 
@@ -2276,8 +2397,21 @@ namespace ElectricalImpedanceTomography.ViewModels
                                          double norm,
                                          int frameIndex,
                                          double? angle)
+                : this(iteration, vector, norm, frameIndex, angle, iteration, 1)
+            {
+            }
+
+            public GradientHistorySample(int iteration,
+                                         double[] vector,
+                                         double norm,
+                                         int frameIndex,
+                                         double? angle,
+                                         int firstIteration,
+                                         int collapsedCount)
             {
                 Iteration = iteration;
+                FirstIteration = Math.Min(firstIteration, iteration);
+                CollapsedCount = Math.Max(1, collapsedCount);
                 _vector = vector;
                 Norm = norm;
                 FrameIndex = frameIndex;
@@ -2285,9 +2419,12 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
 
             public int Iteration { get; }
+            public int FirstIteration { get; }
+            public int CollapsedCount { get; }
             public double Norm { get; }
             public int FrameIndex { get; }
             public double? Angle { get; }
+            public bool IsAggregated => CollapsedCount > 1;
             public IReadOnlyList<double> Vector => Array.AsReadOnly(_vector);
 
             internal double[] GetVectorCopy() => (double[])_vector.Clone();

--- a/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml.cs
@@ -281,7 +281,21 @@ public partial class GradientInspectionPopup : Popup
 
         _selectedIndex = index;
         var sample = _samples[index];
-        SelectionLabel.Text = $"Iteration {sample.Iteration}: ‖∇J‖ = {sample.Norm:F4}";
+        string iterationLabel;
+        if (sample.CollapsedCount > 1 && sample.FirstIteration != sample.Iteration)
+        {
+            iterationLabel = $"Iterations {sample.FirstIteration}–{sample.Iteration} ({sample.CollapsedCount} steps)";
+        }
+        else if (sample.CollapsedCount > 1)
+        {
+            iterationLabel = $"Iteration {sample.Iteration} ({sample.CollapsedCount} steps)";
+        }
+        else
+        {
+            iterationLabel = $"Iteration {sample.Iteration}";
+        }
+
+        SelectionLabel.Text = $"{iterationLabel}: ‖∇J‖ = {sample.Norm:F4}";
         UpdateNavigationButtons();
         UpdateValleySurface();
         GradientCanvas.InvalidateSurface();


### PR DESCRIPTION
## Summary
- collapse consecutive gradient samples with similar directions into grouped entries before exposing them to the popup
- keep selection, playback sync, and history counts aligned with the grouped data while exposing iteration range metadata
- update the gradient inspection popup label to reflect grouped iteration ranges for each rendered arrow

## Testing
- dotnet build (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_6903e6a73c0c8333bef6e20dfe3792a5