### PR TITLE
Refine gradient popup layout and surface fitting

### DIFF
--- a/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml
+++ b/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml
@@ -9,10 +9,10 @@
     <Border Stroke="Transparent" StrokeShape="RoundRectangle 10" BackgroundColor="Transparent">
         
 
-    <Grid RowDefinitions="Auto,*,Auto"
+    <Grid RowDefinitions="Auto,*"
           BackgroundColor="{AppThemeBinding Light=#1E2A3C, Dark=#0C101A}">
         <Grid Row="0"
-              ColumnDefinitions="Auto,*,Auto"
+              ColumnDefinitions="*,Auto"
               Padding="16"
               BackgroundColor="{AppThemeBinding Light=#24354F, Dark=#141B2A}">
             <Label Text="Gradient Trajectory"
@@ -25,55 +25,6 @@
             <HorizontalStackLayout Grid.Column="1"
                                     Spacing="12"
                                     VerticalOptions="Center">
-                <Image x:Name="PrevStepButton"
-                       Source="icon_next_player.png"
-                       HeightRequest="32"
-                       WidthRequest="32"
-                       Rotation="180"
-                       IsEnabled="False"
-                       Opacity="0.35">
-                    <Image.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="OnPreviousGradientTapped"/>
-                    </Image.GestureRecognizers>
-                </Image>
-                <Image x:Name="NextStepButton"
-                       Source="icon_next_player.png"
-                       HeightRequest="32"
-                       WidthRequest="32"
-                       IsEnabled="False"
-                       Opacity="0.35">
-                    <Image.GestureRecognizers>
-                        <TapGestureRecognizer Tapped="OnNextGradientTapped"/>
-                    </Image.GestureRecognizers>
-                </Image>
-                <VerticalStackLayout Spacing="4"
-                                      VerticalOptions="Center"
-                                      WidthRequest="240">
-                    <Slider x:Name="GradientSlider"
-                            Minimum="0"
-                            Maximum="0"
-                            IsEnabled="False"
-                            ValueChanged="OnGradientSliderValueChanged"
-                            DragStarted="OnGradientSliderDragStarted"
-                            DragCompleted="OnGradientSliderDragCompleted"
-                            HorizontalOptions="FillAndExpand"/>
-                    <Label x:Name="GradientIndexLabel"
-                           Text="0 / 0"
-                           HorizontalOptions="Center"
-                           TextColor="#A8B6D6"
-                           FontSize="12"/>
-                </VerticalStackLayout>
-                <Label x:Name="SelectionLabel"
-                       Text="No gradient data yet"
-                       TextColor="#A8B6D6"
-                       LineBreakMode="WordWrap"
-                       MaxLines="2"
-                       VerticalOptions="Center"
-                       HorizontalOptions="StartAndExpand"/>
-            </HorizontalStackLayout>
-            <HorizontalStackLayout Grid.Column="2"
-                                    Spacing="12"
-                                    VerticalOptions="Center">
                 <Button Text="Reset View"
                         Clicked="OnResetViewClicked"
                         BackgroundColor="#2C3D59"
@@ -83,8 +34,159 @@
                         CornerRadius="8"/>
             </HorizontalStackLayout>
         </Grid>
