### PR TITLE
Ensure LBM ghost conductivities mirror interior cells

### DIFF
--- a/BusinessLayer/MeasurementPersistence.cs
+++ b/BusinessLayer/MeasurementPersistence.cs
@@ -106,6 +106,8 @@ namespace BusinessLayer
                 throw new ArgumentNullException(nameof(solver));
 
             LBMGrid deepCopy = (LBMGrid)grid.DeepCopy();
+            // Ensure the ghost layer mirrors interior conductivities before launching forward solves.
+            deepCopy.UpdateGhostConductivityFromNeighbors();
             Workspace.UpdateCurrentGlobalLbmElectrodes(deepCopy);
             var electrodes = Workspace.GetCurrentGlobalLbmElectrodes();
             bool applyVirtuals = virtualSettings.ShouldApplyVirtualElectrodes();

--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -828,6 +828,8 @@ namespace BusinessLayer
             {
                 LBMGrid measMesh = (LBMGrid)mesh.DeepCopy();
                 measMesh.SetConductivityDistribution(originalSigma);
+                // Ghost-layer conductivities are derived from the interior; recompute them before any solves.
+                measMesh.UpdateGhostConductivityFromNeighbors();
                 var simulation = GenerateLbmMeasurements(measMesh, 1.0);
                 measurementFrames = simulation.Amplitude.HasValue
                     ? new EITMeasurement(simulation.Frames, simulation.Amplitude.Value, simulation.Pattern)
@@ -847,6 +849,8 @@ namespace BusinessLayer
                 ?? ConductivityDistributionFactory.CreateInitialDistribution(mesh, _initialDistributionType);
             initialSigma = ConductivityClipper.Clip(initialSigma);
             mesh.SetConductivityDistribution(initialSigma);
+            // Reconstruction only optimises interior conductivities; keep the ghost layer in sync with them.
+            mesh.UpdateGhostConductivityFromNeighbors();
 
             Workspace.UpdateCurrentGlobalLbmElectrodes(mesh);
             Workspace.UpdateCurrentGlobalLbmElements(mesh);
@@ -860,6 +864,9 @@ namespace BusinessLayer
             double driveAmplitude = measurementFrames.CurrentAmplitude ?? 1.0;
 
             var elements = Workspace.GetCurrentGlobalLbmElements();
+            var interiorElementIds = new HashSet<int>(elements
+                .Where(el => !el.GhostElement && !el.IsWall)
+                .Select(el => el.Id));
 
             List<ReconstructionFrame> frames = [];
 
@@ -917,10 +924,14 @@ namespace BusinessLayer
 
                 var newSigmaDict = sigma.Conductivities.ToDictionary(
                     kvp => kvp.Key,
-                    kvp => kvp.Value + _gradientStepSize * totalGrad[kvp.Key]);
+                    kvp => interiorElementIds.Contains(kvp.Key)
+                        ? kvp.Value + _gradientStepSize * totalGrad[kvp.Key]
+                        : kvp.Value);
 
                 var updated = ConductivityClipper.Clip(new ConductivityDistribution(newSigmaDict));
                 mesh.SetConductivityDistribution(updated);
+                // Ghost conductivities are derived quantities; refresh them immediately after interior updates.
+                mesh.UpdateGhostConductivityFromNeighbors();
             }
 
             ConductivityDistribution reconstructed = mesh.GetConductivityDistribution();
@@ -1304,6 +1315,7 @@ namespace BusinessLayer
 
             ConductivityDistribution originalConductivityDistribution = _originalSigma ?? ((LBMGrid)lbmGrid.DeepCopy()).GetConductivityDistribution();
             lbmGrid = (LBMGrid)lbmGrid.DeepCopy();
+            lbmGrid.UpdateGhostConductivityFromNeighbors();
 
             Workspace.UpdateCurrentGlobalLbmElectrodes(lbmGrid);
             Workspace.UpdateCurrentGlobalLbmElements(lbmGrid);
