### PR TITLE
Refactor measurement pipeline into dedicated persistence and service

### DIFF
--- a/BusinessLayer/IMeasurementPersistence.cs
+++ b/BusinessLayer/IMeasurementPersistence.cs
@@ -1,0 +1,67 @@
+using Utility.Classes.Measurement;
+using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Classes.ReconstructionParameters;
+using Utility.Classes.Reconstruction.VirtualElectrodes;
+using Utility.Classes;
+
+namespace BusinessLayer
+{
+    /// <summary>
+    /// Provides low-level measurement generation utilities used prior to running
+    /// reconstruction.  Implementations encapsulate the heavy lifting required
+    /// to produce simulated electrode measurements for FEM/LBM discretizations.
+    /// </summary>
+    public interface IMeasurementPersistence
+    {
+        /// <summary>
+        /// Simulates a full drive-pattern cycle on the provided FEM mesh.
+        /// </summary>
+        /// <param name="mesh">Finite element mesh to simulate on.</param>
+        /// <param name="excitationAmplitude">Excitation current amplitude.</param>
+        /// <param name="drivePattern">Electrode drive pattern used in the cycle.</param>
+        /// <param name="usePotentialDifferences">Whether potentials should be represented as differences.</param>
+        /// <param name="solver">Differential equation solver configured for the reconstruction session.</param>
+        /// <param name="measurementSetup">Current electrode measurement setup (active/non-active).</param>
+        /// <param name="virtualSettings">Virtual electrode options currently active.</param>
+        /// <returns>Simulated measurement frames and the inferred metadata.</returns>
+        MeasurementSimulationResult SimulateFemMeasurements(FEMMesh mesh,
+                                                            double excitationAmplitude,
+                                                            DrivePattern drivePattern,
+                                                            bool usePotentialDifferences,
+                                                            IDifferentialEquationSolver solver,
+                                                            ElectrodeMeasurementSetup measurementSetup,
+                                                            VirtualElectrodeSettings virtualSettings);
+
+        /// <summary>
+        /// Simulates a full drive-pattern cycle on the provided LBM grid.
+        /// </summary>
+        /// <param name="grid">Lattice Boltzmann grid to simulate on.</param>
+        /// <param name="excitationAmplitude">Excitation current amplitude.</param>
+        /// <param name="drivePattern">Electrode drive pattern used in the cycle.</param>
+        /// <param name="usePotentialDifferences">Whether potentials should be represented as differences.</param>
+        /// <param name="solver">Differential equation solver configured for the reconstruction session.</param>
+        /// <param name="measurementSetup">Current electrode measurement setup (active/non-active).</param>
+        /// <param name="virtualSettings">Virtual electrode options currently active.</param>
+        /// <returns>Simulated measurement frames and the inferred metadata.</returns>
+        MeasurementSimulationResult SimulateLbmMeasurements(LBMGrid grid,
+                                                            double excitationAmplitude,
+                                                            DrivePattern drivePattern,
+                                                            bool usePotentialDifferences,
+                                                            IDifferentialEquationSolver solver,
+                                                            ElectrodeMeasurementSetup measurementSetup,
+                                                            VirtualElectrodeSettings virtualSettings);
+    }
+
+    /// <summary>
+    /// Bundles measurement frames with metadata inferred during simulation.
+    /// </summary>
+    /// <param name="Frames">Simulated measurement frames.</param>
+    /// <param name="Amplitude">Optional amplitude associated with the frames.</param>
+    /// <param name="Pattern">Measurement pattern describing channel ordering.</param>
+    /// <param name="MeasurementSetup">Whether driven electrodes are included in the frames.</param>
+    public sealed record MeasurementSimulationResult(List<double[]> Frames,
+                                                      double? Amplitude,
+                                                      MeasurementPattern? Pattern,
+                                                      ElectrodeMeasurementSetup MeasurementSetup);
+}

--- a/BusinessLayer/IReconstructionPersistence.cs
+++ b/BusinessLayer/IReconstructionPersistence.cs
@@ -30,11 +30,6 @@ namespace BusinessLayer
         public ReconstructionResult InverseSolveFem(int maxIterationCount, double gradientStepSize, double redularizationStepSize, double excitationAmplitude, double tolerance = 1e-6);
         public ReconstructionResult InverseSolveLbm(int maxIterationCount, double gradientStepSize, double redularizationStepSize, double excitationAmplitude, double tolerance = 1e-6);
         public ReconstructionResult InverseSolveLbmCuda(int maxIterationCount, double gradientStepSize, double redularizationStepSize, double excitationAmplitude, double tolerance = 1e-6);
-
-
-        public List<double[]> SimulateFemMeasurements(FEMMesh mesh, double excitationAmplitude, DrivePattern drivePattern);
-        public EITMeasurement SimulateLbmMeasurements(LBMGrid mesh, double excitationAmplitude, DrivePattern drivePattern);
-
         // --- Graph-based Reconstruction ---
         /// <summary>
         ///     Performs a forward solve using the graph-based CEM model.  The
@@ -63,5 +58,7 @@ namespace BusinessLayer
         void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters);
         IEnumerable<ReconstructionInfo> GetReconstructions();
         List<ReconstructionResult> LoadReconstruction(string filePath);
+
+        IDifferentialEquationSolver? GetDifferentialEquationSolver();
     }
 }

--- a/BusinessLayer/MeasurementPersistence.cs
+++ b/BusinessLayer/MeasurementPersistence.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes;
+using Utility.Classes.Application;
+using Utility.Classes.Measurement;
+using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Classes.ReconstructionParameters;
+using Utility.Classes.Reconstruction.VirtualElectrodes;
+using Utility.Classes.Factories;
+
+namespace BusinessLayer
+{
+    /// <summary>
+    /// Default measurement persistence implementation that reuses the configured
+    /// differential equation solver to generate simulated electrode data prior to
+    /// reconstruction.
+    /// </summary>
+    public class MeasurementPersistence : IMeasurementPersistence
+    {
+        /// <inheritdoc />
+        public MeasurementSimulationResult SimulateFemMeasurements(FEMMesh mesh,
+                                                                    double excitationAmplitude,
+                                                                    DrivePattern drivePattern,
+                                                                    bool usePotentialDifferences,
+                                                                    IDifferentialEquationSolver solver,
+                                                                    ElectrodeMeasurementSetup measurementSetup,
+                                                                    VirtualElectrodeSettings virtualSettings)
+        {
+            if (mesh == null)
+                throw new ArgumentNullException(nameof(mesh));
+            if (solver == null)
+                throw new ArgumentNullException(nameof(solver));
+
+            FEMMesh deepCopy = (FEMMesh)mesh.DeepCopy();
+            var electrodes = deepCopy.GetElectrodes().ToList();
+            bool applyVirtuals = virtualSettings.ShouldApplyVirtualElectrodes();
+            var realElectrodes = electrodes.Where(e => !e.IsVirtual).ToList();
+            int electrodeCount = realElectrodes.Count;
+
+            var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
+            int cycleLength = electrodeCount > 0
+                ? Math.Max(1, strategy.GetCycleLength(electrodeCount))
+                : 1;
+
+            var frames = new List<double[]>(cycleLength);
+            MeasurementPattern? referencePattern = null;
+
+            for (int i = 0; i < cycleLength; i++)
+            {
+                foreach (var el in electrodes)
+                {
+                    el.Current = 0.0;
+                    el.IsExcitation = false;
+                    el.IsGround = false;
+                    el.IsMeasuring = true;
+                    el.Potential = 0.0;
+                }
+
+                if (electrodeCount > 0)
+                {
+                    var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
+                    var excitation = realElectrodes[excitationIndex];
+                    excitation.IsExcitation = true;
+                    excitation.IsMeasuring = false;
+                    excitation.Current = excitationAmplitude;
+
+                    var ground = realElectrodes[groundIndex];
+                    ground.IsGround = true;
+                    ground.IsMeasuring = false;
+                    ground.Current = -excitationAmplitude;
+                }
+
+                FEMMesh result = SolveFemForward(deepCopy, solver);
+
+                double[] potentials = PotentialClipper.Clip(result.GetElectrodePotentials());
+                var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+                var pattern = MeasurementPatternBuilder.Build(electrodeProjectionList,
+                                                              measurementSetup,
+                                                              usePotentialDifferences);
+                referencePattern ??= pattern;
+                var raw = pattern.ExtractRawMeasurement(potentials);
+                frames.Add(applyVirtuals
+                    ? FilterVirtualMeasurementChannels(pattern, electrodeProjectionList, raw)
+                    : raw);
+            }
+
+            return new MeasurementSimulationResult(frames, null, referencePattern, measurementSetup);
+        }
+
+        /// <inheritdoc />
+        public MeasurementSimulationResult SimulateLbmMeasurements(LBMGrid grid,
+                                                                    double excitationAmplitude,
+                                                                    DrivePattern drivePattern,
+                                                                    bool usePotentialDifferences,
+                                                                    IDifferentialEquationSolver solver,
+                                                                    ElectrodeMeasurementSetup measurementSetup,
+                                                                    VirtualElectrodeSettings virtualSettings)
+        {
+            if (grid == null)
+                throw new ArgumentNullException(nameof(grid));
+            if (solver == null)
+                throw new ArgumentNullException(nameof(solver));
+
+            LBMGrid deepCopy = (LBMGrid)grid.DeepCopy();
+            Workspace.UpdateCurrentGlobalLbmElectrodes(deepCopy);
+            var electrodes = Workspace.GetCurrentGlobalLbmElectrodes();
+            bool applyVirtuals = virtualSettings.ShouldApplyVirtualElectrodes();
+            var realElectrodes = electrodes.Where(e => !e.IsVirtual).ToList();
+            int electrodeCount = realElectrodes.Count;
+
+            var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
+            int cycleLength = electrodeCount > 0
+                ? Math.Max(1, strategy.GetCycleLength(electrodeCount))
+                : 1;
+
+            var frames = new List<double[]>(cycleLength);
+            MeasurementPattern? referencePattern = null;
+
+            for (int i = 0; i < cycleLength; i++)
+            {
+                foreach (var el in electrodes)
+                {
+                    el.IsMeasuring = true;
+                    el.IsGround = false;
+                    el.IsExcitation = false;
+                    el.Potential = 0.0;
+                    el.Current = 0.0;
+                }
+
+                if (electrodeCount > 0)
+                {
+                    var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
+
+                    var excitation = realElectrodes[excitationIndex];
+                    excitation.IsExcitation = true;
+                    excitation.IsMeasuring = false;
+                    excitation.Current = excitationAmplitude;
+
+                    var ground = realElectrodes[groundIndex];
+                    ground.IsGround = true;
+                    ground.IsMeasuring = false;
+                    ground.Current = -excitationAmplitude;
+                }
+
+                var boundaryCondition = new LBMBoundaryCondition(electrodes);
+                Workspace.SetCurrentGlobalLbmBoundaryCondition(boundaryCondition);
+
+                _ = solver.Solve(deepCopy, boundaryCondition, null);
+
+                double[] electrodePotentials = PotentialClipper.Clip(deepCopy.GetElectrodePotentials());
+                var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
+                var pattern = MeasurementPatternBuilder.Build(electrodeProjectionList,
+                                                              measurementSetup,
+                                                              usePotentialDifferences);
+                referencePattern ??= pattern;
+                var raw = pattern.ExtractRawMeasurement(electrodePotentials);
+                frames.Add(applyVirtuals
+                    ? FilterVirtualMeasurementChannels(pattern, electrodeProjectionList, raw)
+                    : raw);
+            }
+
+            return new MeasurementSimulationResult(frames, null, referencePattern, measurementSetup);
+        }
+
+        private static FEMMesh SolveFemForward(FEMMesh mesh, IDifferentialEquationSolver solver)
+        {
+            var boundaryCondition = new FEMBoundaryCondition(mesh.GetElectrodes().ToList());
+            var potentialDistribution = solver.Solve(mesh, boundaryCondition, null);
+            mesh.SetPotentialDistribution(PotentialClipper.Clip(potentialDistribution));
+            return mesh;
+        }
+
+        private static double[] FilterVirtualMeasurementChannels(MeasurementPattern pattern,
+                                                                  IList<Electrode> electrodes,
+                                                                  double[] raw)
+        {
+            if (pattern == null)
+                throw new ArgumentNullException(nameof(pattern));
+            if (electrodes == null)
+                throw new ArgumentNullException(nameof(electrodes));
+            if (raw == null)
+                throw new ArgumentNullException(nameof(raw));
+
+            var filtered = new List<double>(raw.Length);
+            var channels = pattern.Channels;
+            for (int idx = 0; idx < channels.Count; idx++)
+            {
+                var channel = channels[idx];
+                bool involvesVirtual = false;
+
+                if (channel.FirstElectrodeIndex >= 0 && channel.FirstElectrodeIndex < electrodes.Count)
+                    involvesVirtual |= electrodes[channel.FirstElectrodeIndex].IsVirtual;
+
+                if (channel.SecondElectrodeIndex >= 0 && channel.SecondElectrodeIndex < electrodes.Count)
+                    involvesVirtual |= electrodes[channel.SecondElectrodeIndex].IsVirtual;
+
+                if (involvesVirtual)
+                    continue;
+
+                filtered.Add(raw[idx]);
+            }
+
+            return filtered.ToArray();
+        }
+    }
+}