-        <Grid Row="1" Padding="16">
-            <Border StrokeShape="RoundRectangle 16"
+
+        <Grid Row="1"
+              Padding="16"
+              ColumnDefinitions="300,*"
+              ColumnSpacing="16">
+            <Border Grid.Column="0"
+                    StrokeShape="RoundRectangle 12"
+                    StrokeThickness="1"
+                    Stroke="#2F405C"
+                    BackgroundColor="{AppThemeBinding Light=#172132, Dark=#0A0F18}">
+                <ScrollView>
+                    <VerticalStackLayout Padding="16"
+                                         Spacing="20">
+                        <VerticalStackLayout Spacing="10">
+                            <Label Text="Step Selection"
+                                   TextColor="#F0F4FF"
+                                   FontAttributes="Bold"
+                                   FontSize="14"/>
+                            <HorizontalStackLayout Spacing="10"
+                                                    VerticalOptions="Center">
+                                <Image x:Name="PrevStepButton"
+                                       Source="icon_next_player.png"
+                                       HeightRequest="28"
+                                       WidthRequest="28"
+                                       Rotation="180"
+                                       IsEnabled="False"
+                                       Opacity="0.35">
+                                    <Image.GestureRecognizers>
+                                        <TapGestureRecognizer Tapped="OnPreviousGradientTapped"/>
+                                    </Image.GestureRecognizers>
+                                </Image>
+                                <Slider x:Name="GradientSlider"
+                                        Minimum="0"
+                                        Maximum="0"
+                                        IsEnabled="False"
+                                        ValueChanged="OnGradientSliderValueChanged"
+                                        DragStarted="OnGradientSliderDragStarted"
+                                        DragCompleted="OnGradientSliderDragCompleted"
+                                        HorizontalOptions="FillAndExpand"/>
+                                <Image x:Name="NextStepButton"
+                                       Source="icon_next_player.png"
+                                       HeightRequest="28"
+                                       WidthRequest="28"
+                                       IsEnabled="False"
+                                       Opacity="0.35">
+                                    <Image.GestureRecognizers>
+                                        <TapGestureRecognizer Tapped="OnNextGradientTapped"/>
+                                    </Image.GestureRecognizers>
+                                </Image>
+                            </HorizontalStackLayout>
+                            <Label x:Name="GradientIndexLabel"
+                                   Text="0 / 0"
+                                   HorizontalOptions="Center"
+                                   TextColor="#A8B6D6"
+                                   FontSize="12"/>
+                            <Label x:Name="SelectionLabel"
+                                   Text="No gradient data yet"
+                                   TextColor="#A8B6D6"
+                                   LineBreakMode="WordWrap"
+                                   MaxLines="3"
+                                   HorizontalOptions="Fill"
+                                   FontSize="13"/>
+                        </VerticalStackLayout>
+
+                        <BoxView HeightRequest="1"
+                                 BackgroundColor="#2F405C"
+                                 Opacity="0.6"/>
+
+                        <Grid ColumnDefinitions="Auto,*,Auto"
+                              RowDefinitions="Auto,Auto,Auto,Auto"
+                              ColumnSpacing="12"
+                              RowSpacing="12">
+                            <Label Text="Zoom"
+                                   Grid.Column="0"
+                                   Grid.Row="0"
+                                   TextColor="Gray"
+                                   VerticalOptions="Center"/>
+                            <Slider x:Name="ZoomSlider"
+                                    Grid.Column="1"
+                                    Grid.Row="0"
+                                    Minimum="1"
+                                    Maximum="12"
+                                    ValueChanged="OnZoomSliderValueChanged"/>
+                            <Label x:Name="ZoomValueLabel"
+                                   Grid.Column="2"
+                                   Grid.Row="0"
+                                   Text="1.0×"
+                                   TextColor="#A8B6D6"
+                                   VerticalOptions="Center"/>
+
+                            <Label Text="Scale"
+                                   Grid.Column="0"
+                                   Grid.Row="1"
+                                   TextColor="#F0F4FF"
+                                   VerticalOptions="Center"/>
+                            <Slider x:Name="ScaleSlider"
+                                    Grid.Column="1"
+                                    Grid.Row="1"
+                                    Minimum="0.1"
+                                    Maximum="20"
+                                    Value="1"
+                                    ValueChanged="OnScaleSliderValueChanged"/>
+                            <Label x:Name="ScaleValueLabel"
+                                   Grid.Column="2"
+                                   Grid.Row="1"
+                                   Text="1.0× (auto 1.0×)"
+                                   TextColor="#A8B6D6"
+                                   VerticalOptions="Center"/>
+
+                            <Label Text="Surface Opacity"
+                                   Grid.Column="0"
+                                   Grid.Row="2"
+                                   TextColor="#F0F4FF"
+                                   VerticalOptions="Center"/>
+                            <Slider x:Name="SurfaceOpacitySlider"
+                                    Grid.Column="1"
+                                    Grid.Row="2"
+                                    Minimum="0.05"
+                                    Maximum="1"
+                                    Value="0.68"
+                                    ValueChanged="OnSurfaceOpacitySliderValueChanged"/>
+                            <Label x:Name="SurfaceOpacityValueLabel"
+                                   Grid.Column="2"
+                                   Grid.Row="2"
+                                   Text="68%"
+                                   TextColor="#A8B6D6"
+                                   VerticalOptions="Center"/>
+
+                            <Label Text="Valley Depth"
+                                   Grid.Column="0"
+                                   Grid.Row="3"
+                                   TextColor="#F0F4FF"
+                                   VerticalOptions="Center"/>
+                            <Slider x:Name="ValleyDepthSlider"
+                                    Grid.Column="1"
+                                    Grid.Row="3"
+                                    Minimum="0.25"
+                                    Maximum="1"
+                                    Value="0.65"
+                                    ValueChanged="OnValleyDepthSliderValueChanged"/>
+                            <Label x:Name="ValleyDepthValueLabel"
+                                   Grid.Column="2"
+                                   Grid.Row="3"
+                                   Text="65%"
+                                   TextColor="#A8B6D6"
+                                   VerticalOptions="Center"/>
+                        </Grid>
+                    </VerticalStackLayout>
+                </ScrollView>
+            </Border>
+
+            <Border Grid.Column="1"
+                    StrokeShape="RoundRectangle 16"
                     StrokeThickness="1"
                     Stroke="#2F405C"
                     BackgroundColor="{AppThemeBinding Light=#0F1724, Dark=#070B12}">
