### PR TITLE
Implement ghost-node electrode boundary conditions for LBM solver

### DIFF
--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannCudaHelper.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannCudaHelper.cs
@@ -28,19 +28,30 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
         /// Value -1 indicates no neighbor (boundary or outside domain).
         /// </summary>
         public int[] NeighborIndices { get; }
-        
+
         /// <summary>
         /// Flattened array indicating if each neighbor is a wall for bounce-back.
         /// Same layout as NeighborIndices: 1=wall, 0=fluid.
         /// Used by streaming kernel to determine bounce-back behavior.
         /// </summary>
         public int[] NeighborIsWall { get; }
+
+        /// <summary>
+        /// Flattened array indicating whether a neighbor is a ghost node (1) or not (0).
+        /// The ghost layer carries Neumann boundary information for electrodes.
+        /// </summary>
+        public int[] NeighborIsGhost { get; }
         
         /// <summary>
         /// Array indicating which elements are walls (1) or fluid (0).
         /// Wall elements don't participate in collision or streaming operations.
         /// </summary>
         public int[] IsWall { get; }
+
+        /// <summary>
+        /// Array indicating which elements belong to the ghost layer (1) or the physical domain (0).
+        /// </summary>
+        public int[] IsGhost { get; }
         
         /// <summary>
         /// Dictionary mapping original element IDs to linear array indices.
@@ -63,14 +74,18 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             int[] elementIds,
             int[] neighborIndices,
             int[] neighborIsWall,
+            int[] neighborIsGhost,
             int[] isWall,
+            int[] isGhost,
             Dictionary<int, int> idToIndex)
         {
             Elements = elements;
             ElementIds = elementIds;
             NeighborIndices = neighborIndices;
             NeighborIsWall = neighborIsWall;
+            NeighborIsGhost = neighborIsGhost;
             IsWall = isWall;
+            IsGhost = isGhost;
             IdToIndex = idToIndex;
         }
     }
@@ -109,7 +124,9 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             // Allocate flattened arrays for neighbor connectivity (9 directions per element)
             var neighborIndices = new int[count * 9];    // Neighbor linear indices
             var neighborIsWall = new int[count * 9];     // Neighbor wall flags
+            var neighborIsGhost = new int[count * 9];    // Neighbor ghost flags
             var isWall = new int[count];                 // Current element wall flags
+            var isGhost = new int[count];                // Current element ghost flags
 
             // Process each element to build flattened neighbor arrays
             for (int i = 0; i < count; i++)
@@ -118,6 +135,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 
                 // Convert boolean wall flag to integer for GPU compatibility
                 isWall[i] = element.IsWall ? 1 : 0;
+                isGhost[i] = element.GhostElement ? 1 : 0;
 
                 // Process all 9 D2Q9 directions for current element
                 for (int k = 0; k < 9; k++)
@@ -133,12 +151,14 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                         
                         // Store neighbor's wall status for bounce-back decisions
                         neighborIsWall[arrayIndex] = neighbor.IsWall ? 1 : 0;
+                        neighborIsGhost[arrayIndex] = neighbor.GhostElement ? 1 : 0;
                     }
                     else
                     {
                         // No neighbor (domain boundary) - mark as invalid
                         neighborIndices[arrayIndex] = -1; // Invalid index sentinel
                         neighborIsWall[arrayIndex] = 0;   // Not a wall (boundary)
+                        neighborIsGhost[arrayIndex] = 0;
                     }
                 }
             }
@@ -149,7 +169,9 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 elementIds,        // Element ID array
                 neighborIndices,   // Flattened neighbor indices
                 neighborIsWall,    // Flattened neighbor wall flags
+                neighborIsGhost,  // Flattened neighbor ghost flags
                 isWall,           // Element wall flags
+                isGhost,          // Element ghost flags
                 idToIndex);       // ID-to-index mapping dictionary
         }
     }

--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
@@ -29,8 +29,6 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
         // LBM stability constants
         private const double TauSafetyEpsilon = 1e-6;          // Small value to prevent numerical instability
         private const double MinTau = 0.5 + TauSafetyEpsilon; // Minimum relaxation time for stability
-        private const double ElectrodeFluxCoefficient = 0.75; // Gentle relaxation factor for Neumann electrode corrections
-
         // CUDA kernel management - static to share across solver instances
         private static readonly object _cudaKernelLock = new(); // Thread-safe kernel compilation
 