@@ -1317,6 +1329,7 @@ namespace BusinessLayer
             {
                 LBMGrid measMesh = (LBMGrid)lbmGrid.DeepCopy();
                 measMesh.SetConductivityDistribution(originalConductivityDistribution);
+                measMesh.UpdateGhostConductivityFromNeighbors();
                 var simulation = GenerateLbmMeasurements(measMesh, 1.0);
                 measurementFrames = simulation.Amplitude.HasValue
                     ? new EITMeasurement(simulation.Frames, simulation.Amplitude.Value, simulation.Pattern)
@@ -1325,6 +1338,7 @@ namespace BusinessLayer
             }
             else
             {
+                lbmGrid.UpdateGhostConductivityFromNeighbors();
                 var simulation = GenerateLbmMeasurements(lbmGrid, 1.0);
                 measurementFrames = simulation.Amplitude.HasValue
                     ? new EITMeasurement(simulation.Frames, simulation.Amplitude.Value, simulation.Pattern)
@@ -1334,6 +1348,10 @@ namespace BusinessLayer
 
             // Container to hold partial results from reconstrucion
             List<ReconstructionFrame> frames = [];
+            var interiorElementIds = new HashSet<int>(lbmGrid.GetElements()
+                .Cast<LBMElement>()
+                .Where(el => !el.GhostElement && !el.IsWall)
+                .Select(el => el.Id));
 
             // --- Inverse Solver Iterations ---
 
@@ -1353,11 +1371,15 @@ namespace BusinessLayer
 
                     var newSigmaDict = sigma.Conductivities.ToDictionary(
                         kvp => kvp.Key,
-                        kvp => kvp.Value - step * frame.ConductivityGradient.GetConductivity(kvp.Key)                        
+                        kvp => interiorElementIds.Contains(kvp.Key)
+                            ? kvp.Value - step * frame.ConductivityGradient.GetConductivity(kvp.Key)
+                            : kvp.Value
                     );
 
                     var updatedSigma = ConductivityClipper.Clip(new ConductivityDistribution(newSigmaDict));
                     lbmGrid.SetConductivityDistribution(updatedSigma);
+                    // Ghost conductivities inherit from interior cells immediately after each update step.
+                    lbmGrid.UpdateGhostConductivityFromNeighbors();
 
                     // Add partial results
                     frames.Add(frame);

--- a/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMGrid.cs
+++ b/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMGrid.cs
@@ -162,6 +162,47 @@ namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
             RebuildGhostLayerFromMask();
         }
 