@@ -104,69 +206,6 @@
                            IsVisible="False"/>
                 </Grid>
             </Border>
-        </Grid>
-        <Grid Row="2"
-              Padding="16,8,16,16">
-            <Grid ColumnDefinitions="Auto,*,Auto"
-                  RowDefinitions="Auto,Auto,Auto"
-                  ColumnSpacing="12"
-                  RowSpacing="12">
-                <Label Text="Zoom"
-                       Grid.Column="0"
-                       Grid.Row="0"
-                       TextColor="Gray"
-                       VerticalOptions="Center"/>
-                <Slider x:Name="ZoomSlider"
-                        Grid.Column="1"
-                        Grid.Row="0"
-                        Minimum="1"
-                        Maximum="12"
-                        ValueChanged="OnZoomSliderValueChanged"/>
-                <Label x:Name="ZoomValueLabel"
-                       Grid.Column="2"
-                       Grid.Row="0"
-                       Text="1.0×"
-                       TextColor="#A8B6D6"
-                       VerticalOptions="Center"/>
-
-                <Label Text="Scale"
-                       Grid.Column="0"
-                       Grid.Row="1"
-                       TextColor="#F0F4FF"
-                       VerticalOptions="Center"/>
-                <Slider x:Name="ScaleSlider"
-                        Grid.Column="1"
-                        Grid.Row="1"
-                        Minimum="0.1"
-                        Maximum="20"
-                        Value="1"
-                        ValueChanged="OnScaleSliderValueChanged"/>
-                <Label x:Name="ScaleValueLabel"
-                       Grid.Column="2"
-                       Grid.Row="1"
-                       Text="1.0× (auto 1.0×)"
-                       TextColor="#A8B6D6"
-                       VerticalOptions="Center"/>
-
-                <Label Text="Surface Opacity"
-                       Grid.Column="0"
-                       Grid.Row="2"
-                       TextColor="#F0F4FF"
-                       VerticalOptions="Center"/>
-                <Slider x:Name="SurfaceOpacitySlider"
-                        Grid.Column="1"
-                        Grid.Row="2"
-                        Minimum="0.05"
-                        Maximum="1"
-                        Value="0.68"
-                        ValueChanged="OnSurfaceOpacitySliderValueChanged"/>
-                <Label x:Name="SurfaceOpacityValueLabel"
-                       Grid.Column="2"
-                       Grid.Row="2"
-                       Text="68%"
-                       TextColor="#A8B6D6"
-                       VerticalOptions="Center"/>
-            </Grid>
         </Grid>
     </Grid>
     </Border>

--- a/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/GradientInspectionPopup.xaml.cs
@@ -44,6 +44,9 @@ public partial class GradientInspectionPopup : Popup
     private bool _suppressScaleSliderEvent;
     private bool _suppressGradientSliderEvent;
     private bool _suppressOpacitySliderEvent;
+    private float _surfaceDepthPrecision = 0.65f;
+    private bool _suppressDepthSliderEvent;
+    private bool _surfaceUpdatePending;
     private ValleySurface? _valleySurface;
     private float _surfaceOpacity = 0.68f;
     private bool _isGradientSliderDragging;
@@ -299,6 +302,7 @@ public partial class GradientInspectionPopup : Popup
             UpdateScaleSlider();
             UpdateScaleLabel();
             UpdateSurfaceOpacitySlider();
+            UpdateSurfaceDepthSlider();
             return;
         }
 
@@ -402,6 +406,7 @@ public partial class GradientInspectionPopup : Popup
         UpdateScaleSlider();
         UpdateScaleLabel();
         UpdateSurfaceOpacitySlider();
+        UpdateSurfaceDepthSlider();
         GradientCanvas.InvalidateSurface();
     }
 