@@ -53,12 +51,13 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             public readonly ArrayView<double> ElectrodeCurrent;
             public readonly ArrayView<double> ElectrodePotential;
             public readonly ArrayView<int> NeighborIsWall;
+            public readonly ArrayView<int> NeighborIsGhost;
             public readonly ArrayView<int> NeighborIndices;
             public readonly ArrayView<double> Conductivity;
+            public readonly ArrayView<int> IsGhost;
             public readonly ArrayView<double> PhiStreamed;
             public readonly ArrayView<int> Opposite;
             public readonly ArrayView<double> Weights;
-            public readonly double ElectrodeFluxAlpha;
 
             public UpdateKernelParams(
                 ArrayView<double> fi,
@@ -70,12 +69,13 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 ArrayView<double> electrodeCurrent,
                 ArrayView<double> electrodePotential,
                 ArrayView<int> neighborIsWall,
+                ArrayView<int> neighborIsGhost,
                 ArrayView<int> neighborIndices,
                 ArrayView<double> conductivity,
+                ArrayView<int> isGhost,
                 ArrayView<double> phiStreamed,
                 ArrayView<int> opposite,
-                ArrayView<double> weights,
-                double electrodeFluxAlpha)
+                ArrayView<double> weights)
             {
                 Fi = fi;
                 FiNext = fiNext;
@@ -86,12 +86,13 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 ElectrodeCurrent = electrodeCurrent;
                 ElectrodePotential = electrodePotential;
                 NeighborIsWall = neighborIsWall;
+                NeighborIsGhost = neighborIsGhost;
                 NeighborIndices = neighborIndices;
                 Conductivity = conductivity;
+                IsGhost = isGhost;
                 PhiStreamed = phiStreamed;
                 Opposite = opposite;
                 Weights = weights;
-                ElectrodeFluxAlpha = electrodeFluxAlpha;
             }
         }
 
@@ -246,6 +247,68 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             return RunForwardCuda(lbmGrid, bc);
         }
 
+        private static ElectrodeRuntimeData EnsureSingleGroundElectrode(IReadOnlyList<ElectrodeRuntimeData> runtimeElectrodes)
+        {
+            int groundCount = 0;
+            ElectrodeRuntimeData ground = default;
+
+            foreach (var electrode in runtimeElectrodes)
+            {
+                if (!electrode.IsGround)
+                    continue;
+
+                ground = electrode;
+                groundCount++;
+
+                if (groundCount > 1)
+                    break;
+            }
+
+            if (groundCount != 1)
+                throw new InvalidOperationException("LBM solver requires exactly one ground electrode to fix the gauge.");
+
+            return ground;
+        }
+
+        private static int CollectGhostLinks(
+            LBMElement element,
+            IReadOnlyDictionary<int, int> elementIndexLookup,
+            Span<int> directions,
+            Span<int> ghostIndices)
+        {
+            int count = 0;
+
+            void TryAdd(int dir)
+            {
+                if (count >= directions.Length)
+                    return;
+
+                var neighbor = element.Neighbors[dir];
+                if (neighbor is null || !neighbor.GhostElement)
+                    return;
+
+                if (!elementIndexLookup.TryGetValue(neighbor.Id, out int ghostIndex))
+                    return;
+
+                directions[count] = dir;
+                ghostIndices[count] = ghostIndex;
+                count++;
+            }
+
+            ReadOnlySpan<int> cardinal = stackalloc int[] { 1, 2, 3, 4 };
+            foreach (int dir in cardinal)
+                TryAdd(dir);
+
+            if (count == 0)
+            {
+                ReadOnlySpan<int> diagonal = stackalloc int[] { 5, 6, 7, 8 };
+                foreach (int dir in diagonal)
+                    TryAdd(dir);
+            }
+
+            return count;
+        }
+
         /// <summary>
         /// CPU implementation of LBM forward solver using traditional object-oriented approach.
         /// Serves as reference implementation and fallback when GPU is unavailable.
@@ -359,6 +422,20 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                     element.Fi[k] = isWall ? 0.0 : weights[k] * phi0; // Equilibrium initial state.
                 }
             }
