### PR TITLE
Align LBM measurement simulation grid with reconstruction

### DIFF
--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -117,7 +117,15 @@ namespace ServiceLayer
                 _originalSigma = Workspace.GetOriginalDiscretization()?.GetConductivityDistribution()
                                  ?? discretization.DeepCopy().GetConductivityDistribution();
 
-                var measurementDiscretization = discretization.DeepCopy();
+                // Measurement simulations must reuse the exact lattice that was generated on the
+                // meshing page so that the boundary links, ghost cells and electrode ordering
+                // match the reconstruction phase.  When an original discretization is available
+                // in the workspace prefer cloning it; otherwise fall back to the current
+                // reconstruction discretization.
+                var workspaceDiscretization = Workspace.GetOriginalDiscretization();
+                var measurementDiscretization = workspaceDiscretization != null
+                    ? workspaceDiscretization.DeepCopy()
+                    : discretization.DeepCopy();
                 measurementDiscretization.SetConductivityDistribution(_originalSigma);
 
                 _initialSigma = Workspace.GetInitialDiscretization()?.GetConductivityDistribution()


### PR DESCRIPTION
## Summary
- ensure the reconstruction service initialises the measurement service with a clone of the discretisation stored on the meshing page when available
- keeps the lattice, boundary links and electrode ordering identical between simulated measurements and the reconstruction grid

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: `dotnet` command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a60155f048333b9f8bfc6da84288a)