@@ -433,7 +438,7 @@ public partial class GradientInspectionPopup : Popup
                 : "Select a sample to inspect";
             UpdateNavigationButtons();
             UpdateGradientSlider();
-            UpdateValleySurface();
+            RequestSurfaceUpdate();
             GradientCanvas.InvalidateSurface();
             return;
         }
@@ -460,7 +465,7 @@ public partial class GradientInspectionPopup : Popup
         SelectionLabel.Text = $"{iterationLabel}: {normDescriptor} = {sample.Norm:F4}";
         UpdateNavigationButtons();
         UpdateGradientSlider();
-        UpdateValleySurface();
+        RequestSurfaceUpdate();
         GradientCanvas.InvalidateSurface();
     }
 
@@ -541,7 +546,7 @@ public partial class GradientInspectionPopup : Popup
         if (_cameraDistance <= 0f)
             _cameraDistance = _defaultCameraDistance;
 
-        UpdateValleySurface();
+        RequestSurfaceUpdate();
     }
 
     private void UpdateNavigationButtons()
@@ -690,6 +695,7 @@ public partial class GradientInspectionPopup : Popup
     private void OnGradientSliderDragStarted(object? sender, EventArgs e)
     {
         _isGradientSliderDragging = true;
+        _surfaceUpdatePending = false;
     }
 
     private void OnGradientSliderDragCompleted(object? sender, EventArgs e)
@@ -723,6 +729,7 @@ public partial class GradientInspectionPopup : Popup
         }
 
         UpdateGradientIndexLabel();
+        ProcessPendingSurfaceUpdate();
     }
 
     private void UpdateSurfaceOpacitySlider()
@@ -745,6 +752,39 @@ public partial class GradientInspectionPopup : Popup
             return;
 
         SurfaceOpacityValueLabel.Text = $"{_surfaceOpacity:0%}";
+    }
+
+    private void UpdateSurfaceDepthSlider()
+    {
+        if (ValleyDepthSlider == null)
+            return;
+
+        _suppressDepthSliderEvent = true;
+        ValleyDepthSlider.Minimum = 0.25;
+        ValleyDepthSlider.Maximum = 1.0;
+        ValleyDepthSlider.Value = Math.Clamp(_surfaceDepthPrecision, 0.25f, 1f);
+        ValleyDepthSlider.IsEnabled = _displaySamples.Count > 0;
+        _suppressDepthSliderEvent = false;
+        UpdateSurfaceDepthLabel();
+    }
+
+    private void UpdateSurfaceDepthLabel()
+    {
+        if (ValleyDepthValueLabel == null)
+            return;
+
+        ValleyDepthValueLabel.Text = $"{_surfaceDepthPrecision:0%}";
+    }
+
+    private void OnValleyDepthSliderValueChanged(object? sender, ValueChangedEventArgs e)
+    {
+        if (_suppressDepthSliderEvent)
+            return;
+
+        _surfaceDepthPrecision = (float)Math.Clamp(e.NewValue, 0.25, 1.0);
+        UpdateSurfaceDepthLabel();
+        RequestSurfaceUpdate();
+        GradientCanvas.InvalidateSurface();
     }
 
     private void CancelSurfaceRebuild()
@@ -773,6 +813,27 @@ public partial class GradientInspectionPopup : Popup
         GradientCanvas.InvalidateSurface();
     }
 