--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -13,6 +13,7 @@ using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Models;
 using Utility.Classes.Reconstruction;
+using Utility.Classes.Reconstruction.VirtualElectrodes;
 using Utility.Classes.ReconstructionParameters;
 using Utility.Exports;
 using Utility.Classes.Solvers.FiniteElementSolver;
@@ -37,6 +38,7 @@ namespace BusinessLayer
         // --- Persistence / repositories ---
         private readonly IDAQRepository _daqRepository;
         private readonly IReconstructionRepository _reconstructionRepository;
+        private readonly IMeasurementPersistence _measurementPersistence;
 
         // --- Core components configured during InitializeReconstruction() ---
         private InverseModel? _inverseModel = null;
@@ -78,10 +80,13 @@ namespace BusinessLayer
         // reconstruction result.
         private bool _stopRequested = false;
 
-        public ReconstructionPersistence(IDAQRepository daqRepository, IReconstructionRepository reconstructionRepository)
+        public ReconstructionPersistence(IDAQRepository daqRepository,
+                                         IReconstructionRepository reconstructionRepository,
+                                         IMeasurementPersistence measurementPersistence)
         {
             _daqRepository = daqRepository;
             _reconstructionRepository = reconstructionRepository;
+            _measurementPersistence = measurementPersistence;
         }
 
         /// <summary>
@@ -614,11 +619,33 @@ namespace BusinessLayer
             {
                 FEMMesh measMesh = (FEMMesh)mesh.DeepCopy();
                 measMesh.SetConductivityDistribution(originalSigma);
-                measurementFrames = SimulateFemMeasurements(measMesh, 1.0, _drivePattern);
+                var parameters = Workspace.GetReconstructionParameters();
+                var virtualSettings = parameters?.VirtualElectrodeSettings ?? new VirtualElectrodeSettings();
+                var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+                var solver = _differentialEquationSolver ?? throw new NullReferenceException("Differential equation solver not initialised.");
+                var simulation = _measurementPersistence.SimulateFemMeasurements(measMesh,
+                                                                                1.0,
+                                                                                _drivePattern,
+                                                                                _usePotentialDifferences,
+                                                                                solver,
+                                                                                measurementSetup,
+                                                                                virtualSettings);
+                measurementFrames = simulation.Frames;
             }
             else
             {
-                measurementFrames = SimulateFemMeasurements(mesh, 1.0, _drivePattern);
+                var parameters = Workspace.GetReconstructionParameters();
+                var virtualSettings = parameters?.VirtualElectrodeSettings ?? new VirtualElectrodeSettings();
+                var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+                var solver = _differentialEquationSolver ?? throw new NullReferenceException("Differential equation solver not initialised.");
+                var simulation = _measurementPersistence.SimulateFemMeasurements(mesh,
+                                                                                1.0,
+                                                                                _drivePattern,
+                                                                                _usePotentialDifferences,
+                                                                                solver,
+                                                                                measurementSetup,
+                                                                                virtualSettings);
+                measurementFrames = simulation.Frames;
             }
 
             // Use provided or generated initial sigma
@@ -720,11 +747,19 @@ namespace BusinessLayer
             {
                 LBMGrid measMesh = (LBMGrid)mesh.DeepCopy();
                 measMesh.SetConductivityDistribution(originalSigma);
-                measurementFrames = SimulateLbmMeasurements(measMesh, 1.0, _drivePattern);
+                var simulation = GenerateLbmMeasurements(measMesh, 1.0);
+                measurementFrames = simulation.Amplitude.HasValue
+                    ? new EITMeasurement(simulation.Frames, simulation.Amplitude.Value, simulation.Pattern)
+                    : new EITMeasurement(simulation.Frames, simulation.Pattern);
+                Workspace.SetElectrodeMeasurementSetup(simulation.MeasurementSetup);
             }
             else
             {
-                measurementFrames = SimulateLbmMeasurements(mesh, 1.0, _drivePattern);
+                var simulation = GenerateLbmMeasurements(mesh, 1.0);
+                measurementFrames = simulation.Amplitude.HasValue
+                    ? new EITMeasurement(simulation.Frames, simulation.Amplitude.Value, simulation.Pattern)
+                    : new EITMeasurement(simulation.Frames, simulation.Pattern);
+                Workspace.SetElectrodeMeasurementSetup(simulation.MeasurementSetup);
             }
 
             ConductivityDistribution initialSigma = _initialSigma ?? mesh.GetConductivityDistribution();
@@ -825,10 +860,10 @@ namespace BusinessLayer
             {
                 FEMMesh measMesh = (FEMMesh)mesh.DeepCopy();
                 measMesh.SetConductivityDistribution(originalConductivityDistribution);
-                simulatedMeasurements = SimulateFemMeasurements(measMesh, excitationAmplitude, _drivePattern);
+                simulatedMeasurements = GenerateFemMeasurements(measMesh, excitationAmplitude);
             }
             else
-                simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude, _drivePattern);
+                simulatedMeasurements = GenerateFemMeasurements(mesh, excitationAmplitude);
             
             // Initial field selection
             ConductivityDistribution initialConductivityDistribution = _initialSigma ?? ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
@@ -1149,11 +1184,19 @@ namespace BusinessLayer
             {
                 LBMGrid measMesh = (LBMGrid)lbmGrid.DeepCopy();
                 measMesh.SetConductivityDistribution(originalConductivityDistribution);
-                measurementFrames = SimulateLbmMeasurements(measMesh, 1.0, _drivePattern);
+                var simulation = GenerateLbmMeasurements(measMesh, 1.0);
+                measurementFrames = simulation.Amplitude.HasValue
+                    ? new EITMeasurement(simulation.Frames, simulation.Amplitude.Value, simulation.Pattern)
+                    : new EITMeasurement(simulation.Frames, simulation.Pattern);
+                Workspace.SetElectrodeMeasurementSetup(simulation.MeasurementSetup);
             }
             else
             {
-                measurementFrames = SimulateLbmMeasurements(lbmGrid, 1.0, _drivePattern);
+                var simulation = GenerateLbmMeasurements(lbmGrid, 1.0);
+                measurementFrames = simulation.Amplitude.HasValue
+                    ? new EITMeasurement(simulation.Frames, simulation.Amplitude.Value, simulation.Pattern)
+                    : new EITMeasurement(simulation.Frames, simulation.Pattern);
+                Workspace.SetElectrodeMeasurementSetup(simulation.MeasurementSetup);
             }
 
             // Container to hold partial results from reconstrucion
@@ -1196,81 +1239,6 @@ namespace BusinessLayer
                                             initialConductivityDistribution,
                                             reconstructedConductivityDistribution,
                                             frames);