+        /// <summary>
+        /// Refreshes ghost-layer conductivities so that they mirror adjacent interior cells.
+        /// Ghost cells approximate an extension of the interior domain and therefore inherit the
+        /// average conductivity of their non-ghost, non-wall neighbours instead of being treated
+        /// as independent optimisation variables.
+        /// </summary>
+        public void UpdateGhostConductivityFromNeighbors()
+        {
+            if (ConductivityDistribution is null)
+                return;
+
+            foreach (var cell in _elements)
+            {
+                if (!cell.GhostElement)
+                    continue;
+
+                double sigmaSum = 0.0;
+                int sigmaCount = 0;
+
+                foreach (var neighbor in cell.Neighbors)
+                {
+                    if (neighbor is null || neighbor.GhostElement || neighbor.IsWall)
+                        continue;
+
+                    sigmaSum += neighbor.Conductivity;
+                    sigmaCount++;
+                }
+
+                if (sigmaCount > 0)
+                {
+                    double averaged = sigmaSum / sigmaCount;
+                    cell.Conductivity = averaged;
+                    ConductivityDistribution.Conductivities[cell.Id] = averaged;
+                }
+                else
+                {
+                    // Degenerate case: the ghost cell only sees walls/ghosts. Preserve the previous value.
+                }
+            }
+        }
+
         private void RebuildGhostLayerFromMask()
         {
             for (int y = 0; y < Ny; y++)

--- a/Utility/Classes/Factories/MeshFactory.cs
+++ b/Utility/Classes/Factories/MeshFactory.cs
@@ -476,6 +476,7 @@ namespace Utility.Classes.Factories
 
             var cd = grid.GetElements().ToDictionary(e => e.Id, e => e.Conductivity);
             grid.SetConductivityDistribution(new ConductivityDistribution(cd));
+            grid.UpdateGhostConductivityFromNeighbors();
 
             Workspace.AddLogMessage("MeshFactory", "Created LBMGrid from Perimeter definition.");
 
@@ -496,6 +497,7 @@ namespace Utility.Classes.Factories
 
             var cd = grid.GetElements().ToDictionary(e => e.Id, e => e.Conductivity);
             grid.SetConductivityDistribution(new ConductivityDistribution(cd));
+            grid.UpdateGhostConductivityFromNeighbors();
 
             grid.Metadata.Generator = nameof(CreateRectangularLBMGrid);
             grid.Metadata.Parameters["nx"] = nx.ToString();
@@ -552,6 +554,7 @@ namespace Utility.Classes.Factories
             // 3) rebuild distribution so downstream code sees it
             var cd = grid.GetElements().ToDictionary(e => e.Id, e => e.Conductivity);
             grid.SetConductivityDistribution(new ConductivityDistribution(cd));
+            grid.UpdateGhostConductivityFromNeighbors();
 
             grid.Metadata.Generator = nameof(LBMCreateRectangularWithInhomogenity);
             grid.Metadata.Parameters["nx"] = nx.ToString();
@@ -636,6 +639,7 @@ namespace Utility.Classes.Factories
             // Refresh conductivity distribution
             var cd = grid.GetElements().ToDictionary(e => e.Id, e => e.Conductivity);
             grid.SetConductivityDistribution(new ConductivityDistribution(cd));
+            grid.UpdateGhostConductivityFromNeighbors();
 
             Workspace.AddLogMessage("MeshFactory", "Created ciruclar LBMGrid object.");
 
@@ -680,6 +684,8 @@ namespace Utility.Classes.Factories
             }
 
             discretization.SetConductivityDistribution(new ConductivityDistribution(noisy));
+            if (discretization is LBMGrid lbmGrid)
+                lbmGrid.UpdateGhostConductivityFromNeighbors();
 
             Workspace.AddLogMessage("MeshFactory", "Added gaussian noise to mesh conductivities.");
         }

--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
@@ -366,6 +366,10 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             double tolerance = SolutionTolerance;
             int checkFrequency = Math.Max(1, ConvergenceCheckFrequency);
 
+            // Reconstruction updates only touch interior conductivities.  Mirror those values to the
+            // ghost layer so that ghosts remain a numerical extension of the domain, not optimisation variables.
+            lbmGrid.UpdateGhostConductivityFromNeighbors();
+
             // D2Q9 lattice constants shared with the CUDA path so that both
             // implementations evaluate exactly the same algebra.
             var weights = LatticeBoltzmannConstants.Weights;       // Equilibrium weights wi
@@ -706,6 +710,10 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             int maxIter = MaxIterationCount;
             double tolerance = SolutionTolerance;
             int checkFrequency = Math.Max(1, ConvergenceCheckFrequency);
+
+            // Mirror interior conductivities to the ghost layer before uploading data to the GPU.
+            // Ghost cells remain derived values so optimisation and reconstruction never manipulate them directly.
+            lbmGrid.UpdateGhostConductivityFromNeighbors();
 
             var topology = LatticeBoltzmannCudaHelper.BuildTopology(lbmGrid);
             int elementCount = topology.ElementCount;


### PR DESCRIPTION
## Summary
- add LBMGrid.UpdateGhostConductivityFromNeighbors to mirror ghost-layer conductivities from adjacent interior cells
- invoke the helper whenever conductivities change or before running CPU/CUDA solves so ghosts stay derived quantities
- keep reconstruction updates focused on interior cells and refresh ghost conductivities after each optimisation step

## Testing
- ⚠️ `dotnet build ElectricalImpedanceTomography.sln` *(dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c95b9004833383f8c94c51ee9b4e)