+
+            var groundElectrode = EnsureSingleGroundElectrode(runtimeElectrodes);
+            int groundIndex = groundElectrode.ElementIndex;
+            double groundPotential = groundElectrode.Potential;
+
+            // Ensure the ground node starts at equilibrium with its prescribed potential.
+            var groundElement = groundElectrode.Element;
+            for (int k = 0; k < 9; k++)
+            {
+                double eq = weights[k] * groundPotential;
+                groundElement.Fi[k] = eq;
+                groundElement.Fi_next[k] = 0.0;
+            }
+            phi[groundIndex] = groundPotential;
 
             // Main time-stepping loop: identical ordering with the CUDA implementation.
             for (int iteration = 0; iteration < maxIter; iteration++)
@@ -490,8 +567,12 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
 
             // Assemble the final potential distribution and push it back to the grid.
             var result = new Dictionary<int, double>(elementCount);
+            double groundPhi = elements[groundIndex].Fi.Sum();
             for (int idx = 0; idx < elementCount; idx++)
-                result[elements[idx].Id] = elements[idx].Fi.Sum();
+            {
+                double value = elements[idx].Fi.Sum() - groundPhi;
+                result[elements[idx].Id] = value;
+            }
 
             var pd = new PotentialDistribution(result);
             lbmGrid.SetPotentialDistribution(pd);