-        }
-
-        /// <summary>
-        /// Simulates LBM measurement frames according to the selected drive pattern on a deep copy of the mesh.
-        /// Each frame corresponds to one excitation/ground pair configuration with unit amplitude.
-        /// </summary>
-        public EITMeasurement SimulateLbmMeasurements(LBMGrid mesh, double exciationAmplitude, DrivePattern drivePattern)
-        {
-            if (_differentialEquationSolver == null)
-                throw new NullReferenceException("Differential equation solver was null, check initializiation code!");
-
-            LBMGrid deepCopy = (LBMGrid)mesh.DeepCopy();
-            Workspace.UpdateCurrentGlobalLbmElectrodes(deepCopy);
-            var electrodes = Workspace.GetCurrentGlobalLbmElectrodes();
-            var virtualSettings = Workspace.GetReconstructionParameters().VirtualElectrodeSettings;
-            bool applyVirtuals = virtualSettings.ShouldApplyVirtualElectrodes();
-            var realElectrodes = electrodes.Where(e => !e.IsVirtual).ToList();
-            int electrodeCount = realElectrodes.Count;
-
-            var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
-            int cycleLength = electrodeCount > 0
-                ? Math.Max(1, strategy.GetCycleLength(electrodeCount))
-                : 1;
-
-            var frames = new List<double[]>(cycleLength);
-
-            MeasurementPattern? referencePattern = null;
-
-            for (int i = 0; i < cycleLength; i++)
-            {
-                // Clear electrode status
-                foreach (var el in electrodes)
-                {
-                    el.IsMeasuring = true;
-                    el.IsGround = false;
-                    el.IsExcitation = false;
-                    el.Potential = 0.0;
-                    el.Current = 0.0;
-                }
-
-                if (electrodeCount > 0)
-                {
-                    var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
-
-                    var excitation = realElectrodes[excitationIndex];
-                    excitation.IsExcitation = true;
-                    excitation.IsMeasuring = false;
-                    excitation.Current = exciationAmplitude;
-
-                    var ground = realElectrodes[groundIndex];
-                    ground.IsGround = true;
-                    ground.IsMeasuring = false;
-                    ground.Current = -exciationAmplitude;
-                }
-
-                LBMBoundaryCondition boundaryCondition = new LBMBoundaryCondition(electrodes);
-                Workspace.SetCurrentGlobalLbmBoundaryCondition(boundaryCondition);
-
-                _ = _differentialEquationSolver.Solve(deepCopy, boundaryCondition, null);
-
-                double[] electrodePotentials = PotentialClipper.Clip(deepCopy.GetElectrodePotentials());
-                var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
-                var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
-                var pattern = MeasurementPatternBuilder.Build(electrodeProjectionList,
-                                                              measurementSetup,
-                                                              _usePotentialDifferences);
-                referencePattern ??= pattern;
-                var raw = pattern.ExtractRawMeasurement(electrodePotentials);
-                frames.Add(applyVirtuals
-                    ? FilterVirtualMeasurementChannels(pattern, electrodeProjectionList, raw)
-                    : raw);
-            }
-
-            Workspace.SetMeasurementPattern(referencePattern);
-            return new EITMeasurement(frames, referencePattern);
         }
 
         #endregion
@@ -1316,7 +1284,7 @@ namespace BusinessLayer
 
             _regularizationWeight = regularization;
 
-            List<double[]> simulatedMeasurements = SimulateFemMeasurements(mesh, excitationAmplitude, _drivePattern);
+            List<double[]> simulatedMeasurements = GenerateFemMeasurements(mesh, excitationAmplitude);
             
             // 2) Initialize conductivity (σ^{(0)}) based on user selection
             ConductivityDistribution sigma = ConductivityClipper.Clip(ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType));
@@ -1502,105 +1470,38 @@ namespace BusinessLayer
             return mesh;
         }
 
-        /// <summary>
-        /// Simulates forward FEM measurements for a full cycle of the selected drive pattern.
-        /// Each frame is the set of electrode potentials for a single excitation/ground pair.
-        /// </summary>
-        public List<double[]> SimulateFemMeasurements(FEMMesh mesh, double excitationAmplitude, DrivePattern drivePattern)
+        private List<double[]> GenerateFemMeasurements(FEMMesh mesh, double excitationAmplitude)
         {
-            List<double[]> measurements = [];
+            var parameters = Workspace.GetReconstructionParameters();
+            var virtualSettings = parameters?.VirtualElectrodeSettings ?? new VirtualElectrodeSettings();
+            var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+            var solver = _differentialEquationSolver ?? throw new NullReferenceException("Differential equation solver not initialised.");
 
-            FEMMesh deepCopy = (FEMMesh)mesh.DeepCopy();
-            var electrodes = deepCopy.GetElectrodes().ToList();
-            var virtualSettings = Workspace.GetReconstructionParameters().VirtualElectrodeSettings;
-            bool applyVirtuals = virtualSettings.ShouldApplyVirtualElectrodes();
-            var realElectrodes = electrodes.Where(e => !e.IsVirtual).ToList();
-            int electrodeCount = realElectrodes.Count;
-
-            var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
-            int cycleLength = electrodeCount > 0
-                ? Math.Max(1, strategy.GetCycleLength(electrodeCount))
-                : 1;
-
-            MeasurementPattern? referencePattern = null;
-
-            for (int i = 0; i < cycleLength; i++)
-            {
-                // Clear electrode status
-                foreach(var el in electrodes)
-                {
-                    el.Current = 0.0;
-                    el.IsExcitation = false;
-                    el.IsGround = false;
-                    el.IsMeasuring = true;
-                    el.Potential = 0.0;
-                }
-
-                // Set new electrode setup
-                if (electrodeCount > 0)
-                {
-                    var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
-                    var excitation = realElectrodes[excitationIndex];
-                    excitation.IsExcitation = true;
-                    excitation.IsMeasuring = false;
-                    excitation.Current = excitationAmplitude;
-
-                    var ground = realElectrodes[groundIndex];
-                    ground.IsGround = true;
-                    ground.IsMeasuring = false;
-                    ground.Current = -excitationAmplitude;
-                }
-
-                FEMMesh result = SolveFemForward(deepCopy);
-
-                double[] potentials = PotentialClipper.Clip(result.GetElectrodePotentials());
-                var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
-                var electrodeProjectionList = electrodes.Cast<Electrode>().ToList();
-                var pattern = MeasurementPatternBuilder.Build(electrodeProjectionList,
-                                                              measurementSetup,
-                                                              _usePotentialDifferences);
-                referencePattern ??= pattern;
-                var raw = pattern.ExtractRawMeasurement(potentials);
-                measurements.Add(applyVirtuals
-                    ? FilterVirtualMeasurementChannels(pattern, electrodeProjectionList, raw)
-                    : raw);
-            }
-
-            Workspace.SetMeasurementPattern(referencePattern);
-            return measurements;
+            return _measurementPersistence
+                .SimulateFemMeasurements(mesh,
+                                          excitationAmplitude,
+                                          _drivePattern,
+                                          _usePotentialDifferences,
+                                          solver,
+                                          measurementSetup,
+                                          virtualSettings)
+                .Frames;
         }
 
-        private static double[] FilterVirtualMeasurementChannels(MeasurementPattern pattern,
-                                                                  IList<Electrode> electrodes,
-                                                                  double[] raw)
+        private MeasurementSimulationResult GenerateLbmMeasurements(LBMGrid grid, double excitationAmplitude)
         {
-            if (pattern == null)
-                throw new ArgumentNullException(nameof(pattern));
-            if (electrodes == null)
-                throw new ArgumentNullException(nameof(electrodes));
-            if (raw == null)
-                throw new ArgumentNullException(nameof(raw));
+            var parameters = Workspace.GetReconstructionParameters();
+            var virtualSettings = parameters?.VirtualElectrodeSettings ?? new VirtualElectrodeSettings();
+            var measurementSetup = Workspace.GetElectrodeMeasurementSetup();
+            var solver = _differentialEquationSolver ?? throw new NullReferenceException("Differential equation solver not initialised.");
 
-            var filtered = new List<double>(raw.Length);
-            var channels = pattern.Channels;
-            for (int idx = 0; idx < channels.Count; idx++)
-            {
-                var channel = channels[idx];
-                bool involvesVirtual = false;
-
-                if (channel.FirstElectrodeIndex >= 0 && channel.FirstElectrodeIndex < electrodes.Count)
-                    involvesVirtual |= electrodes[channel.FirstElectrodeIndex].IsVirtual;
-
-                if (channel.SecondElectrodeIndex >= 0 && channel.SecondElectrodeIndex < electrodes.Count)
-                    involvesVirtual |= electrodes[channel.SecondElectrodeIndex].IsVirtual;
-
-                if (involvesVirtual)
-                    continue;
-
-                filtered.Add(raw[idx]);
-            }
-
-            return filtered.ToArray();
+            return _measurementPersistence.SimulateLbmMeasurements(grid,
+                                                                    excitationAmplitude,
+                                                                    _drivePattern,
+                                                                    _usePotentialDifferences,
+                                                                    solver,
+                                                                    measurementSetup,
+                                                                    virtualSettings);
         }
 
         #endregion
@@ -1662,5 +1563,7 @@ namespace BusinessLayer
         /// Loads a previously saved reconstruction from a file path.
         /// </summary>
         public List<ReconstructionResult> LoadReconstruction(string filePath) => _reconstructionRepository.LoadReconstruction(filePath);
+
+        public IDifferentialEquationSolver? GetDifferentialEquationSolver() => _differentialEquationSolver;
     }
 }

--- a/BusinessLayer/Settings.cs
+++ b/BusinessLayer/Settings.cs
@@ -8,6 +8,7 @@ namespace BusinessLayer
         {
             return DataAccessLayer.Settings.ApplyContainerRegistration()
                 .RegisterType<IDAQPersistence, DAQPersistence>()
+                .RegisterType<IMeasurementPersistence, MeasurementPersistence>()
                 .RegisterType<IReconstructionPersistence, ReconstructionPersistence>();
         }
     }

--- a/ServiceLayer/IMeasurementService.cs
+++ b/ServiceLayer/IMeasurementService.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Utility.Classes;
+using Utility.Classes.Discretizer;
+using Utility.Classes.Measurement;
+using Utility.Classes.ReconstructionParameters;
+
+namespace ServiceLayer
+{
+    public interface IMeasurementService
+    {
+        void Initialize(IDiscretization discretization,
+                        EITReconstructionParameters parameters,
+                        DrivePattern drivePattern,
+                        Func<IDifferentialEquationSolver?> solverAccessor);
+
+        void SyncMeasurementSource();
+        void EnsureMeasurements(double excitationAmplitude);
+        double[] GetMeasurementForStep(int stepIndex);
+        IReadOnlyList<double[]> GetAllMeasurements();
+        double[] PrepareMeasurementFrame(double[] measurement, IList<Electrode> electrodes);
+
+        int FramesPerCycle { get; }
+        double? RealMeasurementAmplitude { get; }
+        ElectrodeMeasurementSetup MeasurementSetup { get; }
+        MeasurementPattern? CurrentPattern { get; }
+        bool UsePotentialDifferences { get; }
+    }
+}

