### PR TITLE
Align LBM measurement simulation with reconstruction forward solve

### DIFF
--- a/BusinessLayer/MeasurementPersistence.cs
+++ b/BusinessLayer/MeasurementPersistence.cs
@@ -13,7 +13,6 @@ using Utility.Classes.Reconstruction; // For PotentialClipper
 using Utility.Classes.Reconstruction.DESolvers;
 using Utility.Classes.Reconstruction.VirtualElectrodes;
 using Utility.Classes.ReconstructionParameters;
-using Utility.Classes.Solvers.LatticeBoltzmannSolver;
 
 namespace BusinessLayer
 {
@@ -112,8 +111,6 @@ namespace BusinessLayer
             // Ensure the ghost layer mirrors interior conductivities before launching forward solves.
             deepCopy.UpdateGhostConductivityFromNeighbors();
 
-            var measurementSolver = CreateIsolatedLbmSolver(solver);
-
             // Work directly with the mesh-owned electrode objects so that current assignments
             // immediately influence the forward solve.  Ordering the collection by the logical
             // electrode id guarantees that the drive-pattern strategy rotates through adjacent
@@ -184,13 +181,10 @@ namespace BusinessLayer
                 Workspace.UpdateCurrentGlobalLbmElectrodes(deepCopy);
                 Workspace.UpdateCurrentGlobalLbmElements(deepCopy);
 
-                // Preserve the forward drive pair so the adjoint boundary condition retains the
-                // same grounding reference instead of falling back to the library defaults.
-                var forwardElectrodeSnapshot = boundaryCondition.GetElectrodes()
-                                                 .Select(CloneLbmElectrode)
-                                                 .ToList();
-
-                deepCopy = SolveLbmForward(deepCopy, measurementSolver);
+                // Execute the forward solve using the same solver configuration as reconstruction so
+                // the resulting potentials match the reconstruction forward pass exactly.
+                var solvedDistribution = PotentialClipper.Clip(solver.Solve(deepCopy, boundaryCondition, null));
+                deepCopy.SetPotentialDistribution(solvedDistribution);
 
                 // Persist the freshly solved state so diagnostic tools and exports observe the
                 // electrode ordering and potentials that were actually used for the frame.
@@ -218,47 +212,6 @@ namespace BusinessLayer
             var potentialDistribution = solver.Solve(mesh, boundaryCondition, null);
             mesh.SetPotentialDistribution(PotentialClipper.Clip(potentialDistribution));
             return mesh;
-        }
-
-        private static LBMGrid SolveLbmForward(LBMGrid grid, IDifferentialEquationSolver solver)
-        {
-            var boundaryCondition = new LBMBoundaryCondition(grid.GetElectrodes().Cast<LBMElectrode>().ToList());
-            var potentialDistribtion = solver.Solve(grid, boundaryCondition, null);
-            grid.SetPotentialDistribution(PotentialClipper.Clip(potentialDistribtion));
-            return grid;
-        }
-
-        private static IDifferentialEquationSolver CreateIsolatedLbmSolver(IDifferentialEquationSolver reference)
-        {
-            // Extract configuration from reference solver
-            if (reference is LatticeBoltzmannDESolver lbmDeSolver)
-            {
-                // Return a new wrapper with fresh state
-                return  new LatticeBoltzmannDESolver(
-                        maxIterations: 5000,            // Use conservative defaults for measurement
-                        convergenceThreshold: 1e-8,
-                        checkInterval: 200,
-                        useCudaAcceleration: false);   // Force CPU for measurement consistency
-            }
-
-            // Fallback: use the reference solver (shouldn't happen in LBM case)
-            return reference;
-        }
-
-        private static LBMElectrode CloneLbmElectrode(LBMElectrode electrode)
-        {
-            if (electrode == null)
-                throw new ArgumentNullException(nameof(electrode));
-
-            return new LBMElectrode(electrode.Id,
-                                     electrode.GridId,
-                                     electrode.Current,
-                                     electrode.Potential,
-                                     electrode.ZContact,
-                                     electrode.IsExcitation,
-                                     electrode.IsGround,
-                                     electrode.IsMeasuring,
-                                     electrode.IsVirtual);
         }
 
 


### PR DESCRIPTION
## Summary
- reuse the active LBM differential equation solver when generating simulated measurements
- run the measurement forward solve through the same workspace updates as reconstruction to mirror potential maps
- remove the unused helper utilities that created isolated solvers and electrode clones

## Testing
- dotnet build *(fails: `dotnet` is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691539c522388333acc2f3158c53158b)