### PR TITLE
Add initial distribution editor popup

### DIFF
--- a/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
+++ b/ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj
@@ -83,6 +83,9 @@
           <Compile Update="Controls\PlusMinusEntryControl.xaml.cs">
             <DependentUpon>PlusMinusEntryControl.xaml</DependentUpon>
           </Compile>
+          <Compile Update="Views\InitialDistributionEditorPopup.xaml.cs">
+            <DependentUpon>InitialDistributionEditorPopup.xaml</DependentUpon>
+          </Compile>
           <Compile Update="Views\VideoExportProgressPopup.xaml.cs">
             <DependentUpon>VideoExportProgressPopup.xaml</DependentUpon>
           </Compile>
@@ -108,6 +111,9 @@
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
           <MauiXaml Update="Controls\PlusMinusEntryControl.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\InitialDistributionEditorPopup.xaml">
             <Generator>MSBuild:Compile</Generator>
           </MauiXaml>
           <MauiXaml Update="Views\MeshingPage.xaml">

--- a/ElectricalImpedanceTomography/Helpers/DistributionRenderingHelper.cs
+++ b/ElectricalImpedanceTomography/Helpers/DistributionRenderingHelper.cs
@@ -1,0 +1,264 @@
+﻿using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes;
+using Utility.Classes.Discretizer;
+using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+
+namespace ElectricalImpedanceTomography.Helpers
+{
+    public static class DistributionRenderingHelper
+    {
+        private static readonly SKColor DistributionCanvasBackgroundColor = SKColor.Parse("#1A2436");
+
+        private readonly record struct FemTransform(float Scale,
+                                                     float MarginX,
+                                                     float MarginY,
+                                                     float MinX,
+                                                     float MinY,
+                                                     float CanvasHeight);
+
+        public static void DrawConductivity(SKCanvas canvas,
+                                            SKImageInfo info,
+                                            IDiscretization? discretization,
+                                            ConductivityDistribution? distribution)
+        {
+            if (canvas == null)
+                throw new ArgumentNullException(nameof(canvas));
+
+            canvas.Clear(DistributionCanvasBackgroundColor);
+
+            if (discretization == null || distribution == null)
+                return;
+
+            switch (discretization)
+            {
+                case FEMMesh fem:
+                    DrawFemConductivity(canvas, info, fem, distribution);
+                    break;
+                case LBMGrid lbm:
+                    DrawLbmConductivity(canvas, info, lbm, distribution);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        public static void DrawColorBar(SKCanvas canvas,
+                                        SKImageInfo info,
+                                        IDiscretization? discretization,
+                                        ConductivityDistribution? distribution)
+        {
+            if (canvas == null)
+                throw new ArgumentNullException(nameof(canvas));
+
+            canvas.Clear(DistributionCanvasBackgroundColor);
+
+            if (discretization == null || distribution == null)
+                return;
+
+            double min;
+            double max;
+
+            if (discretization is LBMGrid lbm)
+            {
+                (min, max) = GetLbmValueRange(lbm, distribution.Conductivities);
+            }
+            else
+            {
+                min = distribution.Conductivities.Values.Min();
+                max = distribution.Conductivities.Values.Max();
+                if (Math.Abs(max - min) < 1e-12)
+                    max = min + 1e-12;
+            }
+
+            DrawColorBar(canvas, info, min, max);
+        }
+
+        private static void DrawFemConductivity(SKCanvas canvas,
+                                                SKImageInfo info,
+                                                FEMMesh mesh,
+                                                ConductivityDistribution distribution)
+        {
+            var transform = ComputeFemTransform(mesh, info);
+            using var fill = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
+            using var stroke = new SKPaint { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1, IsAntialias = true };
+
+            double min = distribution.Conductivities.Values.Min();
+            double max = distribution.Conductivities.Values.Max();
+            if (Math.Abs(max - min) < 1e-12)
+                max = min + 1e-12;
+
+            foreach (var element in mesh.GetElements().Cast<FEMElement>())
+            {
+                double value = distribution.GetConductivity(element.Id);
+                fill.Color = ColorForValue(value, min, max);
+
+                using var path = new SKPath();
+                path.MoveTo(ToCanvas(element.Vertices[0], transform));
+                path.LineTo(ToCanvas(element.Vertices[1], transform));
+                path.LineTo(ToCanvas(element.Vertices[2], transform));
+                path.Close();
+
+                canvas.DrawPath(path, fill);
+                canvas.DrawPath(path, stroke);
+            }
+        }
+
+        private static void DrawLbmConductivity(SKCanvas canvas,
+                                                SKImageInfo info,
+                                                LBMGrid grid,
+                                                ConductivityDistribution distribution)
+        {
+            float cellWidth = info.Width / (float)grid.Nx;
+            float cellHeight = info.Height / (float)grid.Ny;
+            var (min, max) = GetLbmValueRange(grid, distribution.Conductivities);
+
+            for (int y = 0; y < grid.Ny; y++)
+            {
+                for (int x = 0; x < grid.Nx; x++)
+                {
+                    var element = grid.GetElementAt(x, y);
+                    SKColor color;
+
+                    if (element.IsWall)
+                    {
+                        color = SKColors.Black;
+                    }
+                    else
+                    {
+                        double value = distribution.Conductivities.TryGetValue(element.Id, out var v) ? v : min;
+                        color = ColorForValue(value, min, max);
+                    }
+
+                    using var fill = new SKPaint { Style = SKPaintStyle.Fill, Color = color };
+                    var rect = SKRect.Create(x * cellWidth, y * cellHeight, cellWidth, cellHeight);
+                    canvas.DrawRect(rect, fill);
+                    canvas.DrawRect(rect, new SKPaint { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1 });
+                }
+            }
+        }
+
+        private static FemTransform ComputeFemTransform(FEMMesh mesh, SKImageInfo info)
+        {
+            const float padding = 10f;
+            float availableWidth = info.Width - 2 * padding;
+            float availableHeight = info.Height - 2 * padding;
+
+            float minX = (float)mesh.Vertices.Min(v => v.X);
+            float minY = (float)mesh.Vertices.Min(v => v.Y);
+            float maxX = (float)mesh.Vertices.Max(v => v.X);
+            float maxY = (float)mesh.Vertices.Max(v => v.Y);
+
+            float meshWidth = maxX - minX;
+            float meshHeight = maxY - minY;
+            float scale = Math.Min(availableWidth / meshWidth, availableHeight / meshHeight);
+
+            float usedWidth = meshWidth * scale;
+            float usedHeight = meshHeight * scale;
+            float marginX = padding + (availableWidth - usedWidth) / 2f;
+            float marginY = padding + (availableHeight - usedHeight) / 2f;
+
+            return new FemTransform(scale, marginX, marginY, minX, minY, info.Height);
+        }
+
+        private static SKPoint ToCanvas(FEMVertex vertex, in FemTransform transform)
+        {
+            float x = (float)(vertex.X - transform.MinX) * transform.Scale + transform.MarginX;
+            float y = transform.CanvasHeight - ((float)(vertex.Y - transform.MinY) * transform.Scale + transform.MarginY);
+            return new SKPoint(x, y);
+        }
+
+        private static SKColor ColorForValue(double value, double min, double max)
+        {
+            double midpoint = (min + max) * 0.5;
+            if (value >= midpoint)
+            {
+                float t = (float)((value - midpoint) / (max - midpoint));
+                t = Math.Clamp(t, 0f, 1f);
+                byte r = (byte)(255 * t);
+                return new SKColor(r, 0, 0);
+            }
+            else
+            {
+                float t = (float)((midpoint - value) / (midpoint - min));
+                t = Math.Clamp(t, 0f, 1f);
+                byte b = (byte)(255 * t);
+                return new SKColor(0, 0, b);
+            }
+        }
+
+        private static (double Min, double Max) GetLbmValueRange(LBMGrid grid, IReadOnlyDictionary<int, double> values)
+        {
+            bool hasValue = false;
+            double min = 0.0;
+            double max = 0.0;
+
+            foreach (var element in grid.GetElements().Cast<LBMElement>())
+            {
+                if (element.IsWall)
+                    continue;
+
+                if (!values.TryGetValue(element.Id, out double value))
+                    continue;
+
+                if (double.IsNaN(value) || double.IsInfinity(value))
+                    continue;
+
+                if (!hasValue)
+                {
+                    min = max = value;
+                    hasValue = true;
+                }
+                else
+                {
+                    if (value < min) min = value;
+                    if (value > max) max = value;
+                }
+            }
+
+            if (!hasValue)
+                return (0.0, 1e-12);
+
+            if (Math.Abs(max - min) < 1e-12)
+                max = min + 1e-12;
+
+            return (min, max);
+        }
+
+        private static void DrawColorBar(SKCanvas canvas, SKImageInfo info, double min, double max)
+        {
+            var rect = new SKRect(0, 0, info.Width, info.Height);
+            int steps = 256;
+            var colors = new SKColor[steps];
+            var positions = new float[steps];
+
+            for (int i = 0; i < steps; i++)
+            {
+                double t = i / (double)(steps - 1);
+                double value = min + (max - min) * t;
+                colors[i] = ColorForValue(value, min, max);
+                positions[i] = (float)t;
+            }
+
+            using var shader = SKShader.CreateLinearGradient(new SKPoint(rect.Left, rect.Top),
+                                                              new SKPoint(rect.Right, rect.Top),
+                                                              colors,
+                                                              positions,
+                                                              SKShaderTileMode.Clamp);
+            using var paint = new SKPaint { Shader = shader };
+            canvas.DrawRect(rect, paint);
+
+            using var border = new SKPaint
+            {
+                Style = SKPaintStyle.Stroke,
+                Color = SKColors.Black,
+                StrokeWidth = 1,
+                IsAntialias = true
+            };
+            canvas.DrawRect(rect, border);
+        }
+    }
+}

--- a/ElectricalImpedanceTomography/ViewModels/InitialDistributionEditorViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/InitialDistributionEditorViewModel.cs
@@ -1,0 +1,304 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes;
+using Utility.Classes.Application;
+using Utility.Classes.Discretizer;
+using Utility.Classes.Factories;
+using Utility.Classes.Reconstruction;
+
+namespace ElectricalImpedanceTomography.ViewModels
+{
+    public enum InitialDistributionEditorMode
+    {
+        Homogeneous,
+        Random,
+        CloseToTarget
+    }
+
+    public partial class InitialDistributionEditorViewModel : ObservableObject
+    {
+        private readonly Random _random = new();
+
+        private IDiscretization? _discretization;
+        private ConductivityDistribution? _originalDistribution;
+        private ConductivityDistribution? _currentDistribution;
+
+        private bool _suppressUpdates;
+        private bool _isInitialized;
+
+        public IReadOnlyList<InitialDistributionEditorMode> AvailableModes { get; }
+            = Enum.GetValues<InitialDistributionEditorMode>();
+
+        [ObservableProperty]
+        private InitialDistributionEditorMode selectedMode = InitialDistributionEditorMode.Homogeneous;
+
+        [ObservableProperty]
+        private double backgroundConductivity;
+
+        [ObservableProperty]
+        private double randomPercent = 10.0;
+
+        [ObservableProperty]
+        private double distortionStrength = 10.0;
+
+        public bool IsRandomMode => SelectedMode == InitialDistributionEditorMode.Random;
+
+        public bool IsCloseToTargetMode => SelectedMode == InitialDistributionEditorMode.CloseToTarget;
+
+        public string RandomPercentLabel => $"{Math.Round(RandomPercent)}% of elements randomized";
+
+        public string DistortionLabel => $"{Math.Round(DistortionStrength)}% distortion";
+
+        public ConductivityDistribution? CurrentDistribution => _currentDistribution;
+
+        public IDiscretization? Discretization => _discretization;
+
+        public event EventHandler? DistributionUpdated;
+
+        public void Initialize(IDiscretization discretization,
+                               ConductivityDistribution initialDistribution,
+                               ConductivityDistribution? originalDistribution,
+                               InitialDistributionTypes initialType)
+        {
+            _discretization = discretization ?? throw new ArgumentNullException(nameof(discretization));
+            _originalDistribution = originalDistribution != null
+                ? new ConductivityDistribution(originalDistribution.Conductivities)
+                : null;
+
+            _currentDistribution = new ConductivityDistribution(initialDistribution.Conductivities);
+
+            double minBound = ConductivityClipper.MinimumBound;
+            double maxBound = ConductivityClipper.MaximumBound;
+            double average = initialDistribution.Conductivities.Count > 0
+                ? initialDistribution.Conductivities.Values.Average()
+                : Math.Clamp(1.0, minBound, maxBound);
+            average = Math.Clamp(average, minBound, maxBound);
+
+            _suppressUpdates = true;
+            BackgroundConductivity = average;
+            RandomPercent = 10.0;
+            DistortionStrength = 10.0;
+            SelectedMode = MapInitialTypeToMode(initialType);
+            _suppressUpdates = false;
+
+            _isInitialized = true;
+
+            OnPropertyChanged(nameof(IsRandomMode));
+            OnPropertyChanged(nameof(IsCloseToTargetMode));
+            OnPropertyChanged(nameof(RandomPercentLabel));
+            OnPropertyChanged(nameof(DistortionLabel));
+            OnPropertyChanged(nameof(CurrentDistribution));
+
+            RaiseDistributionUpdated();
+        }
+
+        partial void OnSelectedModeChanged(InitialDistributionEditorMode value)
+        {
+            if (!_isInitialized || _suppressUpdates)
+                return;
+
+            OnPropertyChanged(nameof(IsRandomMode));
+            OnPropertyChanged(nameof(IsCloseToTargetMode));
+
+            UpdateDistribution();
+        }
+
+        partial void OnBackgroundConductivityChanged(double value)
+        {
+            if (!_isInitialized || _suppressUpdates)
+                return;
+
+            if (!double.IsFinite(value))
+            {
+                SetBackgroundConductivity(Math.Clamp(ConductivityClipper.MinimumBound,
+                                                     ConductivityClipper.MinimumBound,
+                                                     ConductivityClipper.MaximumBound));
+                return;
+            }
+
+            double min = ConductivityClipper.MinimumBound;
+            double max = ConductivityClipper.MaximumBound;
+            double sanitized = Math.Clamp(value, min, max);
+
+            if (Math.Abs(sanitized - value) > double.Epsilon)
+            {
+                SetBackgroundConductivity(sanitized);
+                return;
+            }
+
+            UpdateDistribution();
+        }
+
+        partial void OnRandomPercentChanged(double value)
+        {
+            if (!_isInitialized || _suppressUpdates)
+                return;
+
+            double sanitized = Math.Clamp(value, 0.0, 100.0);
+            if (Math.Abs(sanitized - value) > double.Epsilon)
+            {
+                SetRandomPercent(sanitized);
+                return;
+            }
+
+            OnPropertyChanged(nameof(RandomPercentLabel));
+            UpdateDistribution();
+        }
+
+        partial void OnDistortionStrengthChanged(double value)
+        {
+            if (!_isInitialized || _suppressUpdates)
+                return;
+
+            double sanitized = Math.Clamp(value, 0.0, 100.0);
+            if (Math.Abs(sanitized - value) > double.Epsilon)
+            {
+                SetDistortionStrength(sanitized);
+                return;
+            }
+
+            OnPropertyChanged(nameof(DistortionLabel));
+            UpdateDistribution();
+        }
+
+        private void SetBackgroundConductivity(double value)
+        {
+            _suppressUpdates = true;
+            BackgroundConductivity = value;
+            _suppressUpdates = false;
+
+            if (_isInitialized)
+                UpdateDistribution();
+        }
+
+        private void SetRandomPercent(double value)
+        {
+            _suppressUpdates = true;
+            RandomPercent = value;
+            _suppressUpdates = false;
+            OnPropertyChanged(nameof(RandomPercentLabel));
+
+            if (_isInitialized)
+                UpdateDistribution();
+        }
+
+        private void SetDistortionStrength(double value)
+        {
+            _suppressUpdates = true;
+            DistortionStrength = value;
+            _suppressUpdates = false;
+            OnPropertyChanged(nameof(DistortionLabel));
+
+            if (_isInitialized)
+                UpdateDistribution();
+        }
+
+        private void UpdateDistribution()
+        {
+            if (!_isInitialized || _suppressUpdates)
+                return;
+
+            if (_discretization == null)
+                return;
+
+            var updated = GenerateDistribution();
+            updated = ConductivityClipper.Clip(updated);
+
+            _currentDistribution = new ConductivityDistribution(updated.Conductivities);
+
+            _discretization.SetConductivityDistribution(new ConductivityDistribution(_currentDistribution.Conductivities));
+            Workspace.SetInitialConductivityDistribution(new ConductivityDistribution(_currentDistribution.Conductivities));
+            Workspace.SetInitialDiscretization(_discretization.DeepCopy());
+
+            var parameters = Workspace.GetReconstructionParameters();
+            parameters.InitialDistributionType = MapModeToInitialType(SelectedMode);
+
+            OnPropertyChanged(nameof(CurrentDistribution));
+            RaiseDistributionUpdated();
+        }
+
+        private ConductivityDistribution GenerateDistribution()
+        {
+            if (_discretization == null)
+                throw new InvalidOperationException("Discretization is not available.");
+
+            var elements = _discretization.GetElements();
+            var values = new Dictionary<int, double>(elements.Count);
+            double minBound = ConductivityClipper.MinimumBound;
+            double maxBound = ConductivityClipper.MaximumBound;
+
+            switch (SelectedMode)
+            {
+                case InitialDistributionEditorMode.Random:
+                    foreach (var element in elements)
+                        values[element.Id] = BackgroundConductivity;
+
+                    int totalCount = elements.Count;
+                    if (totalCount > 0)
+                    {
+                        double ratio = Math.Clamp(RandomPercent / 100.0, 0.0, 1.0);
+                        int targetCount = (int)Math.Round(totalCount * ratio);
+                        if (ratio > 0.0 && targetCount == 0)
+                            targetCount = 1;
+
+                        if (targetCount > 0)
+                        {
+                            var shuffledIds = elements.Select(e => e.Id)
+                                                       .OrderBy(_ => _random.NextDouble())
+                                                       .Take(targetCount);
+
+                            foreach (var id in shuffledIds)
+                            {
+                                double randomValue = minBound + _random.NextDouble() * (maxBound - minBound);
+                                values[id] = randomValue;
+                            }
+                        }
+                    }
+                    break;
+
+                case InitialDistributionEditorMode.CloseToTarget:
+                    var source = _originalDistribution ?? _discretization.GetConductivityDistribution();
+                    double distortion = Math.Clamp(DistortionStrength / 100.0, 0.0, 1.0);
+
+                    foreach (var pair in source.Conductivities)
+                    {
+                        double noise = (_random.NextDouble() * 2.0 - 1.0) * distortion;
+                        double perturbed = pair.Value * (1.0 + noise);
+                        values[pair.Key] = perturbed;
+                    }
+                    break;
+
+                case InitialDistributionEditorMode.Homogeneous:
+                default:
+                    foreach (var element in elements)
+                        values[element.Id] = BackgroundConductivity;
+                    break;
+            }
+
+            return new ConductivityDistribution(values);
+        }
+
+        private static InitialDistributionEditorMode MapInitialTypeToMode(InitialDistributionTypes type)
+            => type switch
+            {
+                InitialDistributionTypes.Random => InitialDistributionEditorMode.Random,
+                InitialDistributionTypes.CloseToTarget => InitialDistributionEditorMode.CloseToTarget,
+                _ => InitialDistributionEditorMode.Homogeneous
+            };
+
+        private static InitialDistributionTypes MapModeToInitialType(InitialDistributionEditorMode mode)
+            => mode switch
+            {
+                InitialDistributionEditorMode.Random => InitialDistributionTypes.Random,
+                InitialDistributionEditorMode.CloseToTarget => InitialDistributionTypes.CloseToTarget,
+                _ => InitialDistributionTypes.Homogeneous
+            };
+
+        private void RaiseDistributionUpdated()
+        {
+            DistributionUpdated?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -51,6 +51,8 @@ namespace ElectricalImpedanceTomography.ViewModels
         [ObservableProperty]
         private int iterationCount = 0;
 
+        public bool CanEditInitialDistribution => IterationCount == 0;
+
         [ObservableProperty]
         private double residual = 1.0;
 
@@ -729,6 +731,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             UpdateMetric(MetricKeys.IterationCount, value.ToString(CultureInfo.InvariantCulture));
             UpdateIterationsPerSecond();
             UpdateTimePerIteration();
+            OnPropertyChanged(nameof(CanEditInitialDistribution));
         }
 
         partial void OnResidualChanged(double value)

--- a/ElectricalImpedanceTomography/Views/InitialDistributionEditorPopup.xaml
+++ b/ElectricalImpedanceTomography/Views/InitialDistributionEditorPopup.xaml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+               xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+               xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+               xmlns:skia="clr-namespace:SkiaSharp.Views.Maui.Controls;assembly=SkiaSharp.Views.Maui.Controls"
+               xmlns:viewmodels="clr-namespace:ElectricalImpedanceTomography.ViewModels"
+               x:Class="ElectricalImpedanceTomography.Views.InitialDistributionEditorPopup"
+               x:DataType="viewmodels:InitialDistributionEditorViewModel"
+               Size="900,620">
+    <Border Stroke="Transparent"
+            StrokeShape="RoundRectangle 12"
+            BackgroundColor="Transparent">
+        <Grid RowDefinitions="Auto,*"
+              BackgroundColor="{AppThemeBinding Light=#1C2739, Dark=#101926}">
+            <Grid Row="0"
+                  ColumnDefinitions="*,Auto"
+                  Padding="20,16"
+                  BackgroundColor="{AppThemeBinding Light=#24354D, Dark=#182232}">
+                <Label Text="Initial Distribution Editor"
+                       VerticalOptions="Center"
+                       FontAttributes="Bold"
+                       FontFamily="SF Pro Text"
+                       FontSize="18"
+                       TextColor="#F0F4FF" />
+                <Button Grid.Column="1"
+                        Text="Close"
+                        Clicked="OnCloseClicked"
+                        BackgroundColor="#2E3C55"
+                        TextColor="#E5EEFF"
+                        Padding="18,8"
+                        CornerRadius="10" />
+            </Grid>
+
+            <Grid Row="1"
+                  ColumnDefinitions="*,320"
+                  ColumnSpacing="18"
+                  Padding="20">
+                <Border Grid.Column="0"
+                        StrokeThickness="1"
+                        Stroke="#2E3C55"
+                        BackgroundColor="{AppThemeBinding Light=#172132, Dark=#0C131F}"
+                        StrokeShape="RoundRectangle 12">
+                    <VerticalStackLayout Padding="20"
+                                         Spacing="20"
+                                         HorizontalOptions="Center">
+                        <Label Text="Preview"
+                               FontAttributes="Bold"
+                               FontFamily="SF Pro Text"
+                               TextColor="#F0F4FF"
+                               HorizontalOptions="Center" />
+                        <skia:SKCanvasView x:Name="PreviewCanvas"
+                                           HeightRequest="360"
+                                           WidthRequest="360"
+                                           PaintSurface="OnPreviewCanvasPaintSurface" />
+                        <skia:SKCanvasView x:Name="PreviewColorbarCanvas"
+                                           HeightRequest="20"
+                                           WidthRequest="360"
+                                           PaintSurface="OnColorbarCanvasPaintSurface" />
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border Grid.Column="1"
+                        StrokeThickness="1"
+                        Stroke="#2E3C55"
+                        BackgroundColor="{AppThemeBinding Light=#1C273A, Dark=#121A29}"
+                        StrokeShape="RoundRectangle 12">
+                    <ScrollView>
+                        <VerticalStackLayout Padding="20"
+                                             Spacing="18">
+                            <Label Text="Distribution Type"
+                                   FontAttributes="Bold"
+                                   FontFamily="SF Pro Text"
+                                   TextColor="#F0F4FF" />
+                            <Picker ItemsSource="{Binding AvailableModes}"
+                                    SelectedItem="{Binding SelectedMode}"
+                                    TextColor="#F0F4FF"
+                                    TitleColor="#9DAAD3"
+                                    BackgroundColor="#23334A" />
+
+                            <Label Text="Background Conductivity [S]"
+                                   FontAttributes="Bold"
+                                   FontFamily="SF Pro Text"
+                                   TextColor="#F0F4FF" />
+                            <Entry Text="{Binding BackgroundConductivity, Mode=TwoWay}"
+                                   Keyboard="Numeric"
+                                   BackgroundColor="#23334A"
+                                   TextColor="#F0F4FF" />
+
+                            <VerticalStackLayout Spacing="10"
+                                                  IsVisible="{Binding IsRandomMode}">
+                                <Label Text="Randomized Percent"
+                                       FontAttributes="Bold"
+                                       FontFamily="SF Pro Text"
+                                       TextColor="#F0F4FF" />
+                                <Slider Minimum="0"
+                                        Maximum="100"
+                                        Value="{Binding RandomPercent, Mode=TwoWay}" />
+                                <Label Text="{Binding RandomPercentLabel}"
+                                       FontFamily="SF Pro Text"
+                                       FontSize="12"
+                                       TextColor="#A8B6D6" />
+                            </VerticalStackLayout>
+
+                            <VerticalStackLayout Spacing="10"
+                                                  IsVisible="{Binding IsCloseToTargetMode}">
+                                <Label Text="Distortion Strength"
+                                       FontAttributes="Bold"
+                                       FontFamily="SF Pro Text"
+                                       TextColor="#F0F4FF" />
+                                <Slider Minimum="0"
+                                        Maximum="100"
+                                        Value="{Binding DistortionStrength, Mode=TwoWay}" />
+                                <Label Text="{Binding DistortionLabel}"
+                                       FontFamily="SF Pro Text"
+                                       FontSize="12"
+                                       TextColor="#A8B6D6" />
+                            </VerticalStackLayout>
+
+                            <Label Text="Adjust the parameters to customise the starting conductivity distribution."
+                                   FontFamily="SF Pro Text"
+                                   FontSize="12"
+                                   TextColor="#93A3C7"
+                                   LineBreakMode="WordWrap" />
+                        </VerticalStackLayout>
+                    </ScrollView>
+                </Border>
+            </Grid>
+        </Grid>
+    </Border>
+</toolkit:Popup>

--- a/ElectricalImpedanceTomography/Views/InitialDistributionEditorPopup.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/InitialDistributionEditorPopup.xaml.cs
@@ -1,0 +1,69 @@
+using CommunityToolkit.Maui.Views;
+using ElectricalImpedanceTomography.Helpers;
+using ElectricalImpedanceTomography.ViewModels;
+using Microsoft.Maui.ApplicationModel;
+using SkiaSharp.Views.Maui;
+using System;
+using Utility.Classes;
+using Utility.Classes.Discretizer;
+using Utility.Classes.Factories;
+
+namespace ElectricalImpedanceTomography.Views;
+
+public partial class InitialDistributionEditorPopup : Popup
+{
+    private readonly InitialDistributionEditorViewModel _viewModel;
+
+    public event EventHandler? DistributionChanged;
+
+    public InitialDistributionEditorPopup(IDiscretization discretization,
+                                          ConductivityDistribution initialDistribution,
+                                          ConductivityDistribution? originalDistribution,
+                                          InitialDistributionTypes initialType)
+    {
+        InitializeComponent();
+
+        _viewModel = new InitialDistributionEditorViewModel();
+        BindingContext = _viewModel;
+
+        _viewModel.Initialize(discretization, initialDistribution, originalDistribution, initialType);
+        _viewModel.DistributionUpdated += OnDistributionUpdated;
+    }
+
+    private void OnDistributionUpdated(object? sender, EventArgs e)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            PreviewCanvas.InvalidateSurface();
+            PreviewColorbarCanvas.InvalidateSurface();
+            DistributionChanged?.Invoke(this, EventArgs.Empty);
+        });
+    }
+
+    private void OnPreviewCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    {
+        DistributionRenderingHelper.DrawConductivity(e.Surface.Canvas,
+                                                    e.Info,
+                                                    _viewModel.Discretization,
+                                                    _viewModel.CurrentDistribution);
+    }
+
+    private void OnColorbarCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+    {
+        DistributionRenderingHelper.DrawColorBar(e.Surface.Canvas,
+                                                 e.Info,
+                                                 _viewModel.Discretization,
+                                                 _viewModel.CurrentDistribution);
+    }
+
+    private void OnCloseClicked(object sender, EventArgs e)
+    {
+        Close();
+    }
+
+    protected override void OnClosed(PopupClosedEventArgs e)
+    {
+        base.OnClosed(e);
+        _viewModel.DistributionUpdated -= OnDistributionUpdated;
+    }
+}

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -168,7 +168,23 @@
                                 BackgroundColor="{AppThemeBinding Light=#25324A, Dark=#25324A}">
                             <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
                                 <Label Grid.Row="0" Text="Parameters" FontSize="Medium" FontAttributes="Bold" Margin="0,0,0,12"/>
-                                <Label Grid.Row="1" HorizontalOptions="Start" Text="Initial Distribution" FontFamily="SF Pro Text" FontAttributes="None"/>
+                                <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                                    <Label Grid.Column="0"
+                                           HorizontalOptions="Start"
+                                           Text="Initial Distribution"
+                                           FontFamily="SF Pro Text"
+                                           FontAttributes="None"/>
+                                    <Button Grid.Column="1"
+                                            Text="Edit"
+                                            Padding="12,4"
+                                            FontFamily="SF Pro Text"
+                                            FontSize="12"
+                                            Clicked="OnEditInitialDistributionClicked"
+                                            IsEnabled="{Binding CanEditInitialDistribution}"
+                                            BackgroundColor="#2E3C55"
+                                            TextColor="#E5EEFF"
+                                            CornerRadius="8"/>
+                                </Grid>
                                 <Picker Grid.Row="2" ItemsSource="{Binding InitialDistributionOptions}" SelectedItem="{Binding ReconstructionParameters.InitialDistributionType}" MaximumWidthRequest="150"/>
                                 <Label Grid.Row="3" HorizontalOptions="Start" Text="Max Iteration Count" FontFamily="SF Pro Text" FontAttributes="None"/>
                                 <Entry Grid.Row="4" Text="{Binding MaxIterationCount}"/>

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -19,6 +19,7 @@ using Utility.Rendering;
 using Workspace = Utility.Classes.Application.Workspace;
 using Utility.Exports;
 using CommunityToolkit.Maui.Core;
+using Utility.Classes.Factories;
 
 namespace ElectricalImpedanceTomography.Views;
 
@@ -168,6 +169,12 @@ public partial class ReconstructionPage : ContentPage
     private void UpdateExportButtonState()
         => ExportVideoButton.IsEnabled = Workspace.GetReconstructionFrames().Count > 0;
 
+    private void OnInitialDistributionEdited(object? sender, EventArgs e)
+    {
+        InitialDistributionCanvas.InvalidateSurface();
+        InitialColorbarCanvas.InvalidateSurface();
+    }
+
     #region Simulation control
     private async void OnPlayButtonClicked(object sender, EventArgs e)
     {
@@ -216,6 +223,32 @@ public partial class ReconstructionPage : ContentPage
             PlayButton.IsVisible = true;
             PauseButton.IsVisible = false;
         }
+    }
+
+    private async void OnEditInitialDistributionClicked(object sender, EventArgs e)
+    {
+        if (!_viewModel.CanEditInitialDistribution)
+            return;
+
+        var discretization = GetDiscretization();
+        if (discretization == null)
+        {
+            await DisplayAlert("No Mesh", "You should create or load a mesh before editing the initial distribution!", "Ok");
+            return;
+        }
+
+        var initial = Workspace.GetInitialConductivityDistribution() ?? discretization.GetConductivityDistribution();
+        var original = Workspace.GetOriginalConductivityDistribution();
+        var popup = new InitialDistributionEditorPopup(discretization,
+                                                       initial,
+                                                       original,
+                                                       _viewModel.ReconstructionParameters.InitialDistributionType);
+        popup.DistributionChanged += OnInitialDistributionEdited;
+        await this.ShowPopupAsync(popup);
+        popup.DistributionChanged -= OnInitialDistributionEdited;
+
+        InitialDistributionCanvas.InvalidateSurface();
+        InitialColorbarCanvas.InvalidateSurface();
     }
 
     private async void OnPauseButtonClicked(object sender, EventArgs e)

