### PR TITLE
Adjust LBM electrode coordinates for Wasserstein metrics

### DIFF
--- a/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
@@ -849,12 +849,8 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
 
         #region Coordinate helpers
 
-        private static (double x, double y) ToXY(LBMGrid grid, int gridId)
-        {
-            int x = gridId % grid.Nx;
-            int y = gridId / grid.Nx;
-            return (x, y);
-        }
+        private static (double x, double y) ToXY(LBMGrid grid, int gridId) =>
+            LbmElectrodeCoordinateHelper.ToPhysicalCoordinates(grid, gridId);
 
         private static (double x, double y) GetCoord(FEMMesh mesh, Electrode electrode)
         {

--- a/Utility/Classes/Reconstruction/ErrorMetrics/LbmElectrodeCoordinateHelper.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/LbmElectrodeCoordinateHelper.cs
@@ -1,0 +1,27 @@
+using System;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+
+namespace Utility.Classes.Reconstruction.ErrorMetrics
+{
+    internal static class LbmElectrodeCoordinateHelper
+    {
+        public const double LayerShiftX = 0.1;
+        public const double LayerShiftY = 0.1;
+
+        public static (double x, double y) ToPhysicalCoordinates(LBMGrid grid, int gridId)
+        {
+            if (grid is null)
+                throw new ArgumentNullException(nameof(grid));
+
+            var (ix, iy) = grid.ToLattice(gridId);
+
+            double cx = (grid.Nx - 1) / 2.0;
+            double cy = (grid.Ny - 1) / 2.0;
+
+            double x = (ix - cx) * LayerShiftX;
+            double y = (iy - cy) * LayerShiftY;
+
+            return (x, y);
+        }
+    }
+}

--- a/Utility/Classes/Reconstruction/ErrorMetrics/UnbalancedWasserstein2Metric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/UnbalancedWasserstein2Metric.cs
@@ -790,12 +790,8 @@ public sealed class UnbalancedWasserstein2Metric : IErrorMetric
         return (values.ToArray(), coords.ToArray(), mapping, leftIndices.ToArray());
     }
 
-    private static (double x, double y) ToXY(LBMGrid grid, int gridId)
-    {
-        int x = gridId % grid.Nx;
-        int y = gridId / grid.Nx;
-        return (x, y);
-    }
+    private static (double x, double y) ToXY(LBMGrid grid, int gridId) =>
+        LbmElectrodeCoordinateHelper.ToPhysicalCoordinates(grid, gridId);
 
     private static (double x, double y) GetCoord(FEMMesh mesh, Electrode electrode)
     {

--- a/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
@@ -563,12 +563,8 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return (vals.ToArray(), coords.ToArray(), map);
         }
 
-        private static (double x, double y) ToXY(LBMGrid mesh, int gridId)
-        {
-            int x = gridId % mesh.Nx;
-            int y = gridId / mesh.Nx;
-            return (x, y);
-        }
+        private static (double x, double y) ToXY(LBMGrid mesh, int gridId) =>
+            LbmElectrodeCoordinateHelper.ToPhysicalCoordinates(mesh, gridId);
 
         private static (double x, double y) GetCoord(FEMMesh mesh, FEMElectrode e)
         {


### PR DESCRIPTION
## Summary
- introduce a shared helper for mapping LBM grid indices to physical electrode coordinates
- use geometric centering with 0.1 layer spacing when building electrode supports in all Wasserstein-based LBM metrics

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691205612d3c833398a69cfbca204b6f)