+    private void RequestSurfaceUpdate()
+    {
+        if (_isGradientSliderDragging)
+        {
+            _surfaceUpdatePending = true;
+            return;
+        }
+
+        _surfaceUpdatePending = false;
+        UpdateValleySurface();
+    }
+
+    private void ProcessPendingSurfaceUpdate()
+    {
+        if (!_surfaceUpdatePending)
+            return;
+
+        _surfaceUpdatePending = false;
+        UpdateValleySurface();
+    }
+
     private void UpdateValleySurface()
     {
         int visibleCount = GetVisibleSampleCount();
@@ -796,6 +857,7 @@ public partial class GradientInspectionPopup : Popup
 
         var cts = new CancellationTokenSource();
         _surfaceRebuildCts = cts;
+        float depthPrecision = _surfaceDepthPrecision;
 
         Task.Run(() =>
         {
@@ -805,6 +867,7 @@ public partial class GradientInspectionPopup : Popup
                 surface = BuildValleySurfaceSnapshot(pointSnapshot,
                                                      sampleSnapshot,
                                                      _trajectoryRadius,
+                                                     depthPrecision,
                                                      cts.Token);
             }
             catch (OperationCanceledException)
@@ -841,11 +904,13 @@ public partial class GradientInspectionPopup : Popup
     private ValleySurface? BuildValleySurfaceSnapshot(Point3D[] points,
                                                       GradientDisplaySample[] samples,
                                                       float trajectoryRadius,
+                                                      float depthPrecision,
                                                       CancellationToken token)
     {
         if (points.Length < 4 || samples.Length == 0)
             return null;
 
+        float precision = MathF.Clamp(depthPrecision, 0.25f, 1f);
         var fitPoints = new List<Point3D>(points);
         var vectors = new Vector3[points.Length];
         Vector3 centroid = Vector3.Zero;
@@ -917,9 +982,10 @@ public partial class GradientInspectionPopup : Popup
             projections.Add(new SampleProjection(u, v, w, norm, collapsed));
         }
 
-        float extentA = MathF.Max(maxAbsU * 1.35f, trajectoryRadius * 0.6f);
-        float extentB = MathF.Max(maxAbsV * 1.35f, trajectoryRadius * 0.6f);
-        float extentNormal = MathF.Max(maxAbsW * 1.6f, MathF.Max(trajectoryRadius * 0.35f, 0.3f));
+        float extentA = MathF.Max(maxAbsU * (1.1f + 0.4f * precision), trajectoryRadius * (0.45f + 0.3f * precision));
+        float extentB = MathF.Max(maxAbsV * (1.1f + 0.4f * precision), trajectoryRadius * (0.45f + 0.3f * precision));
+        float extentNormalBase = MathF.Max(maxAbsW * (1.2f + 0.6f * precision), MathF.Max(trajectoryRadius * (0.2f + 0.5f * precision), 0.25f));
+        float extentNormal = extentNormalBase * (0.9f + 0.65f * precision);
 
         if (!TryFitQuadraticSurface(fitPoints, centroid, axisA, axisB, normal, out var coefficients))
             return BuildPlanarValley(centroid, axisA, axisB, extentA, extentB);
@@ -933,6 +999,7 @@ public partial class GradientInspectionPopup : Popup
                                             extentA,
                                             extentB,
                                             extentNormal,
+                                            precision,
                                             token);
     }
 
@@ -945,9 +1012,12 @@ public partial class GradientInspectionPopup : Popup
                                                        float extentA,
                                                        float extentB,
                                                        float extentNormal,
+                                                       float precision,
                                                        CancellationToken token)
     {
-        int resolution = Math.Clamp(samples.Count / 6, 32, 72);
+        float precisionClamped = MathF.Clamp(precision, 0.25f, 1f);
+        int baseResolution = Math.Clamp(samples.Count / 6, 32, 72);
+        int resolution = Math.Clamp((int)(baseResolution * (0.9f + 0.7f * precisionClamped)), 32, 110);
         var grid = new Vector3[resolution, resolution];
         float minElevation = float.PositiveInfinity;
         float maxElevation = float.NegativeInfinity;
@@ -985,15 +1055,18 @@ public partial class GradientInspectionPopup : Popup
 
             double baseHeight = EvaluateQuadratic(coefficients, sample.U, sample.V);
             float residual = (float)(sample.Height - baseHeight);
-            residuals[i] = residual;
-            maxResidual = MathF.Max(maxResidual, MathF.Abs(residual));
+            float depthStrength = 0.65f + 0.9f * precisionClamped;
+            residuals[i] = residual * depthStrength;
+            maxResidual = MathF.Max(maxResidual, MathF.Abs(residuals[i]));
 
             double normFactor = double.IsFinite(sample.Norm)
                 ? Math.Clamp((sample.Norm - minNorm) / normRange, 0.0, 1.0)
                 : 0.0;
 
             float collapsedFactor = MathF.Log(1f + MathF.Max(sample.CollapsedCount, 1));
-            weights[i] = 0.7f + (float)normFactor * 0.8f + collapsedFactor * 0.25f;
+            float normWeight = (float)normFactor * (0.55f + 0.9f * precisionClamped);
+            float collapsedWeight = collapsedFactor * (0.2f + 0.35f * precisionClamped);
+            weights[i] = 0.55f + 0.35f * (1f - precisionClamped) + normWeight + collapsedWeight;
         }
 
         if (maxResidual > extentNormal)
@@ -1003,8 +1076,14 @@ public partial class GradientInspectionPopup : Popup
                 residuals[i] *= scale;
         }
 
