### PR TITLE
Align virtual electrode drive and measurement handling

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -1210,10 +1210,15 @@ namespace BusinessLayer
             LBMGrid deepCopy = (LBMGrid)mesh.DeepCopy();
             Workspace.UpdateCurrentGlobalLbmElectrodes(deepCopy);
             var electrodes = Workspace.GetCurrentGlobalLbmElectrodes();
-            int electrodeCount = electrodes.Count;
+            var virtualSettings = Workspace.GetReconstructionParameters().VirtualElectrodeSettings;
+            bool applyVirtuals = virtualSettings.ShouldApplyVirtualElectrodes();
+            var realElectrodes = electrodes.Where(e => !e.IsVirtual).ToList();
+            int electrodeCount = realElectrodes.Count;
 
             var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
-            int cycleLength = Math.Max(1, strategy.GetCycleLength(electrodeCount));
+            int cycleLength = electrodeCount > 0
+                ? Math.Max(1, strategy.GetCycleLength(electrodeCount))
+                : 1;
 
             var frames = new List<double[]>(cycleLength);
 
@@ -1231,14 +1236,20 @@ namespace BusinessLayer
                     el.Current = 0.0;
                 }
 
-                var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
+                if (electrodeCount > 0)
+                {
+                    var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
 
-                electrodes[excitationIndex].IsExcitation = true;
-                electrodes[excitationIndex].IsMeasuring = false;
-                electrodes[excitationIndex].Current = exciationAmplitude;
-                electrodes[groundIndex].IsGround = true;
-                electrodes[groundIndex].IsMeasuring = false;
-                electrodes[groundIndex].Current = -exciationAmplitude;
+                    var excitation = realElectrodes[excitationIndex];
+                    excitation.IsExcitation = true;
+                    excitation.IsMeasuring = false;
+                    excitation.Current = exciationAmplitude;
+
+                    var ground = realElectrodes[groundIndex];
+                    ground.IsGround = true;
+                    ground.IsMeasuring = false;
+                    ground.Current = -exciationAmplitude;
+                }
 
                 LBMBoundaryCondition boundaryCondition = new LBMBoundaryCondition(electrodes);
                 Workspace.SetCurrentGlobalLbmBoundaryCondition(boundaryCondition);
@@ -1252,7 +1263,10 @@ namespace BusinessLayer
                                                               measurementSetup,
                                                               _usePotentialDifferences);
                 referencePattern ??= pattern;
-                frames.Add(pattern.ExtractRawMeasurement(electrodePotentials));
+                var raw = pattern.ExtractRawMeasurement(electrodePotentials);
+                frames.Add(applyVirtuals
+                    ? FilterVirtualMeasurementChannels(pattern, electrodeProjectionList, raw)
+                    : raw);
             }
 
             Workspace.SetMeasurementPattern(referencePattern);
@@ -1498,10 +1512,15 @@ namespace BusinessLayer
 
             FEMMesh deepCopy = (FEMMesh)mesh.DeepCopy();
             var electrodes = deepCopy.GetElectrodes().ToList();
-            int electrodeCount = electrodes.Count();
+            var virtualSettings = Workspace.GetReconstructionParameters().VirtualElectrodeSettings;
+            bool applyVirtuals = virtualSettings.ShouldApplyVirtualElectrodes();
+            var realElectrodes = electrodes.Where(e => !e.IsVirtual).ToList();
+            int electrodeCount = realElectrodes.Count;
 
             var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
-            int cycleLength = Math.Max(1, strategy.GetCycleLength(electrodeCount));
+            int cycleLength = electrodeCount > 0
+                ? Math.Max(1, strategy.GetCycleLength(electrodeCount))
+                : 1;
 
             MeasurementPattern? referencePattern = null;
 
@@ -1518,13 +1537,19 @@ namespace BusinessLayer
                 }
 
                 // Set new electrode setup
-                var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
-                electrodes[excitationIndex].IsExcitation = true;
-                electrodes[excitationIndex].IsMeasuring = false;
-                electrodes[excitationIndex].Current = excitationAmplitude;
-                electrodes[groundIndex].IsGround = true;
-                electrodes[groundIndex].IsMeasuring = false;
-                electrodes[groundIndex].Current = -excitationAmplitude;
+                if (electrodeCount > 0)
+                {
+                    var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
+                    var excitation = realElectrodes[excitationIndex];
+                    excitation.IsExcitation = true;
+                    excitation.IsMeasuring = false;
+                    excitation.Current = excitationAmplitude;
+
+                    var ground = realElectrodes[groundIndex];
+                    ground.IsGround = true;
+                    ground.IsMeasuring = false;
+                    ground.Current = -excitationAmplitude;
+                }
 
                 FEMMesh result = SolveFemForward(deepCopy);
 
@@ -1535,11 +1560,47 @@ namespace BusinessLayer
                                                               measurementSetup,
                                                               _usePotentialDifferences);
                 referencePattern ??= pattern;