@@ -511,9 +592,6 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             double[] weights,
             int[] opposite)
         {
-            // Same relaxation factor as used in the CUDA kernels.
-            const double alpha = ElectrodeFluxCoefficient;
-
             foreach (var electrode in electrodes)
             {
                 var element = electrode.Element;
@@ -522,107 +600,59 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 // ---------------------------------------------------------------------
                 // 1. Dirichlet anchor for ground electrode (pins the gauge)
                 // ---------------------------------------------------------------------
-                double phiBoundary = phi[elementIndex];
+                double phiInterior = phi[elementIndex];
 
                 if (electrode.IsGround)
                 {
                     double anchorPhi = electrode.Potential;
-
-                    // Overwrite all populations with equilibrium at the ground potential.
                     for (int k = 0; k < 9; k++)
                         element.Fi[k] = weights[k] * anchorPhi;
 
-                    phiBoundary = anchorPhi;
+                    phiInterior = anchorPhi;
                     phi[elementIndex] = anchorPhi;
                 }
 
-                // ---------------------------------------------------------------------
-                // 2. Find outward normal direction: link to a wall with fluid on the
-                //    opposite side (i.e. a wall-interior pair). Prefer cardinal over
-                //    diagonal directions, just like in the CUDA UpdateKernel.
-                // ---------------------------------------------------------------------
-                Span<int> inwardDirections = stackalloc int[4];
                 Span<int> outwardDirections = stackalloc int[4];
-                Span<int> interiorIndices = stackalloc int[4];
-                int directionCount = 0;
+                Span<int> ghostIndices = stackalloc int[4];
+                int linkCount = CollectGhostLinks(element, elementIndexLookup, outwardDirections, ghostIndices);
 
-                for (int dir = 1; dir < 9; dir++) // skip rest direction 0
+                if (linkCount == 0)
+                    continue;
+
+                double fluxPerLink = electrode.Current / linkCount;
+                double sigmaInterior = Math.Max(element.Conductivity, 0.0);
+
+                for (int i = 0; i < linkCount; i++)
                 {
-                    var outerNeighbor = element.Neighbors[dir];
-                    if (outerNeighbor is null || !outerNeighbor.IsWall)
-                        continue;
+                    int dir = outwardDirections[i];
+                    int opp = opposite[dir];
+                    int ghostIndex = ghostIndices[i];
+                    var ghost = element.Neighbors[dir]!;
 
-                    int inwardCandidate = opposite[dir];
-                    var interiorCandidate = element.Neighbors[inwardCandidate];
+                    double sigmaGhost = Math.Max(ghost.Conductivity, 0.0);
+                    if (sigmaGhost <= 0.0)
+                    {
+                        sigmaGhost = sigmaInterior;
+                        ghost.Conductivity = sigmaGhost;
+                    }
 
-                    if (interiorCandidate is null || interiorCandidate.IsWall)
-                        continue;
-
-                    if (!elementIndexLookup.TryGetValue(interiorCandidate.Id, out int interiorIndex))
-                        continue;
-
-                    inwardDirections[directionCount] = inwardCandidate;
-                    outwardDirections[directionCount] = dir;
-                    interiorIndices[directionCount] = interiorIndex;
-                    directionCount++;
-
-                    if (directionCount >= inwardDirections.Length)
-                        break;
-                }
-
-                if (directionCount == 0)
-                    continue; // No clear wall normals -> nothing to correct.
-
-                double phiBoundaryCell = phi[elementIndex]; // may have been anchored above
-                double sigmaBoundary = element.Conductivity;
-                double currentPerLink = Math.Abs(electrode.Current);
-
-                if (directionCount > 0)
-                    currentPerLink /= directionCount;
-
-                if (!electrode.IsExcitation && !electrode.IsGround)
-                    continue; // Floating / measurement electrode: only enforce potential.
-
-                for (int dirIndex = 0; dirIndex < directionCount; dirIndex++)
-                {
-                    int inward = inwardDirections[dirIndex];
-                    int outward = outwardDirections[dirIndex];
-                    int interiorIndex = interiorIndices[dirIndex];
-
-                    var interior = element.Neighbors[inward];
-                    Debug.Assert(interior is not null, "Interior neighbor must exist for inward direction");
-
-                    double phiInterior = phi[interiorIndex];
-                    double sigmaInterior = interior!.Conductivity;
-                    double sigmaAvg = 0.5 * (sigmaBoundary + sigmaInterior);
-
+                    double sigmaAvg = 0.5 * (sigmaInterior + sigmaGhost);
                     if (sigmaAvg <= 0.0)
-                        continue; // Perfect insulator -> no flux through this face.
+                        continue;
 
-                    double flux = -sigmaAvg * (phiInterior - phiBoundaryCell) + currentPerLink;
-                    double deltaFi = alpha * flux * weights[inward];
+                    double phiGhost = phiInterior - fluxPerLink / sigmaAvg;
 
-                    if (electrode.IsExcitation)
+                    double nonEq = element.Fi[dir] - weights[dir] * phiInterior;
+
+                    for (int k = 0; k < 9; k++)
                     {
-                        element.Fi[inward] += deltaFi;
-                        element.Fi[outward] -= deltaFi;
+                        double eq = weights[k] * phiGhost;
+                        ghost.Fi[k] = eq;
                     }
-                    else
-                    {
-                        element.Fi[inward] -= deltaFi;
-                        element.Fi[outward] += deltaFi;
-                    }
+
+                    ghost.Fi[opp] = weights[opp] * phiGhost + nonEq;
+                    phi[ghostIndex] = phiGhost;
                 }
-
-                // ---------------------------------------------------------------------
-                // 5. Update cached macroscopic potential at the electrode cell so that
-                //    subsequent iterations and convergence check see the corrected φ.
-                // ---------------------------------------------------------------------
-                double updatedPhi = 0.0;
-                for (int k = 0; k < 9; k++)
-                    updatedPhi += element.Fi[k];
-
-                phi[elementIndex] = updatedPhi;
             }
         }
 
@@ -651,8 +681,10 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             var elements = topology.Elements;
             var elementIds = topology.ElementIds;
             var isWallHost = topology.IsWall;
+            var isGhostHost = topology.IsGhost;
             var neighborIndicesHost = topology.NeighborIndices;
             var neighborIsWallHost = topology.NeighborIsWall;
+            var neighborIsGhostHost = topology.NeighborIsGhost;
 
             var electrodes = lbmGrid.GetElectrodes().Cast<LBMElectrode>().ToArray();
             var bcElectrodes = bc.GetElectrodes().Cast<LBMElectrode>().ToArray();
@@ -694,6 +726,9 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             }
 
             var electrodeByIndex = runtimeElectrodes.ToDictionary(e => e.ElementIndex);
+            var groundElectrode = EnsureSingleGroundElectrode(runtimeElectrodes);
+            int groundIndex = groundElectrode.ElementIndex;
+            double groundPotential = groundElectrode.Potential;
             var conductivity = lbmGrid.GetConductivityDistribution();
             var initialPotential = lbmGrid.GetPotentialDistribution();
 
@@ -739,12 +774,15 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 }
             }
 