--- a/ServiceLayer/MeasurementService.cs
+++ b/ServiceLayer/MeasurementService.cs
@@ -1,0 +1,469 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BusinessLayer;
+using Utility.Classes;
+using Utility.Classes.Application;
+using Utility.Classes.Discretizer;
+using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Classes.Factories;
+using Utility.Classes.Measurement;
+using Utility.Classes.Reconstruction.VirtualElectrodes;
+using Utility.Classes.ReconstructionParameters;
+using Utility.Logger;
+
+namespace ServiceLayer
+{
+    /// <summary>
+    /// Coordinates acquisition (or simulation) of measurement frames prior to reconstruction.
+    /// The service centralises the previously scattered measurement logic so callers only need
+    /// to request frames and mapping helpers while it tracks metadata, noise injection and
+    /// workspace updates.
+    /// </summary>
+    public class MeasurementService : IMeasurementService
+    {
+        private readonly IMeasurementPersistence _measurementPersistence;
+        private readonly ILogger _logger;
+        private readonly Random _noiseRandom = new();
+
+        private Func<IDifferentialEquationSolver?>? _solverAccessor;
+        private IDiscretization? _discretization;
+        private DrivePattern _drivePattern = DrivePattern.Adjecent;
+        private IDrivePatternStrategy _drivePatternStrategy = DrivePatternStrategyProvider.GetStrategy(DrivePattern.Adjecent);
+        private MeasurementNoiseType _noiseType = MeasurementNoiseType.None;
+        private double _noiseAmplitude;
+        private readonly List<double[]> _measurements = [];
+        private MeasurementSourceOption _measurementSource = MeasurementSourceOption.Simulated;
+        private double? _realMeasurementAmplitude;
+        private ElectrodeMeasurementSetup _measurementSetup = ElectrodeMeasurementSetup.Active;
+        private bool _usePotentialDifferences;
+        private MeasurementPattern? _measurementPattern;
+        private VirtualElectrodeSettings _virtualSettings = new();
+        private int _framesPerCycle = 1;
+
+        public MeasurementService(IMeasurementPersistence measurementPersistence, ILogger logger)
+        {
+            _measurementPersistence = measurementPersistence;
+            _logger = logger;
+        }
+
+        public int FramesPerCycle => _framesPerCycle;
+        public double? RealMeasurementAmplitude => _realMeasurementAmplitude;
+        public ElectrodeMeasurementSetup MeasurementSetup => _measurementSetup;
+        public MeasurementPattern? CurrentPattern => _measurementPattern;
+        public bool UsePotentialDifferences => _usePotentialDifferences;
+
+        /// <summary>
+        /// Configures the measurement service for a new reconstruction session.
+        /// Stores the discretization, solver accessor and noise configuration so that
+        /// future <see cref="EnsureMeasurements"/> calls can generate or adopt frames.
+        /// </summary>
+        public void Initialize(IDiscretization discretization,
+                               EITReconstructionParameters parameters,
+                               DrivePattern drivePattern,
+                               Func<IDifferentialEquationSolver?> solverAccessor)
+        {
+            _discretization = discretization ?? throw new ArgumentNullException(nameof(discretization));
+            _drivePattern = drivePattern;
+            _drivePatternStrategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
+            _solverAccessor = solverAccessor ?? throw new ArgumentNullException(nameof(solverAccessor));
+
+            _noiseType = parameters.MeasurementNoiseType;
+            _noiseAmplitude = parameters.MeasurementNoiseAmplitude;
+            _usePotentialDifferences = parameters.UsePotentialDifferences;
+            _virtualSettings = parameters.VirtualElectrodeSettings ?? new VirtualElectrodeSettings();
+
+            _measurementSource = Workspace.GetMeasurementSource();
+            _measurementPattern = null;
+            _measurements.Clear();
+            _realMeasurementAmplitude = null;
+            _measurementSetup = ElectrodeMeasurementSetup.Active;
+            Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
+            Workspace.SetMeasurementPattern(null);
+
+            _framesPerCycle = Math.Max(1, DetermineCycleLength());
+        }
+
+        /// <summary>
+        /// Aligns the cached measurement source with the workspace selection. Switching
+        /// from simulated to real data (or vice versa) clears previously generated frames
+        /// so new ones can be obtained from the requested origin.
+        /// </summary>
+        public void SyncMeasurementSource()
+        {
+            var desired = Workspace.GetMeasurementSource();
+            if (desired == _measurementSource)
+                return;
+
+            _measurementSource = desired;
+            _measurements.Clear();
+            _realMeasurementAmplitude = null;
+            _measurementPattern = null;
+            Workspace.SetMeasurementPattern(null);
+            _measurementSetup = ElectrodeMeasurementSetup.Active;
+            Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
+            _framesPerCycle = Math.Max(1, DetermineCycleLength());
+        }
+
+        /// <summary>
+        /// Guarantees that measurement frames are available. Depending on the configured
+        /// source the frames are either cloned from the workspace (real data) or simulated
+        /// via the persistence layer using the provided excitation amplitude.
+        /// </summary>
+        public void EnsureMeasurements(double excitationAmplitude)
+        {
+            if (_measurements.Count > 0)
+                return;
+            if (_discretization == null)
+                throw new InvalidOperationException("Measurement service has not been initialised.");
+
+            int electrodeCount = DetermineElectrodeCount();
+
+            if (_measurementSource == MeasurementSourceOption.Real)
+            {
+                var measurement = Workspace.GetImportedMeasurement();
+                if (measurement != null && measurement.Frames.Count > 0)
+                {
+                    // Clone the imported buffers so we can inject noise or modifications without
+                    // mutating the workspace copy.
+                    _measurements.Clear();
+                    _measurements.AddRange(measurement.Frames.Select(frame => (double[])frame.Clone()));
+                    _realMeasurementAmplitude = measurement.CurrentAmplitude;
+                    AdoptMeasurementMetadata(measurement.Pattern, _measurements, electrodeCount, measurement.Pattern?.MeasurementSetup);
+                    _framesPerCycle = Math.Max(1, _measurements.Count);
+                    return;
+                }
+
+                // If the user requested real measurements but none are available we fall back
+                // to simulated data and inform them via the workspace message stream.
+                Workspace.AddWarningMessage("Real measurement data was requested but is not available. Falling back to simulated measurements.");
+                _logger.LogWarning("Real measurement data was requested but not available. Falling back to simulated measurements.");
+                _measurementSource = MeasurementSourceOption.Simulated;
+                _realMeasurementAmplitude = null;
+            }
+
+            var solver = _solverAccessor?.Invoke();
+            if (solver == null)
+                throw new InvalidOperationException("Differential equation solver is not available for measurement simulation.");
+
+            MeasurementSimulationResult simulation = _discretization switch
+            {
+                // Delegate the heavy lifting to the measurement persistence implementation
+                // which mirrors the old reconstruction persistence helpers.
+                FEMMesh fem => _measurementPersistence.SimulateFemMeasurements(fem,
+                                                                               excitationAmplitude,
+                                                                               _drivePattern,
+                                                                               _usePotentialDifferences,
+                                                                               solver,
+                                                                               _measurementSetup,
+                                                                               _virtualSettings),
+                LBMGrid lbm => _measurementPersistence.SimulateLbmMeasurements(lbm,
+                                                                               excitationAmplitude,
+                                                                               _drivePattern,
+                                                                               _usePotentialDifferences,
+                                                                               solver,
+                                                                               _measurementSetup,
+                                                                               _virtualSettings),
+                _ => throw new InvalidOperationException($"Unsupported discretization type {_discretization.GetType().Name} for measurement simulation.")
+            };
+
+            _measurements.Clear();
+            _measurements.AddRange(simulation.Frames.Select(frame => (double[])frame.Clone()));
+            _realMeasurementAmplitude = simulation.Amplitude;
+
+            // Noise is injected only for simulated data so real measurements remain pristine.
+            ApplyMeasurementNoise(_measurements, _noiseType, _noiseAmplitude);
+            // Update measurement setup / pattern inference based on the freshly generated frames.
+            AdoptMeasurementMetadata(simulation.Pattern, _measurements, electrodeCount, simulation.MeasurementSetup);
+            _framesPerCycle = Math.Max(1, _measurements.Count);
+        }
+
+        /// <summary>
+        /// Returns the measurement frame corresponding to the requested drive-pattern step.
+        /// The index is wrapped so callers can iterate indefinitely.
+        /// </summary>
+        public double[] GetMeasurementForStep(int stepIndex)
+        {
+            if (_measurements.Count == 0)
+                throw new InvalidOperationException("Measurements have not been prepared yet.");
+
+            int index = stepIndex % _measurements.Count;
+            if (index < 0)
+                index += _measurements.Count;
+            return _measurements[index];
+        }
+
+        public IReadOnlyList<double[]> GetAllMeasurements() => _measurements;
+
+        /// <summary>
+        /// Normalises a raw measurement snapshot to the solver ordering by applying optional
+        /// virtual electrode completion and mapping it through the current measurement pattern.
+        /// </summary>
+        public double[] PrepareMeasurementFrame(double[] measurement, IList<Electrode> electrodes)
+        {
+            if (measurement == null)
+                throw new ArgumentNullException(nameof(measurement));
+            if (electrodes == null)
+                throw new ArgumentNullException(nameof(electrodes));
+
+            if (electrodes.Count == 0)
+                return measurement;
+
+            if (_virtualSettings.ShouldApplyVirtualElectrodes())
+            {
+                var estimator = VirtualElectrodeEstimatorFactory.Create(_virtualSettings);
+                var context = BuildForwardContext(electrodes);
+                measurement = estimator.CompleteElectrodePotentials(electrodes, measurement, _virtualSettings, context);
+            }
+
+            var electrodeProjection = electrodes.ToList();
+            var pattern = MeasurementPatternBuilder.Build(electrodeProjection,
+                                                          Workspace.GetElectrodeMeasurementSetup(),
+                                                          _usePotentialDifferences);
+            _measurementPattern = pattern;
+            Workspace.SetMeasurementPattern(pattern);
+
+            return pattern.MapMeasurement(measurement);
+        }
+
+        private int DetermineElectrodeCount()
+        {
+            return _discretization switch
+            {
+                FEMMesh fem => GetDriveElectrodeCount(fem.GetElectrodes().Cast<Electrode>()),
+                LBMGrid lbm => GetDriveElectrodeCount(lbm.GetElectrodes().Cast<Electrode>()),
+                _ => 0
+            };
+        }
+
+        private int DetermineCycleLength()
+        {
+            int electrodeCount = DetermineElectrodeCount();
+            if (electrodeCount <= 0)
+                return 1;
+            return Math.Max(1, _drivePatternStrategy.GetCycleLength(electrodeCount));
+        }
+
+        private static int GetDriveElectrodeCount(IEnumerable<Electrode> electrodes)
+        {
+            if (electrodes == null)
+                return 0;
+
+            var electrodeList = electrodes as IList<Electrode> ?? electrodes.ToList();
+            if (electrodeList.Count == 0)
+                return 0;
+
+            int realCount = electrodeList.Count(e => !e.IsVirtual);
+            return realCount > 0 ? realCount : electrodeList.Count;
+        }
+
+        private void ApplyMeasurementNoise(List<double[]> measurements, MeasurementNoiseType noiseType, double noiseAmplitude)
+        {
+            if (measurements.Count == 0 || noiseType == MeasurementNoiseType.None)
+                return;
+            if (_measurementSource != MeasurementSourceOption.Simulated)
+                return;
+
+            bool amplitudeInDecibels = noiseAmplitude < 0.0;
+            double amplitude = amplitudeInDecibels
+                ? Math.Pow(10.0, noiseAmplitude / 20.0)
+                : Math.Abs(noiseAmplitude);
+            if (amplitude <= double.Epsilon)
+                return;
+
+            foreach (var frame in measurements)
+            {
+                for (int i = 0; i < frame.Length; i++)
+                {
+                    // Gaussian uses Box-Muller, uniform simply samples from [-amp, amp].
+                    double noise = noiseType switch
+                    {
+                        MeasurementNoiseType.Gaussian => NextGaussian(0.0, amplitude),
+                        MeasurementNoiseType.Uniform => (_noiseRandom.NextDouble() * 2.0 - 1.0) * amplitude,
+                        _ => 0.0
+                    };
+
+                    frame[i] += noise;
+                }
+            }
+        }
+
+        private double NextGaussian(double mean, double stdDev)
+        {
+            double u1 = 1.0 - _noiseRandom.NextDouble();
+            double u2 = 1.0 - _noiseRandom.NextDouble();
+            double randStdNormal = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);
+            return mean + stdDev * randStdNormal;
+        }
+
+        private void AdoptMeasurementMetadata(MeasurementPattern? pattern,
+                                              IReadOnlyList<double[]> frames,
+                                              int electrodeCount,
+                                              ElectrodeMeasurementSetup? enforcedSetup)
+        {
+            if (pattern != null)
+            {
+                if (_measurementSetup != pattern.MeasurementSetup)
+                {
+                    _measurementSetup = pattern.MeasurementSetup;
+                    Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
+                }
+
+                bool useDifferences = pattern.Representation == MeasurementRepresentation.PotentialDifference;
+                ApplyUsePotentialDifferenceSetting(useDifferences,
+                    useDifferences
+                        ? "Adopting potential-difference mode from provided measurement pattern."
+                        : "Adopting amplitude mode from provided measurement pattern.");
+
+                _measurementPattern = pattern;
+                Workspace.SetMeasurementPattern(pattern);
+                return;
+            }
+
+            if (enforcedSetup.HasValue && _measurementSetup != enforcedSetup.Value)
+            {
+                _measurementSetup = enforcedSetup.Value;
+                Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
+            }
+
+            UpdateMeasurementOptionsFromFrames(electrodeCount, frames);
+        }
+
+        private void UpdateMeasurementOptionsFromFrames(int electrodeCount, IReadOnlyList<double[]> frames)
+        {
+            if (electrodeCount <= 0 || frames == null || frames.Count == 0)
+            {
+                _measurementSetup = ElectrodeMeasurementSetup.Active;
+                Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
+                return;
+            }
+
+            int frameLength = frames[0].Length;
+            long totalMeasurements = (long)frameLength * frames.Count;
+            long expectedActiveTotal = (long)electrodeCount * electrodeCount;
+            long expectedNonActiveTotal = (long)electrodeCount * Math.Max(0, electrodeCount - 3);
+            int nonActiveAmplitudeLength = Math.Max(0, electrodeCount - 2);
+            int nonActiveDifferenceLength = Math.Max(0, electrodeCount - 3);
+
+            bool looksActive = frameLength == electrodeCount || totalMeasurements == expectedActiveTotal;
+            bool looksNonActive = !looksActive && (frameLength == nonActiveAmplitudeLength || totalMeasurements == expectedNonActiveTotal);
+
+            _measurementSetup = looksActive ? ElectrodeMeasurementSetup.Active : ElectrodeMeasurementSetup.NonActive;
+
+            if (!looksActive && !looksNonActive)
+            {
+                Workspace.AddWarningMessage($"Ambiguous measurement frame dimensions (frame length {frameLength}, frame count {frames.Count}, electrodes {electrodeCount}). Assuming {_measurementSetup} electrodes.");
+            }
+
+            Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
+
+            bool inferredDifferences = InferPotentialDifferenceMode(electrodeCount, frames);
+            ApplyUsePotentialDifferenceSetting(inferredDifferences,
+                inferredDifferences
+                    ? "Detected potential-difference measurements from frame statistics."
+                    : "Detected amplitude measurements from frame statistics.");
+        }
+
+        private bool InferPotentialDifferenceMode(int electrodeCount, IReadOnlyList<double[]> frames)
+        {
+            if (frames == null || frames.Count == 0)
+                return _usePotentialDifferences;
+
+            int frameLength = frames[0].Length;
+            int nonActiveAmplitudeLength = Math.Max(0, electrodeCount - 2);
+            int nonActiveDifferenceLength = Math.Max(0, electrodeCount - 3);
+
+            if (_measurementSetup == ElectrodeMeasurementSetup.NonActive)
+            {
+                if (frameLength == nonActiveDifferenceLength)
+                    return true;
+                if (frameLength == nonActiveAmplitudeLength)
+                    return false;
+            }
+            else if (frameLength == nonActiveDifferenceLength)
+            {
+                return true;
+            }
+
+            if (frameLength != electrodeCount)
+                return _usePotentialDifferences;
+
+            int framesToInspect = Math.Min(frames.Count, 5);
+            int zeroLikeFrames = 0;
+            int finiteFrames = 0;
+
+            for (int i = 0; i < framesToInspect; i++)
+            {
+                var frame = frames[i];
+                double sum = 0.0;
+                double maxAbs = 0.0;
+                int finiteCount = 0;
+
+                foreach (var sample in frame)
+                {
+                    if (!double.IsFinite(sample))
+                        continue;
+
+                    sum += sample;
+                    finiteCount++;
+                    double abs = Math.Abs(sample);
+                    if (abs > maxAbs)
+                        maxAbs = abs;
+                }
+
+                if (finiteCount == 0)
+                    continue;
+
+                finiteFrames++;
+                double tolerance = Math.Max(1e-6, maxAbs * 1e-3);
+                if (Math.Abs(sum) <= tolerance)
+                    zeroLikeFrames++;
+            }
+
+            return finiteFrames > 0 && zeroLikeFrames == finiteFrames;
+        }
+
+        private void ApplyUsePotentialDifferenceSetting(bool enabled, string reason)
+        {
+            if (_usePotentialDifferences == enabled)
+                return;
+
+            _usePotentialDifferences = enabled;
+
+            var parameters = Workspace.GetReconstructionParameters();
+            if (parameters != null && parameters.UsePotentialDifferences != enabled)
+                parameters.UsePotentialDifferences = enabled;
+
+            Workspace.AddLogMessage("Measurement Service", reason);
+            _measurementPattern = null;
+            Workspace.SetMeasurementPattern(null);
+        }
+
+        private ForwardModelContext BuildForwardContext(IReadOnlyList<Electrode> electrodes)
+        {
+            if (_discretization is FEMMesh fem)
+            {
+                return new ForwardModelContext
+                {
+                    ElectrodeAngles = fem.GetElectrodeAngles(),
+                    RealElectrodeCount = electrodes.Count(e => !e.IsVirtual)
+                };
+            }
+
+            if (_discretization is LBMGrid lbm)
+            {
+                return new ForwardModelContext
+                {
+                    ElectrodeAngles = lbm.GetElectrodeAngles(),
+                    RealElectrodeCount = electrodes.Count(e => !e.IsVirtual)
+                };
+            }
+
+            return new ForwardModelContext
+            {
+                RealElectrodeCount = electrodes.Count(e => !e.IsVirtual)
+            };
+        }
+    }
+}

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -13,7 +13,6 @@ using Utility.Logger;
 
 using Workspace = Utility.Classes.Application.Workspace;
 using Utility.Exports;