-                measurements.Add(pattern.ExtractRawMeasurement(potentials));
+                var raw = pattern.ExtractRawMeasurement(potentials);
+                measurements.Add(applyVirtuals
+                    ? FilterVirtualMeasurementChannels(pattern, electrodeProjectionList, raw)
+                    : raw);
             }
 
             Workspace.SetMeasurementPattern(referencePattern);
             return measurements;
+        }
+
+        private static double[] FilterVirtualMeasurementChannels(MeasurementPattern pattern,
+                                                                  IList<Electrode> electrodes,
+                                                                  double[] raw)
+        {
+            if (pattern == null)
+                throw new ArgumentNullException(nameof(pattern));
+            if (electrodes == null)
+                throw new ArgumentNullException(nameof(electrodes));
+            if (raw == null)
+                throw new ArgumentNullException(nameof(raw));
+
+            var filtered = new List<double>(raw.Length);
+            var channels = pattern.Channels;
+            for (int idx = 0; idx < channels.Count; idx++)
+            {
+                var channel = channels[idx];
+                bool involvesVirtual = false;
+
+                if (channel.FirstElectrodeIndex >= 0 && channel.FirstElectrodeIndex < electrodes.Count)
+                    involvesVirtual |= electrodes[channel.FirstElectrodeIndex].IsVirtual;
+
+                if (channel.SecondElectrodeIndex >= 0 && channel.SecondElectrodeIndex < electrodes.Count)
+                    involvesVirtual |= electrodes[channel.SecondElectrodeIndex].IsVirtual;
+
+                if (involvesVirtual)
+                    continue;
+
+                filtered.Add(raw[idx]);
+            }
+
+            return filtered.ToArray();
         }
 
         #endregion

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -1,4 +1,5 @@
 ﻿using BusinessLayer;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Utility.Classes;
@@ -155,8 +156,11 @@ namespace ServiceLayer
                 _useOmpParallelization = parameters.UseOmpParallelization;
 
                 // Determine frames per cycle based on electrode count and pattern.
-                var electrodeCount = discretization.GetElectrodes().Count;
-                _framesPerCycle = electrodeCount > 0 ? Math.Max(1, _drivePatternStrategy.GetCycleLength(electrodeCount)) : 1;
+                var electrodes = discretization.GetElectrodes();
+                int driveElectrodeCount = GetDriveElectrodeCount(electrodes);
+                _framesPerCycle = driveElectrodeCount > 0
+                    ? Math.Max(1, _drivePatternStrategy.GetCycleLength(driveElectrodeCount))
+                    : 1;
 
                 // Store noise settings for subsequent simulations/import handling.
                 _measurementNoiseType = parameters.MeasurementNoiseType;
@@ -205,6 +209,19 @@ namespace ServiceLayer
         /// <param name="electrodeCount">Number of electrodes.</param>
         /// <param name="stepIndex">Index of the step within the overall sequence.</param>
         /// <returns>Tuple of excitation and ground indices.</returns>
+        private static int GetDriveElectrodeCount(IEnumerable<Electrode> electrodes)
+        {
+            if (electrodes == null)
+                return 0;
+
+            var electrodeList = electrodes as IList<Electrode> ?? electrodes.ToList();
+            if (electrodeList.Count == 0)
+                return 0;
+
+            int realCount = electrodeList.Count(e => !e.IsVirtual);
+            return realCount > 0 ? realCount : electrodeList.Count;
+        }
+
         private (int ExcitationIndex, int GroundIndex) GetDrivePatternPair(int electrodeCount, int stepIndex)
         {
             if (electrodeCount <= 0)
@@ -237,10 +254,18 @@ namespace ServiceLayer
                 el.Potential = 0.0;
             }
 
-            var (excitationIndex, groundIndex) = GetDrivePatternPair(electrodes.Count, stepIndex);
+            var realElectrodes = electrodes
+                .Select((el, idx) => (Electrode: el, Index: idx))
+                .Where(pair => !pair.Electrode.IsVirtual)
+                .ToList();
+
+            if (realElectrodes.Count == 0)
+                return;
+
+            var (excitationIndex, groundIndex) = GetDrivePatternPair(realElectrodes.Count, stepIndex);
 
             // Assign excitation electrode and inject current.
-            var excitation = electrodes[excitationIndex];
+            var excitation = realElectrodes[excitationIndex].Electrode;
             excitation.IsExcitation = true;
             excitation.IsMeasuring = false;
 
@@ -249,7 +274,7 @@ namespace ServiceLayer
             excitation.Current = excitationAmplitude;
 
             // Assign ground electrode and sink the same current.
-            var ground = electrodes[groundIndex];
+            var ground = realElectrodes[groundIndex].Electrode;
             ground.IsGround = true;
             ground.IsMeasuring = false;
 