+            initialPhiHost[groundIndex] = groundPotential;
+
             var accelerator = LatticeBoltzmannCudaContext.Accelerator;
 
             using var fiBuffer = accelerator.Allocate1D<double>(elementCount * 9);
             using var fiNextBuffer = accelerator.Allocate1D<double>(elementCount * 9);
             using var conductivityBuffer = accelerator.Allocate1D<double>(elementCount);
             using var isWallBuffer = accelerator.Allocate1D<int>(elementCount);
+            using var isGhostBuffer = accelerator.Allocate1D<int>(elementCount);
             using var isElectrodeBuffer = accelerator.Allocate1D<int>(elementCount);
             using var electrodeIsExcitationBuffer = accelerator.Allocate1D<int>(elementCount);
             using var electrodeIsGroundBuffer = accelerator.Allocate1D<int>(elementCount);
@@ -752,10 +790,12 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             using var electrodePotentialBuffer = accelerator.Allocate1D<double>(elementCount);
             using var neighborIndexBuffer = accelerator.Allocate1D<int>(elementCount * 9);
             using var neighborIsWallBuffer = accelerator.Allocate1D<int>(elementCount * 9);
+            using var neighborIsGhostBuffer = accelerator.Allocate1D<int>(elementCount * 9);
             using var phiBuffer = accelerator.Allocate1D<double>(elementCount);
             using var initialPhiBuffer = accelerator.Allocate1D<double>(elementCount);
 
             isWallBuffer.CopyFromCPU(isWallHost);
+            isGhostBuffer.CopyFromCPU(isGhostHost);
             isElectrodeBuffer.CopyFromCPU(isElectrodeHost);
             electrodeIsExcitationBuffer.CopyFromCPU(electrodeIsExcitationHost);
             electrodeIsGroundBuffer.CopyFromCPU(electrodeIsGroundHost);
@@ -764,6 +804,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             conductivityBuffer.CopyFromCPU(conductivityHost);
             neighborIndexBuffer.CopyFromCPU(neighborIndicesHost);
             neighborIsWallBuffer.CopyFromCPU(neighborIsWallHost);
+            neighborIsGhostBuffer.CopyFromCPU(neighborIsGhostHost);
             initialPhiBuffer.CopyFromCPU(initialPhiHost);
 
             if (_initializeKernel == null)
@@ -813,12 +854,13 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                     electrodeCurrentBuffer.View,
                     electrodePotentialBuffer.View,
                     neighborIsWallBuffer.View,
+                    neighborIsGhostBuffer.View,
                     neighborIndexBuffer.View,
                     conductivityBuffer.View,
+                    isGhostBuffer.View,
                     phiBuffer.View,
                     LatticeBoltzmannCudaContext.OppositeView,
-                    LatticeBoltzmannCudaContext.WeightsView,
-                    ElectrodeFluxCoefficient);
+                    LatticeBoltzmannCudaContext.WeightsView);
 
                 _updateKernel(elementCount, updateParams);
 
@@ -855,6 +897,11 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             accelerator.Synchronize();
 
             var finalFi = fiBuffer.GetAsArray1D();
+            double groundPhi = 0.0;
+            int groundBaseIndex = groundIndex * 9;
+            for (int k = 0; k < 9; k++)
+                groundPhi += finalFi[groundBaseIndex + k];
+
             var result = new Dictionary<int, double>(elementCount);
 
             for (int idx = 0; idx < elementCount; idx++)
@@ -871,7 +918,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                     phiValue += value;
                 }
 
-                result[elementIds[idx]] = phiValue;
+                result[elementIds[idx]] = phiValue - groundPhi;
             }
 
             var pd = new PotentialDistribution(result);
@@ -1053,7 +1100,8 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             Index1D index,
             UpdateKernelParams p)
         {
-            if (p.IsWall[index] == 1)
+            bool isGhostCell = p.IsGhost[index] == 1;
+            if (p.IsWall[index] == 1 && !isGhostCell)
                 return;
 
             int baseIndex = index * 9;
@@ -1067,7 +1115,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 phiBoundary += value;
             }
 
-            if (p.IsElectrode[index] == 0)
+            if (p.IsElectrode[index] == 0 || isGhostCell)
             {
                 p.PhiStreamed[index] = phiBoundary;
                 return;
@@ -1090,77 +1138,148 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 p.PhiStreamed[index] = phiBoundary;
             }
 