-using Utility.Classes.Reconstruction.VirtualElectrodes;
 
 namespace ServiceLayer
 {
@@ -32,6 +31,7 @@ namespace ServiceLayer
     public class ReconstructionService : IReconstructionService
     {
         private readonly IReconstructionPersistence _reconstructionPersistence;
+        private readonly IMeasurementService _measurementService;
         private readonly ILogger _logger;
 
         // Background reconstruction state
@@ -44,28 +44,14 @@ namespace ServiceLayer
         private double _stepSize;                                           // Optimizer step size for inverse steps
         private double _regularizationWeight;                               // Regularization weight sent to the persistence layer
         private double _excitationAmplitude;                                // Current amplitude applied to the excitation electrode
-        private List<double[]> _simulatedMeasurements = [];                 // Synthetic/real measurement frames for a cycle
         private int _simMeasurementIndex;                                   // Index of the current frame within a cycle
         private List<ReconstructionFrame> _currentCycleFrames = [];         // Frames accumulated within the active cycle
         private ConductivityDistribution? _originalSigma;                   // Ground-truth conductivities (for comparison)
         private ConductivityDistribution? _initialSigma;                    // Starting conductivities for the current iteration/cycle
-        private int _framesPerCycle;                                        // Number of frames in one drive-pattern cycle
-        private MeasurementNoiseType _measurementNoiseType = MeasurementNoiseType.None; // Noise model used for simulated/loaded frames
-        private double _measurementNoiseAmplitude;                          // Noise amplitude (linear or in dB if negative)
         private DrivePattern _drivePattern = DrivePattern.Adjecent;         // Selected electrode drive pattern
         private IDrivePatternStrategy _drivePatternStrategy = DrivePatternStrategyProvider.GetStrategy(DrivePattern.Adjecent); // Drive pattern strategy implementation
-        private readonly Random _noiseRandom = new();                       // PRNG for noise injection
         private bool _useOmpParallelization;                                // Exposed from parameters to persistence (not used directly here)
-        private MeasurementSourceOption _measurementSource = MeasurementSourceOption.Simulated; // Source of frames (real or simulated)
-        private double? _realMeasurementAmplitude;                          // Optional amplitude carried with imported measurements
-
-        // Tracks whether the currently loaded measurements include voltages on the driven electrodes
-        // ("active") or omit them ("non-active").  This flag is mirrored to the workspace so that
-        // the UI can communicate the acquisition mode to the user.
-        private ElectrodeMeasurementSetup _measurementSetup = ElectrodeMeasurementSetup.Active;
         private bool _usePotentialDifferences;
-        private MeasurementPattern? _measurementPattern;
-        private ReconstructionProcessContext? _processContext;
 
         /// <summary>
         /// Raised when a full reconstruction result is available (i.e., at the end of a cycle or batch).
@@ -81,9 +67,12 @@ namespace ServiceLayer
         /// </summary>
         /// <param name="reconstructionPersistence">Persistence layer that executes forward/inverse computations.</param>
         /// <param name="logger">Logger used for diagnostics.</param>
-        public ReconstructionService(IReconstructionPersistence reconstructionPersistence, ILogger logger)
+        public ReconstructionService(IReconstructionPersistence reconstructionPersistence,
+                                     IMeasurementService measurementService,
+                                     ILogger logger)
         {
             _reconstructionPersistence = reconstructionPersistence;
+            _measurementService = measurementService;
             _logger = logger;
         }
 
@@ -120,7 +109,6 @@ namespace ServiceLayer
                 _discretization = discretization;
 
                 // Reset per-run buffers/counters.
-                _simulatedMeasurements.Clear();
                 _simMeasurementIndex = 0;
                 _currentCycleFrames.Clear();
 
@@ -144,44 +132,27 @@ namespace ServiceLayer
                 _reconstructionPersistence.SetConductivityDistributions(_originalSigma, _initialSigma);
                 _reconstructionPersistence.InitializeReconstruction(discretization, parameters, reinit);
 
-                // Default to active measurement setup (frames include driven electrodes), unless we learn otherwise later.
-                _measurementSetup = ElectrodeMeasurementSetup.Active;
-                Workspace.SetElectrodeMeasurementSetup(ElectrodeMeasurementSetup.Active);
-                _measurementPattern = null;
-                Workspace.SetMeasurementPattern(null);
-
                 // Configure drive pattern and potential parallelization flag (consumed in persistence layer).
                 _drivePattern = parameters.DrivePattern;
                 _drivePatternStrategy = DrivePatternStrategyProvider.GetStrategy(_drivePattern);
                 _useOmpParallelization = parameters.UseOmpParallelization;
-
-                // Determine frames per cycle based on electrode count and pattern.
-                var electrodes = discretization.GetElectrodes();
-                int driveElectrodeCount = GetDriveElectrodeCount(electrodes);
-                _framesPerCycle = driveElectrodeCount > 0
-                    ? Math.Max(1, _drivePatternStrategy.GetCycleLength(driveElectrodeCount))
-                    : 1;
-
-                // Store noise settings for subsequent simulations/import handling.
-                _measurementNoiseType = parameters.MeasurementNoiseType;
-                _measurementNoiseAmplitude = parameters.MeasurementNoiseAmplitude;
                 _usePotentialDifferences = parameters.UsePotentialDifferences;
 
-                if (_measurementNoiseType == MeasurementNoiseType.None || Math.Abs(_measurementNoiseAmplitude) <= double.Epsilon)
+                if (parameters.MeasurementNoiseType == MeasurementNoiseType.None || Math.Abs(parameters.MeasurementNoiseAmplitude) <= double.Epsilon)
                     Workspace.AddLogMessage("Reconstruction Service", "Measurement noise disabled.");
                 else
                 {
                     // Negative amplitudes are interpreted as dB; convert to linear for logging clarity.
-                    double linearAmplitude = _measurementNoiseAmplitude < 0.0
-                        ? Math.Pow(10.0, _measurementNoiseAmplitude / 20.0)
-                        : Math.Abs(_measurementNoiseAmplitude);
+                    double linearAmplitude = parameters.MeasurementNoiseAmplitude < 0.0
+                        ? Math.Pow(10.0, parameters.MeasurementNoiseAmplitude / 20.0)
+                        : Math.Abs(parameters.MeasurementNoiseAmplitude);
 
-                    string amplitudeDescriptor = _measurementNoiseAmplitude < 0.0
-                        ? string.Format("{0:G4} dB -> {1:G4}", _measurementNoiseAmplitude, linearAmplitude)
+                    string amplitudeDescriptor = parameters.MeasurementNoiseAmplitude < 0.0
+                        ? string.Format("{0:G4} dB -> {1:G4}", parameters.MeasurementNoiseAmplitude, linearAmplitude)
                         : linearAmplitude.ToString("G4");
 
                     Workspace.AddLogMessage("Reconstruction Service",
-                        $"Measurement noise enabled: {_measurementNoiseType} (amplitude {amplitudeDescriptor}).");
+                        $"Measurement noise enabled: {parameters.MeasurementNoiseType} (amplitude {amplitudeDescriptor}).");
                 }
 
                 Workspace.AddLogMessage("Reconstruction Service",
@@ -189,10 +160,11 @@ namespace ServiceLayer
                         ? "Using electrode potential differences for reconstruction misfit evaluation."
                         : "Using direct electrode potentials for reconstruction misfit evaluation.");
 
-                // Seed measurement source state; we may swap to real measurements later.
-                _measurementSource = Workspace.GetMeasurementSource();
-                _realMeasurementAmplitude = null;
-                _processContext = ReconstructionProcessContext.Create(parameters, _reconstructionPersistence);
+                // Initialise the dedicated measurement service so measurement generation is handled centrally.
+                _measurementService.Initialize(discretization,
+                                               parameters,
+                                               _drivePattern,
+                                               () => _reconstructionPersistence.GetDifferentialEquationSolver());
             }
             catch(Exception ex)
             {
@@ -282,350 +254,6 @@ namespace ServiceLayer
         }
 
         /// <summary>
