### PR TITLE
Fix LBM solver ghost cell handling to produce non-zero potentials

### DIFF
--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannCudaHelper.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannCudaHelper.cs
@@ -134,8 +134,10 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 var element = elements[i];
                 
                 // Convert boolean wall flag to integer for GPU compatibility
-                isWall[i] = element.IsWall ? 1 : 0;
-                isGhost[i] = element.GhostElement ? 1 : 0;
+                bool isGhostElement = element.GhostElement;
+                bool isPhysicalWall = element.IsWall && !isGhostElement;
+                isWall[i] = isPhysicalWall ? 1 : 0;
+                isGhost[i] = isGhostElement ? 1 : 0;
 
                 // Process all 9 D2Q9 directions for current element
                 for (int k = 0; k < 9; k++)
@@ -150,7 +152,8 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                         neighborIndices[arrayIndex] = neighborIndex;
                         
                         // Store neighbor's wall status for bounce-back decisions
-                        neighborIsWall[arrayIndex] = neighbor.IsWall ? 1 : 0;
+                        bool neighborIsPhysicalWall = neighbor.IsWall && !neighbor.GhostElement;
+                        neighborIsWall[arrayIndex] = neighborIsPhysicalWall ? 1 : 0;
                         neighborIsGhost[arrayIndex] = neighbor.GhostElement ? 1 : 0;
                     }
                     else

--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
@@ -407,14 +407,18 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             var phi = new double[elementCount];      // Current macroscopic potential
             var prevPhi = new double[elementCount];  // Potential used for convergence checks
 
+            static bool IsPhysicalWall(LBMElement cell) => cell.IsWall && !cell.GhostElement;
+
             for (int idx = 0; idx < elementCount; idx++)
             {
                 var element = elements[idx];
-                bool isWall = element.IsWall;
+                bool isPhysicalWall = IsPhysicalWall(element);
 
                 // Clamp conductivity to physical, non-negative values.  Walls are
                 // treated as perfect insulators so their conductivity is zero.
-                double sigma = isWall ? 0.0 : SanitizeConductivity(conductivity.GetConductivity(element.Id));
+                double sigma = isPhysicalWall
+                    ? 0.0
+                    : SanitizeConductivity(conductivity.GetConductivity(element.Id));
                 element.Conductivity = sigma;
                 conductivity.Conductivities[element.Id] = sigma;
 
@@ -423,15 +427,15 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 // from equilibrium avoids introducing spurious transients that could
                 // destabilise the BGK relaxation during the first few iterations.
                 double phi0 = 0.0;
-                if (!isWall && initialPotential is not null)
+                if (!isPhysicalWall && initialPotential is not null)
                     phi0 = initialPotential.GetValue(element.Id);
 
-                phi[idx] = isWall ? 0.0 : phi0;
+                phi[idx] = isPhysicalWall ? 0.0 : phi0;
 
                 for (int k = 0; k < 9; k++)
                 {
                     element.Fi_next[k] = 0.0;                    // Streaming buffer always starts empty.
-                    element.Fi[k] = isWall ? 0.0 : weights[k] * phi0; // Equilibrium initial state.
+                    element.Fi[k] = isPhysicalWall ? 0.0 : weights[k] * phi0; // Equilibrium initial state.
                 }
             }
 
@@ -457,7 +461,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 // -----------------------------------------------------------------
                 foreach (var element in elements)
                 {
-                    if (element.IsWall)
+                    if (IsPhysicalWall(element))
                         continue; // Walls keep their distributions fixed at zero.
 
                     double phiLocal = 0.0;
@@ -483,7 +487,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 // -----------------------------------------------------------------
                 foreach (var element in elements)
                 {
-                    if (element.IsWall)
+                    if (IsPhysicalWall(element))
                         continue;
 
                     // Ensure the streaming buffer starts clean every iteration.
@@ -493,7 +497,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
 
                 foreach (var element in elements)
                 {
-                    if (element.IsWall)
+                    if (IsPhysicalWall(element))
                         continue;
 
                     for (int dir = 0; dir < 9; dir++)
@@ -501,7 +505,9 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                         double fi = element.Fi[dir];
                         var neighbour = element.Neighbors[dir];
 
-                        if (neighbour is not null && !neighbour.IsWall)
+                        bool neighbourIsPhysicalWall = neighbour is null || IsPhysicalWall(neighbour);
+
+                        if (!neighbourIsPhysicalWall)
                         {
                             // Normal streaming: place Fi in the same directional slot
                             // of the neighbour cell.  Only one population flows through
@@ -525,7 +531,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 for (int idx = 0; idx < elementCount; idx++)
                 {
                     var element = elements[idx];
-                    if (element.IsWall)
+                    if (IsPhysicalWall(element))
                     {
                         phi[idx] = 0.0;
                         continue;


### PR DESCRIPTION
## Summary
- treat LBM ghost elements as non-physical walls so the CPU solver streams distributions into electrode ghost cells instead of bouncing them
- update the CUDA topology builder to mirror the new ghost/physical wall distinction so the GPU path matches the CPU behaviour

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a84683648333a3e7ce006ff37d96)