-            int directionCount = 0;
-            for (int dir = 1; dir < 9; dir++)
+            int ghostDirCount = 0;
+            int ghostDir0 = -1, ghostDir1 = -1, ghostDir2 = -1, ghostDir3 = -1;
+            int ghostIndex0 = -1, ghostIndex1 = -1, ghostIndex2 = -1, ghostIndex3 = -1;
+
+            for (int dir = 1; dir <= 4; dir++)
             {
-                if (p.NeighborIsWall[baseIndex + dir] != 1)
+                if (ghostDirCount >= 4)
+                    break;
+                if (p.NeighborIsGhost[baseIndex + dir] != 1)
                     continue;
-
-                int inward = p.Opposite[dir];
-                if (p.NeighborIsWall[baseIndex + inward] == 1)
+                int ghostIndex = p.NeighborIndices[baseIndex + dir];
+                if (ghostIndex < 0)
                     continue;
-
-                int interiorCandidate = p.NeighborIndices[baseIndex + inward];
-                if (interiorCandidate < 0)
+                if (p.IsGhost[ghostIndex] != 1)
                     continue;
-                if (p.IsWall[interiorCandidate] == 1)
-                    continue;
-
-                directionCount++;
-            }
-
-            if (directionCount == 0)
-                return;
-
-            int isExcitation = p.ElectrodeIsExcitation[index];
-            int isGround = p.ElectrodeIsGround[index];
-            if (isExcitation == 0 && isGround == 0)
-                return;
-
-            double phiBoundaryLocal = p.PhiStreamed[index];
-            double sigmaBoundary = p.Conductivity[index];
-            double currentPerLink = XMath.Abs(p.ElectrodeCurrent[index]) / directionCount;
-
-            for (int dir = 1; dir < 9; dir++)
-            {
-                if (p.NeighborIsWall[baseIndex + dir] != 1)
-                    continue;
-
-                int inward = p.Opposite[dir];
-                if (p.NeighborIsWall[baseIndex + inward] == 1)
-                    continue;
-
-                int interiorIndex = p.NeighborIndices[baseIndex + inward];
-                if (interiorIndex < 0)
-                    continue;
-                if (p.IsWall[interiorIndex] == 1)
-                    continue;
-
-                double phiInterior = p.PhiStreamed[interiorIndex];
-                double sigmaInterior = p.Conductivity[interiorIndex];
-                double sigmaAvg = 0.5 * (sigmaBoundary + sigmaInterior);
-                if (sigmaAvg <= 0.0)
-                    continue;
-
-                double flux = sigmaAvg * (phiInterior - phiBoundaryLocal) + currentPerLink;
-                double deltaFi = p.ElectrodeFluxAlpha * flux * p.Weights[inward];
-
-                if (isExcitation == 1)
+                if (ghostDirCount == 0)
                 {
-                    p.Fi[baseIndex + inward] += deltaFi;
-                    p.Fi[baseIndex + dir] -= deltaFi;
+                    ghostDir0 = dir;
+                    ghostIndex0 = ghostIndex;
+                }
+                else if (ghostDirCount == 1)
+                {
+                    ghostDir1 = dir;
+                    ghostIndex1 = ghostIndex;
+                }
+                else if (ghostDirCount == 2)
+                {
+                    ghostDir2 = dir;
+                    ghostIndex2 = ghostIndex;
                 }
                 else
                 {
-                    p.Fi[baseIndex + inward] -= deltaFi;
-                    p.Fi[baseIndex + dir] += deltaFi;
+                    ghostDir3 = dir;
+                    ghostIndex3 = ghostIndex;
+                }
+                ghostDirCount++;
+            }
+
+            if (ghostDirCount == 0)
+            {
+                for (int dir = 5; dir < 9; dir++)
+                {
+                    if (ghostDirCount >= 4)
+                        break;
+                    if (p.NeighborIsGhost[baseIndex + dir] != 1)
+                        continue;
+                    int ghostIndex = p.NeighborIndices[baseIndex + dir];
+                    if (ghostIndex < 0)
+                        continue;
+                    if (p.IsGhost[ghostIndex] != 1)
+                        continue;
+                    if (ghostDirCount == 0)
+                    {
+                        ghostDir0 = dir;
+                        ghostIndex0 = ghostIndex;
+                    }
+                    else if (ghostDirCount == 1)
+                    {
+                        ghostDir1 = dir;
+                        ghostIndex1 = ghostIndex;
+                    }
+                    else if (ghostDirCount == 2)
+                    {
+                        ghostDir2 = dir;
+                        ghostIndex2 = ghostIndex;
+                    }
+                    else
+                    {
+                        ghostDir3 = dir;
+                        ghostIndex3 = ghostIndex;
+                    }
+                    ghostDirCount++;
                 }
             }
 