@@ -288,8 +313,8 @@ namespace ServiceLayer
 
             int electrodeCount = _discretization switch
             {
-                FEMMesh fem => fem.GetElectrodes().Count,
-                LBMGrid lbm => lbm.GetElectrodes().Count,
+                FEMMesh fem => GetDriveElectrodeCount(fem.GetElectrodes().Cast<Electrode>()),
+                LBMGrid lbm => GetDriveElectrodeCount(lbm.GetElectrodes().Cast<Electrode>()),
                 _ => 0
             };
 
@@ -539,7 +564,7 @@ namespace ServiceLayer
                 return measurement;
 
             var virtualSettings = Workspace.GetReconstructionParameters().VirtualElectrodeSettings;
-            if (virtualSettings.UseVirtualElectrodes)
+            if (virtualSettings.ShouldApplyVirtualElectrodes())
             {
                 var estimator = VirtualElectrodeEstimatorFactory.Create(virtualSettings);
                 var context = BuildForwardContext(electrodes);
@@ -621,13 +646,13 @@ namespace ServiceLayer
                 // excitation pair.  Electrode roles must be reconfigured for
                 // each frame so that the boundary condition reflects the
                 // rotating drive pattern.
-                int electrodeCount = femMesh.GetElectrodes().Count;
-                int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(electrodeCount));
+                var electrodes = femMesh.GetElectrodes().Cast<FEMElectrode>().ToList();
+                int driveElectrodeCount = GetDriveElectrodeCount(electrodes.Cast<Electrode>());
+                int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(driveElectrodeCount));
                 int stepIndex = _simMeasurementIndex % cycleLength;
                 var measurement = _simulatedMeasurements[stepIndex];
 
                 // Recompute electrode roles for this step and build BC.
-                var electrodes = femMesh.GetElectrodes().Cast<FEMElectrode>().ToList();
                 double effectiveAmplitude = _realMeasurementAmplitude ?? _excitationAmplitude;
                 ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, stepIndex);
 
@@ -671,8 +696,8 @@ namespace ServiceLayer
 
                 // Determine the current drive-pattern step and attach the boundary condition.
                 var electrodes = lbmGrid.GetElectrodes().Cast<LBMElectrode>().ToList();
-                int electrodeCount = electrodes.Count;
-                int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(electrodeCount));
+                int driveElectrodeCount = GetDriveElectrodeCount(electrodes.Cast<Electrode>());
+                int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(driveElectrodeCount));
                 int stepIndex = _simMeasurementIndex % cycleLength;
                 double effectiveAmplitude = _realMeasurementAmplitude ?? _excitationAmplitude;
                 ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, stepIndex);

--- a/Utility/Classes/Discretizer/FiniteElementMesh/FEMMesh.cs
+++ b/Utility/Classes/Discretizer/FiniteElementMesh/FEMMesh.cs
@@ -470,7 +470,7 @@ namespace Utility.Classes.Discretizer.FiniteElementMesh
                 SetElectrodes(realElectrodes);
             }
 
-            if (!settings.UseVirtualElectrodes || settings.VirtualElectrodesPerGap <= 0 || _electrodes.Count < 2)
+            if (!settings.ShouldApplyVirtualElectrodes() || settings.VirtualElectrodesPerGap <= 0 || _electrodes.Count < 2)
                 return;
 
             if (_orderedBoundaryVertices.Count == 0)

--- a/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMGrid.cs
+++ b/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMGrid.cs
@@ -188,7 +188,7 @@ namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
                 SetElectrodes(realElectrodes);
             }
 
-            if (!settings.UseVirtualElectrodes || settings.VirtualElectrodesPerGap <= 0 || _electrodes.Count < 2)
+            if (!settings.ShouldApplyVirtualElectrodes() || settings.VirtualElectrodesPerGap <= 0 || _electrodes.Count < 2)
                 return;
 
             var boundaryRing = GetBoundaryRing();

--- a/Utility/Classes/VirtualElectrodes/VirtualElectrodeSettings.cs
+++ b/Utility/Classes/VirtualElectrodes/VirtualElectrodeSettings.cs
@@ -54,5 +54,14 @@ namespace Utility.Classes.VirtualElectrodes
 
         [ObservableProperty]
         private double gpNoiseVariance = 1e-6;
+
+        /// <summary>
+        /// Indicates whether virtual electrodes should actively participate in the
+        /// reconstruction workflow.  Selecting "None" as the estimation method is
+        /// treated as an explicit request to disable virtual electrode processing
+        /// even if the UI toggle is enabled.
+        /// </summary>
+        public bool ShouldApplyVirtualElectrodes()
+            => UseVirtualElectrodes && Method != VirtualElectrodeMethod.None;
     }
 }


### PR DESCRIPTION
## Summary
- add an explicit guard on virtual electrode usage so meshes skip synthetic contacts when the method is set to "None"
- update FEM and LBM measurement simulation to drive only real electrodes and back-fill virtual channels through dedicated filtering
- adjust the reconstruction service to honour the new drive-count logic and only synthesize virtual potentials when required

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6909ff462e2883338e7801892ba248a1