-        float kernelRadius = ComputeKernelRadius(samples, extentA, extentB);
+        float kernelRadiusBase = ComputeKernelRadius(samples, extentA, extentB);
+        float kernelRadius = MathF.Max(kernelRadiusBase * (1.2f - 0.5f * precisionClamped), 0.08f);
         float kernelRadiusSq = kernelRadius * kernelRadius;
+        float innerRadiusSq = kernelRadiusSq * (0.25f + 0.25f * precisionClamped);
+        float midRadiusSq = kernelRadiusSq * (0.7f + 0.2f * precisionClamped);
+        float anchorRadiusSq = kernelRadiusSq * (0.36f + 0.28f * precisionClamped);
+        float fadeRadius = kernelRadius * (1.55f - 0.35f * precisionClamped);
+        double residualStrength = 0.85 + 0.95 * precisionClamped;
 
         for (int row = 0; row < resolution; row++)
         {
@@ -1021,6 +1100,8 @@ public partial class GradientInspectionPopup : Popup
                 double adjusted = 0.0;
                 double weightSum = 0.0;
                 double nearest = double.PositiveInfinity;
+                double anchorHeight = 0.0;
+                double anchorWeight = 0.0;
 
                 for (int i = 0; i < samples.Count; i++)
                 {
@@ -1032,24 +1113,49 @@ public partial class GradientInspectionPopup : Popup
                     if (distance < nearest)
                         nearest = distance;
 
-                    double influence = Math.Exp(-distanceSq / Math.Max(1e-6f, kernelRadiusSq * 0.8f));
-                    if (distanceSq < kernelRadiusSq * 0.35f)
-                        influence *= 1.75;
+                    double influence = Math.Exp(-distanceSq / Math.Max(1e-6f, kernelRadiusSq * (0.75f - 0.2f * precisionClamped)));
+                    if (distanceSq <= innerRadiusSq)
+                    {
+                        influence *= 1.6 + 1.4 * precisionClamped;
+                    }
+                    else if (distanceSq <= midRadiusSq)
+                    {
+                        influence *= 1.05 + 0.95 * precisionClamped;
+                    }
+                    else
+                    {
+                        influence *= 0.55 + 0.6 * (1f - precisionClamped);
+                    }
 
-                    influence *= weights[i];
-                    adjusted += residuals[i] * influence;
-                    weightSum += influence;
+                    double weightedInfluence = influence * weights[i];
+                    adjusted += residuals[i] * weightedInfluence;
+                    weightSum += weightedInfluence;
+
+                    if (distanceSq <= anchorRadiusSq)
+                    {
+                        double anchorInfluence = Math.Exp(-distanceSq / Math.Max(1e-6f, anchorRadiusSq * (0.75f - 0.25f * precisionClamped)));
+                        anchorHeight += sample.Height * anchorInfluence;
+                        anchorWeight += anchorInfluence;
+                    }
                 }
 
-                double residualAdjustment = weightSum > 1e-6 ? adjusted / weightSum : 0.0;
+                double residualAdjustment = weightSum > 1e-6 ? (adjusted / weightSum) * residualStrength : 0.0;
 
-                if (nearest > kernelRadius * 1.8f)
+                if (nearest > fadeRadius)
                 {
-                    double fade = Math.Exp(-Math.Pow((nearest - kernelRadius * 1.8f) / (kernelRadius * 1.2f + 1e-6f), 2));
+                    double fade = Math.Exp(-Math.Pow((nearest - fadeRadius) / (fadeRadius * (0.85 + 0.4 * (1f - precisionClamped)) + 1e-6f), 2));
                     residualAdjustment *= fade;
                 }
 
                 double height = baseHeight + residualAdjustment;
+
+                if (anchorWeight > 1e-6)
+                {
+                    double anchorAverage = anchorHeight / anchorWeight;
+                    double blend = 0.2 + 0.55 * precisionClamped;
+                    height = height * (1.0 - blend) + anchorAverage * blend;
+                }
+
                 height = Math.Clamp(height, -extentNormal, extentNormal);
 
                 var point = centroid + axisA * u + axisB * v + normal * (float)height;


### PR DESCRIPTION
## Summary
- reorganize the gradient inspection popup so controls live in a left panel and add a valley depth precision slider
- defer expensive surface rebuilds while scrubbing the gradient slider and expose depth precision updates from the UI
- refine the valley surface fitting algorithm for better point alignment and tunable detail

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69089c4453d4833397d4942b0c53e19a