-            double phiUpdated = 0.0;
-            for (int k = 0; k < 9; k++)
-                phiUpdated += p.Fi[baseIndex + k];
-            p.PhiStreamed[index] = phiUpdated;
+            if (ghostDirCount == 0)
+                return;
+
+            double phiInterior = p.PhiStreamed[index];
+            double sigmaInterior = p.Conductivity[index];
+            if (sigmaInterior < 0.0)
+                sigmaInterior = 0.0;
+
+            double fluxPerLink = p.ElectrodeCurrent[index] / ghostDirCount;
+
+            for (int n = 0; n < ghostDirCount; n++)
+            {
+                int dir;
+                int ghostIndex;
+                if (n == 0)
+                {
+                    dir = ghostDir0;
+                    ghostIndex = ghostIndex0;
+                }
+                else if (n == 1)
+                {
+                    dir = ghostDir1;
+                    ghostIndex = ghostIndex1;
+                }
+                else if (n == 2)
+                {
+                    dir = ghostDir2;
+                    ghostIndex = ghostIndex2;
+                }
+                else
+                {
+                    dir = ghostDir3;
+                    ghostIndex = ghostIndex3;
+                }
+
+                if (dir < 0 || ghostIndex < 0)
+                    continue;
+
+                double sigmaGhost = p.Conductivity[ghostIndex];
+                if (sigmaGhost <= 0.0)
+                {
+                    sigmaGhost = sigmaInterior;
+                    if (sigmaGhost <= 0.0)
+                        continue;
+                }
+
+                double sigmaAvg = 0.5 * (sigmaInterior + sigmaGhost);
+                if (sigmaAvg <= 0.0)
+                    continue;
+
+                double phiGhost = phiInterior - fluxPerLink / sigmaAvg;
+                int ghostBase = ghostIndex * 9;
+
+                for (int k = 0; k < 9; k++)
+                {
+                    double eq = p.Weights[k] * phiGhost;
+                    p.Fi[ghostBase + k] = eq;
+                    p.FiNext[ghostBase + k] = 0.0;
+                }
+
+                int opp = p.Opposite[dir];
+                double nonEq = p.Fi[baseIndex + dir] - p.Weights[dir] * phiInterior;
+                p.Fi[ghostBase + opp] = p.Weights[opp] * phiGhost + nonEq;
+                p.PhiStreamed[ghostIndex] = phiGhost;
+            }
+
+            p.PhiStreamed[index] = phiInterior;
         }
 
         /// <summary>