--- a/Utility/Classes/Factories/ConductivityDistributionFactory.cs
+++ b/Utility/Classes/Factories/ConductivityDistributionFactory.cs
@@ -1,4 +1,5 @@
-﻿using Utility.Classes.Discretizer;
+﻿using System.Linq;
+using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 
 using Workspace = Utility.Classes.Application.Workspace;
@@ -10,7 +11,8 @@ namespace Utility.Classes.Factories
         Homogeneous = 1,
         Random = 2,
         SlightlyDiffering = 3,
-        RandomSlightlyDiffering = 4
+        RandomSlightlyDiffering = 4,
+        CloseToTarget = 5
     }
 
     public static class ConductivityDistributionFactory
@@ -112,6 +114,44 @@ namespace Utility.Classes.Factories
         }
 
         /// <summary>
+        /// Creates a conductivity distribution that closely resembles the original (target)
+        /// distribution while applying a gentle random distortion.
+        /// </summary>
+        /// <param name="discretization">The discretization that defines the element layout.</param>
+        /// <param name="distortion">Relative distortion strength in the [0, 1] range.</param>
+        /// <returns>A conductivity distribution similar to the target distribution.</returns>
+        public static ConductivityDistribution CreateCloseToTarget(IDiscretization discretization, double distortion = 0.1)
+        {
+            if (distortion < 0.0)
+                distortion = 0.0;
+
+            if (distortion > 1.0)
+                distortion = 1.0;
+
+            var random = new Random();
+
+            ConductivityDistribution? targetDistribution = Workspace.GetOriginalConductivityDistribution()
+                ?? Workspace.GetOriginalDiscretization()?.GetConductivityDistribution()
+                ?? discretization.GetConductivityDistribution();
+
+            // Clone the target conductivities so that callers get an independent copy.
+            var closeDistribution = new ConductivityDistribution(targetDistribution.Conductivities);
+
+            foreach (var elementId in closeDistribution.Conductivities.Keys.ToArray())
+            {
+                double originalValue = closeDistribution.Conductivities[elementId];
+                // Apply a symmetric random distortion around the original value.
+                double delta = (random.NextDouble() * 2.0 - 1.0) * distortion;
+                double distortedValue = originalValue * (1.0 + delta);
+                closeDistribution.Conductivities[elementId] = distortedValue;
+            }
+
+            Workspace.AddLogMessage("ConductivityDistributionFactory", "Created CloseToTarget ConductivityDistribution object.");
+
+            return closeDistribution;
+        }
+
+        /// <summary>
         /// Creates a conductivity distribution object, which is exactly the same as the provided mesh has
         /// </summary>
         /// <param name="mesh">The mesh that contians the conductivity distribution definition.</param>
@@ -139,6 +179,7 @@ namespace Utility.Classes.Factories
                 InitialDistributionTypes.SlightlyDiffering => CreateSlightlyDiffering(discretization, 0.95),
                 InitialDistributionTypes.RandomSlightlyDiffering =>
                     CreateRandomSlightlyDiffering(discretization, Math.Max(1, discretization.GetElements().Count / 10), 0.95),
+                InitialDistributionTypes.CloseToTarget => CreateCloseToTarget(discretization, 0.1),
                 _ => CreateHomogeneous(discretization)
             };
         }


### PR DESCRIPTION
## Summary
- add an initial distribution editor popup with an embedded preview canvas and controls
- implement a view model and rendering helper to generate homogeneous, random, and close-to-target starting distributions
- expose the editor from the reconstruction page with iteration-gated access and extend the factory with a close-to-target option

## Testing
- dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6908ac663fb48333b3701d9a2d679b5f