-        /// Synchronizes the local measurement-source mode with the workspace setting. If the source changes,
-        /// cached frames are discarded so they can be regenerated from the appropriate origin.
-        /// </summary>
-        private void SyncMeasurementSource()
-        {
-            var desired = Workspace.GetMeasurementSource();
-            if (desired == _measurementSource)
-                return;
-
-            _measurementSource = desired;
-            _simulatedMeasurements.Clear();
-            _simMeasurementIndex = 0;
-            _realMeasurementAmplitude = null;
-            _measurementSetup = ElectrodeMeasurementSetup.Active;
-            Workspace.SetElectrodeMeasurementSetup(ElectrodeMeasurementSetup.Active);
-            _measurementPattern = null;
-            Workspace.SetMeasurementPattern(null);
-        }
-
-        /// <summary>
-        /// Ensures that <see cref="_simulatedMeasurements"/> contains frames for the active discretization.
-        /// If real measurements are selected and available, those are adopted; otherwise frames are simulated
-        /// on the original discretization (kept immutable) and optional noise is applied.
-        /// </summary>
-        private void EnsureSimulatedMeasurements()
-        {
-            if (_simulatedMeasurements.Count > 0)
-                return; // Already populated
-
-            int electrodeCount = _discretization switch
-            {
-                FEMMesh fem => GetDriveElectrodeCount(fem.GetElectrodes().Cast<Electrode>()),
-                LBMGrid lbm => GetDriveElectrodeCount(lbm.GetElectrodes().Cast<Electrode>()),
-                _ => 0
-            };
-
-            // Prefer real measurements if requested and available via the workspace.
-            if (_measurementSource == MeasurementSourceOption.Real)
-            {
-                var measurement = Workspace.GetImportedMeasurement();
-                if (measurement != null && measurement.Frames.Count > 0)
-                {
-                    // Deep clone to avoid accidental modification of the imported buffers.
-                    _simulatedMeasurements = measurement.Frames.Select(frame => (double[])frame.Clone()).ToList();
-                    _realMeasurementAmplitude = measurement.CurrentAmplitude;
-
-                    AdoptMeasurementMetadata(measurement.Pattern, _simulatedMeasurements, electrodeCount);
-                    return;
-                }
-
-                Workspace.AddWarningMessage("Real measurement data was requested but is not available. Falling back to simulated measurements.");
-                _measurementSource = MeasurementSourceOption.Simulated;
-                _realMeasurementAmplitude = null;
-            }
-
-            var original = Workspace.GetOriginalDiscretization()
-                           ?? throw new NullReferenceException("Original mesh not set.");
-
-            var context = _processContext ?? throw new InvalidOperationException("Reconstruction process is not initialized.");
-            if (context.SimulateMeasurements == null)
-                throw new InvalidOperationException($"Measurement simulation is not available for {context.Solver} reconstructions.");
-
-            var batch = context.SimulateMeasurements(original, _excitationAmplitude, _drivePattern);
-
-            _simulatedMeasurements = CloneMeasurementsWithNoise(batch.Frames, _measurementNoiseType, _measurementNoiseAmplitude);
-            _realMeasurementAmplitude = null;
-
-            AdoptMeasurementMetadata(batch.Pattern, _simulatedMeasurements, electrodeCount, batch.MeasurementSetup);
-        }
-
-        /// <summary>
-        /// Creates deep copies of the provided frames and applies the requested noise model.
-        /// </summary>
-        private List<double[]> CloneMeasurementsWithNoise(IEnumerable<double[]> measurements,
-            MeasurementNoiseType noiseType,
-            double noiseAmplitude)
-        {
-            var clones = measurements.Select(frame => (double[])frame.Clone()).ToList();
-            ApplyMeasurementNoise(clones, noiseType, noiseAmplitude);
-            return clones;
-        }
-
-        /// <summary>
-        /// Applies in-place additive noise to the given frames. If amplitude is negative, it is interpreted
-        /// as a value in decibels and converted to a linear scale before sampling.
-        /// </summary>
-        private void ApplyMeasurementNoise(List<double[]> measurements, MeasurementNoiseType noiseType, double noiseAmplitude)
-        {
-            if (measurements.Count == 0 || noiseType == MeasurementNoiseType.None)
-                return;
-
-            bool amplitudeInDecibels = noiseAmplitude < 0.0;
-            double amplitude = amplitudeInDecibels
-                ? Math.Pow(10.0, noiseAmplitude / 20.0)
-                : Math.Abs(noiseAmplitude);
-            if (amplitude <= double.Epsilon)
-                return; // Effectively disabled
-
-            foreach (var frame in measurements)
-            {
-                for (int i = 0; i < frame.Length; i++)
-                {
-                    // Draw noise from the requested distribution and add to the sample.
-                    double noise = noiseType switch
-                    {
-                        MeasurementNoiseType.Gaussian => NextGaussian(0.0, amplitude),
-                        MeasurementNoiseType.Uniform => (_noiseRandom.NextDouble() * 2.0 - 1.0) * amplitude,
-                        _ => 0.0
-                    };
-
-                    frame[i] += noise;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Inspects frame dimensions to infer whether the samples include driven electrodes (active) or
-        /// exclude them (non-active). This is mirrored to the workspace for UI and solver decisions.
-        /// </summary>
-        private void UpdateMeasurementOptionsFromFrames(int electrodeCount, IReadOnlyList<double[]> frames)
-        {
-            // Guard clauses: fall back to the default "active" interpretation when
-            // insufficient context is available.
-            if (electrodeCount <= 0 || frames == null || frames.Count == 0)
-            {
-                _measurementSetup = ElectrodeMeasurementSetup.Active;
-                Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
-                return;
-            }
-
-            int frameLength = frames[0].Length;
-            long totalMeasurements = (long)frameLength * frames.Count;
-            long expectedActiveTotal = (long)electrodeCount * electrodeCount;
-            long expectedNonActiveTotal = (long)electrodeCount * Math.Max(0, electrodeCount - 3);
-            int nonActiveAmplitudeLength = Math.Max(0, electrodeCount - 2);
-            int nonActiveDifferenceLength = Math.Max(0, electrodeCount - 3);
-
-            bool looksActive = frameLength == electrodeCount || totalMeasurements == expectedActiveTotal;
-            bool looksNonActive = !looksActive && (frameLength == nonActiveAmplitudeLength || totalMeasurements == expectedNonActiveTotal);
-
-            _measurementSetup = looksActive ? ElectrodeMeasurementSetup.Active : ElectrodeMeasurementSetup.NonActive;
-
-            if (!looksActive && !looksNonActive)
-            {
-                Workspace.AddWarningMessage($"Ambiguous measurement frame dimensions (frame length {frameLength}, frame count {frames.Count}, electrodes {electrodeCount}). Assuming {_measurementSetup} electrodes.");
-            }
-
-            Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
-
-            bool inferredDifferences = InferPotentialDifferenceMode(electrodeCount, frames);
-            ApplyUsePotentialDifferenceSetting(inferredDifferences,
-                inferredDifferences
-                    ? "Detected potential-difference measurements from frame statistics."
-                    : "Detected amplitude measurements from frame statistics.");
-        }
-
-        private bool InferPotentialDifferenceMode(int electrodeCount, IReadOnlyList<double[]> frames)
-        {
-            if (frames == null || frames.Count == 0)
-                return _usePotentialDifferences;
-
-            int frameLength = frames[0].Length;
-            int nonActiveAmplitudeLength = Math.Max(0, electrodeCount - 2);
-            int nonActiveDifferenceLength = Math.Max(0, electrodeCount - 3);
-
-            if (_measurementSetup == ElectrodeMeasurementSetup.NonActive)
-            {
-                if (frameLength == nonActiveDifferenceLength)
-                    return true;
-                if (frameLength == nonActiveAmplitudeLength)
-                    return false;
-            }
-            else if (frameLength == nonActiveDifferenceLength)
-            {
-                // Degenerate case where frames mimic the non-active difference size even though
-                // the instrumentation was configured as "active". Treat as difference data.
-                return true;
-            }
-
-            if (frameLength != electrodeCount)
-                return _usePotentialDifferences;
-
-            int framesToInspect = Math.Min(frames.Count, 5);
-            int zeroLikeFrames = 0;
-            int finiteFrames = 0;
-
-            for (int i = 0; i < framesToInspect; i++)
-            {
-                var frame = frames[i];
-                double sum = 0.0;
-                double maxAbs = 0.0;
-                int finiteCount = 0;
-
-                foreach (var sample in frame)
-                {
-                    if (!double.IsFinite(sample))
-                        continue;
-
-                    sum += sample;
-                    finiteCount++;
-                    double abs = Math.Abs(sample);
-                    if (abs > maxAbs)
-                        maxAbs = abs;
-                }
-
-                if (finiteCount == 0)
-                    continue;
-
-                finiteFrames++;
-                double tolerance = Math.Max(1e-6, maxAbs * 1e-3);
-                if (Math.Abs(sum) <= tolerance)
-                    zeroLikeFrames++;
-            }
-
-            return finiteFrames > 0 && zeroLikeFrames == finiteFrames;
-        }
-
-        private void ApplyUsePotentialDifferenceSetting(bool enabled, string reason)
-        {
-            if (_usePotentialDifferences == enabled)
-                return;
-
-            _usePotentialDifferences = enabled;
-
-            var parameters = Workspace.GetReconstructionParameters();
-            if (parameters.UsePotentialDifferences != enabled)
-                parameters.UsePotentialDifferences = enabled;
-
-            Workspace.AddLogMessage("Reconstruction Service", reason);
-            _measurementPattern = null;
-            Workspace.SetMeasurementPattern(null);
-        }
-
-        private void AdoptMeasurementMetadata(MeasurementPattern? pattern,
-                                              IReadOnlyList<double[]> frames,
-                                              int electrodeCount,
-                                              ElectrodeMeasurementSetup? enforcedSetup = null)
-        {
-            if (pattern != null)
-            {
-                if (_measurementSetup != pattern.MeasurementSetup)
-                {
-                    _measurementSetup = pattern.MeasurementSetup;
-                    Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
-                }
-
-                bool useDifferences = pattern.Representation == MeasurementRepresentation.PotentialDifference;
-                ApplyUsePotentialDifferenceSetting(useDifferences,
-                    useDifferences
-                        ? "Adopting potential-difference mode from provided measurement pattern."
-                        : "Adopting amplitude mode from provided measurement pattern.");
-
-                _measurementPattern = pattern;
-                Workspace.SetMeasurementPattern(pattern);
-                return;
-            }
-
-            if (enforcedSetup.HasValue && _measurementSetup != enforcedSetup.Value)
-            {
-                _measurementSetup = enforcedSetup.Value;
-                Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
-            }
-
-            UpdateMeasurementOptionsFromFrames(electrodeCount, frames);
-        }
-
-        /// <summary>
-        /// Maps a provided measurement frame to the solver's expected per-electrode order. If the input excludes
-        /// driven electrodes (non-active mode), NaN placeholders are injected for those positions so that solver
-        /// residuals can ignore them. Excess values are truncated with a warning.
-        /// </summary>
-        private double[] PrepareMeasurementFrame(double[] measurement, IReadOnlyList<Electrode> electrodes)
-        {
-            if (measurement == null)
-                throw new ArgumentNullException(nameof(measurement));
-            if (electrodes == null)
-                throw new ArgumentNullException(nameof(electrodes));
-
-            if (electrodes.Count == 0)
-                return measurement;
-
-            var virtualSettings = Workspace.GetReconstructionParameters().VirtualElectrodeSettings;
-            if (virtualSettings.ShouldApplyVirtualElectrodes())
-            {
-                var estimator = VirtualElectrodeEstimatorFactory.Create(virtualSettings);
-                var context = BuildForwardContext(electrodes);
-                measurement = estimator.CompleteElectrodePotentials(electrodes, measurement, virtualSettings, context);
-            }
-
-            // Build the measurement pattern for the current electrode roles so
-            // that the sanitiser knows which entries to retain (Options 1 & 4)
-            // or which potential differences to form (Options 2 & 3).
-            var electrodeProjection = electrodes.ToList();
-            var pattern = MeasurementPatternBuilder.Build(electrodeProjection,
-                                                          Workspace.GetElectrodeMeasurementSetup(),
-                                                          _usePotentialDifferences);
-            _measurementPattern = pattern;
-            Workspace.SetMeasurementPattern(pattern);
-
-            // MapMeasurement() injects NaNs for channels that should not
-            // contribute to the residual (e.g. driven electrodes in non-active
-            // modes) so downstream metrics can ignore them naturally.
-            return pattern.MapMeasurement(measurement);
-        }
-
-        private ForwardModelContext BuildForwardContext(IReadOnlyList<Electrode> electrodes)
-        {
-            if (_discretization is FEMMesh fem)
-            {
-                return new ForwardModelContext
-                {
-                    ElectrodeAngles = fem.GetElectrodeAngles(),
-                    RealElectrodeCount = electrodes.Count(e => !e.IsVirtual)
-                };
-            }
-
-            if (_discretization is LBMGrid lbm)
-            {
-                return new ForwardModelContext
-                {
-                    ElectrodeAngles = lbm.GetElectrodeAngles(),
-                    RealElectrodeCount = electrodes.Count(e => !e.IsVirtual)
-                };
-            }
-
-            return new ForwardModelContext
-            {
-                RealElectrodeCount = electrodes.Count(e => !e.IsVirtual)
-            };
-        }
-
-        /// <summary>
-        /// Samples a normally distributed random value with the provided mean and standard deviation.
-        /// </summary>
-        private double NextGaussian(double mean, double stdDev)
-        {
-            // Box–Muller transform
-            double u1 = 1.0 - _noiseRandom.NextDouble();
-            double u2 = 1.0 - _noiseRandom.NextDouble();
-            double randStdNormal = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);
-            return mean + stdDev * randStdNormal;
-        }
-
-        /// <summary>
         /// Performs one inverse step against the active discretization by:
         /// - Ensuring measurement frames are available
         /// - Applying the drive-pattern step to electrodes and building the boundary condition
@@ -636,11 +264,11 @@ namespace ServiceLayer
         private ReconstructionFrame? PerformInverseStep()
         {
             // Ensure measurement source (simulated/real) matches the workspace selection.
-            SyncMeasurementSource();
+            _measurementService.SyncMeasurementSource();
 
             if (_discretization is FEMMesh femMesh)
             {
-                EnsureSimulatedMeasurements();
+                _measurementService.EnsureMeasurements(_excitationAmplitude);
 
                 // Select the measurement frame corresponding to the current
                 // excitation pair.  Electrode roles must be reconfigured for
@@ -650,15 +278,15 @@ namespace ServiceLayer
                 int driveElectrodeCount = GetDriveElectrodeCount(electrodes.Cast<Electrode>());
                 int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(driveElectrodeCount));
                 int stepIndex = _simMeasurementIndex % cycleLength;
-                var measurement = _simulatedMeasurements[stepIndex];
+                var measurement = _measurementService.GetMeasurementForStep(stepIndex);
 
                 // Recompute electrode roles for this step and build BC.
-                double effectiveAmplitude = _realMeasurementAmplitude ?? _excitationAmplitude;
+                double effectiveAmplitude = _measurementService.RealMeasurementAmplitude ?? _excitationAmplitude;
                 ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, stepIndex);
 
                 var bc = new FEMBoundaryCondition(electrodes);
                 // Expand the raw measurement vector to match the solver ordering (injecting NaNs for excluded electrodes).
-                var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
+                var preparedMeasurement = _measurementService.PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
 
                 // Delegate one optimization step to the persistence layer.
                 var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
@@ -670,7 +298,7 @@ namespace ServiceLayer
                 ReconstructionFrameUpdated?.Invoke(this, frame);
 
                 // When the drive-pattern cycle ends, publish a reconstruction result and advance the iteration.
-                if (_simMeasurementIndex % _framesPerCycle == 0)
+                if (_simMeasurementIndex % Math.Max(1, _measurementService.FramesPerCycle) == 0)
                 {
                     var result = new ReconstructionResult(_discretization!.GetDiscretization(),
                                                           _originalSigma!,
@@ -692,19 +320,19 @@ namespace ServiceLayer
             }
             else if (_discretization is LBMGrid lbmGrid)
             {
-                EnsureSimulatedMeasurements();
+                _measurementService.EnsureMeasurements(_excitationAmplitude);
 
                 // Determine the current drive-pattern step and attach the boundary condition.
                 var electrodes = lbmGrid.GetElectrodes().Cast<LBMElectrode>().ToList();
                 int driveElectrodeCount = GetDriveElectrodeCount(electrodes.Cast<Electrode>());
                 int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(driveElectrodeCount));
                 int stepIndex = _simMeasurementIndex % cycleLength;
-                double effectiveAmplitude = _realMeasurementAmplitude ?? _excitationAmplitude;
+                double effectiveAmplitude = _measurementService.RealMeasurementAmplitude ?? _excitationAmplitude;
                 ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, stepIndex);
 
                 var bc = new LBMBoundaryCondition(electrodes);
-                double[] measurement = _simulatedMeasurements[stepIndex];
-                var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
+                double[] measurement = _measurementService.GetMeasurementForStep(stepIndex);
+                var preparedMeasurement = _measurementService.PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
                 var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
                 _simMeasurementIndex++;
@@ -712,7 +340,7 @@ namespace ServiceLayer
                 _currentCycleFrames.Add(frame);
                 ReconstructionFrameUpdated?.Invoke(this, frame);
 
-                if (_simMeasurementIndex % _framesPerCycle == 0)
+                if (_simMeasurementIndex % Math.Max(1, _measurementService.FramesPerCycle) == 0)
                 {
                     var result = new ReconstructionResult(_discretization!.GetDiscretization(),
                                                           _originalSigma!,
@@ -817,24 +445,25 @@ namespace ServiceLayer
             return await Task.Run(() =>
             {
                 // Ensure we are using the correct frame source (real/simulated) and that frames are present.
-                SyncMeasurementSource();
+                _measurementService.SyncMeasurementSource();
 
                 if (_discretization is FEMMesh femMesh)
                 {
-                    EnsureSimulatedMeasurements();
+                    _measurementService.EnsureMeasurements(_excitationAmplitude);
 
                     var electrodes = femMesh.GetElectrodes().Cast<FEMElectrode>().ToList();
                     int electrodeCount = electrodes.Count;
 
-                    for (int i = 0; i < _simulatedMeasurements.Count; i++)
+                    var measurements = _measurementService.GetAllMeasurements();
+                    for (int i = 0; i < measurements.Count; i++)
                     {
-                        double effectiveAmplitude = _realMeasurementAmplitude ?? _excitationAmplitude;
+                        double effectiveAmplitude = _measurementService.RealMeasurementAmplitude ?? _excitationAmplitude;
                         ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, i);
 
                         var bc = new FEMBoundaryCondition(electrodes);
-                        var measurement = _simulatedMeasurements[i];
+                        var measurement = measurements[i];
                         // Convert the measurement snapshot to the solver layout for the current electrode roles.
-                        var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
+                        var preparedMeasurement = _measurementService.PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
 
                         var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
@@ -878,17 +507,18 @@ namespace ServiceLayer
                 }
                 else if (_discretization is LBMGrid lbmGrid)
                 {
-                    EnsureSimulatedMeasurements();
+                    _measurementService.EnsureMeasurements(_excitationAmplitude);
 
-                    for (int i = 0; i < _simulatedMeasurements.Count; i++)
+                    var measurements = _measurementService.GetAllMeasurements();
+                    for (int i = 0; i < measurements.Count; i++)
                     {
                         var electrodes = lbmGrid.GetElectrodes().Cast<LBMElectrode>().ToList();
-                        double effectiveAmplitude = _realMeasurementAmplitude ?? _excitationAmplitude;
+                        double effectiveAmplitude = _measurementService.RealMeasurementAmplitude ?? _excitationAmplitude;
                         ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, i);
                         var bc = new LBMBoundaryCondition(electrodes);
 
-                        var measurement = _simulatedMeasurements[i];
-                        var preparedMeasurement = PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
+                        var measurement = measurements[i];
+                        var preparedMeasurement = _measurementService.PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
                         var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
                         Workspace.AddReconstructionFrameToWorkspace(frame);
@@ -929,55 +559,6 @@ namespace ServiceLayer
             });
         }
 
-
-        private sealed record ReconstructionProcessContext(
-            DifferentialEquationSolver Solver,
-            Func<IDiscretization, double, DrivePattern, MeasurementBatch>? SimulateMeasurements)
-        {
-            public static ReconstructionProcessContext Create(EITReconstructionParameters parameters,
-                                                              IReconstructionPersistence persistence) =>
-                parameters.DifferentialEquationSolver switch
-                {
-                    DifferentialEquationSolver.FEM => new ReconstructionProcessContext(
-                        DifferentialEquationSolver.FEM,
-                        (discretization, amplitude, drivePattern) =>
-                        {
-                            if (discretization is not FEMMesh mesh)
-                                throw new InvalidOperationException("FEM reconstruction requires a FEM mesh.");
-
-                            var frames = persistence.SimulateFemMeasurements(mesh, amplitude, drivePattern);
-                            return MeasurementBatch.FromFem(frames);
-                        }),
-                    DifferentialEquationSolver.LBM => new ReconstructionProcessContext(
-                        DifferentialEquationSolver.LBM,
-                        (discretization, amplitude, drivePattern) =>
-                        {
-                            if (discretization is not LBMGrid grid)
-                                throw new InvalidOperationException("LBM reconstruction requires an LBM grid.");
-
-                            var measurement = persistence.SimulateLbmMeasurements(grid, amplitude, drivePattern);
-                            return MeasurementBatch.FromLbm(measurement);
-                        }),
-                    DifferentialEquationSolver.Graph => new ReconstructionProcessContext(DifferentialEquationSolver.Graph, null),
-                    _ => new ReconstructionProcessContext(parameters.DifferentialEquationSolver, null)
-                };
-        }
-
-        private sealed record MeasurementBatch(
-            List<double[]> Frames,
-            double? Amplitude,
-            MeasurementPattern? Pattern,
-            ElectrodeMeasurementSetup MeasurementSetup)
-        {
-            public static MeasurementBatch FromFem(List<double[]> frames) =>
-                new(frames, null, null, ElectrodeMeasurementSetup.Active);
-
-            public static MeasurementBatch FromLbm(EITMeasurement measurement) =>
-                new(measurement.Frames,
-                    null,
-                    measurement.Pattern,
-                    measurement.Pattern?.MeasurementSetup ?? ElectrodeMeasurementSetup.Active);
-        }
 
         // --- Persistence ---
         /// <summary>

--- a/ServiceLayer/Settings.cs
+++ b/ServiceLayer/Settings.cs
@@ -11,6 +11,7 @@ namespace ServiceLayer
                 .RegisterType<IDAQService, DAQService>()
                 .RegisterType<IReconstructionService, ReconstructionService>()
                 .RegisterType<IReconstructionExportService, ReconstructionExportService>()
+                .RegisterType<IMeasurementService, MeasurementService>()
                 .RegisterType<ILogger, WorkspaceLogger>();
         }
     }


### PR DESCRIPTION
## Summary
- add dedicated measurement persistence interface/implementation to own simulated frame generation
- introduce measurement service to manage measurement sourcing, noise, and workspace metadata
- update reconstruction persistence/service registrations to consume the new measurement components and delegate measurement handling

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690a1db124008333b28b7271e60af84f