--- a/Utility/Tests/LatticeBoltzmannSolverTests.cs
+++ b/Utility/Tests/LatticeBoltzmannSolverTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Classes.Measurement;
+using Utility.Classes.Solvers.LatticeBoltzmannSolver;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Utility.Tests
+{
+    public class LatticeBoltzmannSolverTests
+    {
+        private static (LBMGrid Grid, LBMBoundaryCondition Boundary) CreateTwoElectrodeSetup()
+        {
+            var grid = new LBMGrid(8, 8);
+
+            int nyMid = grid.Ny / 2;
+            var left = grid.GetElementAt(1, nyMid);
+            var right = grid.GetElementAt(grid.Nx - 2, nyMid);
+
+            var gridElectrodes = new List<LBMElectrode>
+            {
+                new LBMElectrode(id: 0, gridId: left.Id, current: -1.0, potential: 0.0, contactImpedance: 0.0, isExcitation: false, isGround: true),
+                new LBMElectrode(id: 1, gridId: right.Id, current: 1.0, potential: 0.0, contactImpedance: 0.0, isExcitation: true, isGround: false)
+            };
+
+            grid.SetElectrodes(gridElectrodes);
+
+            var bcElectrodes = new List<LBMElectrode>
+            {
+                new LBMElectrode(id: 0, gridId: left.Id, current: -1.0, potential: 0.0, contactImpedance: 0.0, isExcitation: false, isGround: true),
+                new LBMElectrode(id: 1, gridId: right.Id, current: 1.0, potential: 0.0, contactImpedance: 0.0, isExcitation: true, isGround: false)
+            };
+
+            var bc = new LBMBoundaryCondition(bcElectrodes, requireDrivePair: false);
+            return (grid, bc);
+        }
+
+        [Fact]
+        public void CpuAndGpuForwardSolveAgreeWithinTolerance()
+        {
+            var (cpuGrid, cpuBoundary) = CreateTwoElectrodeSetup();
+            var solverCpu = new LatticeBoltzmannSolver(2000, 1e-8, 50, useCuda: false);
+            var cpuResult = solverCpu.SolveForward(cpuGrid, cpuBoundary);
+
+            try
+            {
+                var (gpuGrid, gpuBoundary) = CreateTwoElectrodeSetup();
+                var solverGpu = new LatticeBoltzmannSolver(2000, 1e-8, 50, useCuda: true);
+                var gpuResult = solverGpu.SolveForward(gpuGrid, gpuBoundary);
+
+                var cpuPotentials = cpuResult.Potentials;
+                var gpuPotentials = gpuResult.Potentials;
+
+                foreach (var element in cpuGrid.GetElements().Cast<LBMElement>())
+                {
+                    if (element.IsWall || element.GhostElement)
+                        continue;
+
+                    double cpuPhi = cpuPotentials[element.Id];
+                    double gpuPhi = gpuPotentials[element.Id];
+                    Assert.True(Math.Abs(cpuPhi - gpuPhi) < 1e-6, $"Potential mismatch at element {element.Id}: CPU={cpuPhi}, GPU={gpuPhi}");
+                }
+            }
+            catch (InvalidOperationException ex) when (ex.Message.Contains("CUDA"))
+            {
+                throw new SkipException("CUDA accelerator unavailable for GPU comparison test.");
+            }
+        }
+
+        [Fact]
+        public void ElectrodeFluxMatchesAppliedCurrent()
+        {
+            var (grid, boundary) = CreateTwoElectrodeSetup();
+            var solver = new LatticeBoltzmannSolver(2000, 1e-8, 50, useCuda: false);
+            var solution = solver.SolveForward(grid, boundary);
+
+            var potentials = solution.Potentials;
+            var electrodes = boundary.GetElectrodes().Cast<LBMElectrode>().ToList();
+
+            foreach (var electrode in electrodes)
+            {
+                var cell = grid.GetElements().Cast<LBMElement>().First(e => e.Id == electrode.GridId);
+                double phiInterior = potentials[cell.Id];
+                double sigmaInterior = cell.Conductivity;
+                double fluxSum = 0.0;
+
+                for (int dir = 1; dir < 9; dir++)
+                {
+                    var ghost = cell.Neighbors[dir];
+                    if (ghost is null || !ghost.GhostElement)
+                        continue;
+
+                    double sigmaGhost = ghost.Conductivity > 0.0 ? ghost.Conductivity : sigmaInterior;
+                    if (sigmaGhost <= 0.0)
+                        continue;
+
+                    double sigmaAvg = 0.5 * (sigmaInterior + sigmaGhost);
+                    double phiGhost = potentials[ghost.Id];
+                    fluxSum += sigmaAvg * (phiInterior - phiGhost);
+                }
+
+                Assert.True(Math.Abs(fluxSum - electrode.Current) < 1e-6, $"Flux conservation violated for electrode {electrode.Id}: expected {electrode.Current}, got {fluxSum}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the electrode flux tweak with a ghost-node Neumann boundary construction and enforce a single ground electrode gauge
- extend the CUDA topology/update kernel so the GPU path mirrors the CPU ghost treatment and returns potentials relative to ground
- add regression tests that compare CPU/GPU potentials and check discrete flux conservation on a small drive pattern

## Testing
- dotnet test ElectricalImpedanceTomography.sln *(fails: dotnet not installed in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127b6627b88333b776ae01dccda21b)