### PR TITLE
Cache LBM boundary topology

### DIFF
--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -117,8 +117,17 @@ namespace ServiceLayer
                 _originalSigma = Workspace.GetOriginalDiscretization()?.GetConductivityDistribution()
                                  ?? discretization.DeepCopy().GetConductivityDistribution();
 
+                // Measurement simulation must reuse the exact lattice that will later be used
+                // for reconstruction otherwise the LBM solver rebuilds a different set of
+                // boundary links/ghost cells.  Clone the active discretization rather than the
+                // copy stored on the workspace to guarantee that the topology (element order,
+                // ghost ring, electrode ordering) matches the solver's reconstruction state and
+                // only replace the conductivity distribution with the ground truth.
                 var measurementDiscretization = discretization.DeepCopy();
-                measurementDiscretization.SetConductivityDistribution(_originalSigma);
+                if (_originalSigma != null)
+                {
+                    measurementDiscretization.SetConductivityDistribution(_originalSigma);
+                }
 
                 _initialSigma = Workspace.GetInitialDiscretization()?.GetConductivityDistribution()
                                  ?? ConductivityDistributionFactory.CreateInitialDistribution(discretization, parameters.InitialDistributionType);

--- a/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMBoundaryTopology.cs
+++ b/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMBoundaryTopology.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
+{
+    public readonly struct LBMBoundaryLink
+    {
+        public LBMBoundaryLink(int interiorIndex, int ghostIndex, int direction)
+        {
+            InteriorIndex = interiorIndex;
+            GhostIndex = ghostIndex;
+            Direction = direction;
+        }
+
+        public int InteriorIndex { get; }
+        public int GhostIndex { get; }
+        public int Direction { get; }
+    }
+
+    public sealed class LBMBoundaryTopology
+    {
+        private static readonly IReadOnlyList<LBMBoundaryLink> EmptyLinks = new List<LBMBoundaryLink>().AsReadOnly();
+        private static readonly IReadOnlyDictionary<int, IReadOnlyList<int>> EmptyLookup =
+            new ReadOnlyDictionary<int, IReadOnlyList<int>>(new Dictionary<int, IReadOnlyList<int>>());
+
+        public static LBMBoundaryTopology Empty { get; } = new(EmptyLinks, EmptyLookup);
+
+        private LBMBoundaryTopology(
+            IReadOnlyList<LBMBoundaryLink> links,
+            IReadOnlyDictionary<int, IReadOnlyList<int>> linksByInterior)
+        {
+            Links = links;
+            LinksByInterior = linksByInterior;
+        }
+
+        public IReadOnlyList<LBMBoundaryLink> Links { get; }
+        public IReadOnlyDictionary<int, IReadOnlyList<int>> LinksByInterior { get; }
+
+        internal static LBMBoundaryTopology Create(
+            List<LBMBoundaryLink> links,
+            Dictionary<int, List<int>> perInterior)
+        {
+            if (links.Count == 0)
+                return Empty;
+
+            var readOnlyLinks = new ReadOnlyCollection<LBMBoundaryLink>(links.ToArray());
+            var lookup = new Dictionary<int, IReadOnlyList<int>>(perInterior.Count);
+            foreach (var kvp in perInterior)
+                lookup[kvp.Key] = new ReadOnlyCollection<int>(kvp.Value.ToArray());
+
+            return new LBMBoundaryTopology(readOnlyLinks, new ReadOnlyDictionary<int, IReadOnlyList<int>>(lookup));
+        }
+    }
+}

--- a/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMGrid.cs
+++ b/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMGrid.cs
@@ -30,6 +30,9 @@ namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
         public int Nx { get; }
         public int Ny { get; }
 
+        private LBMBoundaryTopology _boundaryTopology = LBMBoundaryTopology.Empty;
+        public LBMBoundaryTopology BoundaryTopology => _boundaryTopology;
+
         // Added for fast, direct access to elements by coordinate
         private readonly LBMElement[,] _grid;
         private readonly Dictionary<int, double> _ghostBaselineConductivity = new();
@@ -253,6 +256,8 @@ namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
                     }
                 }
             }
+
+            RebuildBoundaryTopologyFromState();
         }
 
         public LBMGrid(List<LBMElement> elements, int nx = _defaultNy, int ny = _defaultNy)
@@ -586,6 +591,52 @@ namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
             RebuildGhostLayerFromMask();
         }
 
+        private void RebuildBoundaryTopologyFromState()
+        {
+            if (_elements.Count == 0)
+            {
+                _boundaryTopology = LBMBoundaryTopology.Empty;
+                return;
+            }
+
+            var idToIndex = new Dictionary<int, int>(_elements.Count);
+            for (int i = 0; i < _elements.Count; i++)
+                idToIndex[_elements[i].Id] = i;
+
+            var links = new List<LBMBoundaryLink>();
+            var perInterior = new Dictionary<int, List<int>>();
+
+            for (int idx = 0; idx < _elements.Count; idx++)
+            {
+                var element = _elements[idx];
+                if (element.GhostElement || element.IsWall)
+                    continue;
+
+                for (int dir = 1; dir < NeighborDirections.Length; dir++)
+                {
+                    var neighbor = element.Neighbors[dir];
+                    if (neighbor is null || !neighbor.GhostElement)
+                        continue;
+
+                    if (!idToIndex.TryGetValue(neighbor.Id, out int ghostIndex))
+                        continue;
+
+                    int linkIndex = links.Count;
+                    links.Add(new LBMBoundaryLink(idx, ghostIndex, dir));
+
+                    if (!perInterior.TryGetValue(idx, out var perCell))
+                    {
+                        perCell = new List<int>();
+                        perInterior[idx] = perCell;
+                    }
+
+                    perCell.Add(linkIndex);
+                }
+            }
+
+            _boundaryTopology = LBMBoundaryTopology.Create(links, perInterior);
+        }
+
         private double ComputeCellAngle(int gridId)
         {
             var (x, y) = ToLattice(gridId);
@@ -762,6 +813,8 @@ namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
             copy.SetPotentialDistribution(new PotentialDistribution(pd));
 
             copy.SetElements([.. copy.ElementsTyped]);
+
+            copy.RebuildBoundaryTopologyFromState();
 
             return copy;
         }

--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
@@ -129,20 +129,6 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             public bool IsGround { get; }
         }
 
-        private readonly struct BoundaryLink
-        {
-            public BoundaryLink(int interiorIndex, int ghostIndex, int direction)
-            {
-                InteriorIndex = interiorIndex;
-                GhostIndex = ghostIndex;
-                Direction = direction;
-            }
-
-            public int InteriorIndex { get; }
-            public int GhostIndex { get; }
-            public int Direction { get; }
-        }
-
         /// <summary>
         /// Initializes LBM solver with specified convergence criteria and execution mode.
         /// </summary>
@@ -278,54 +264,14 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             return RunForwardCuda(lbmGrid, bc);
         }
 
-        private static List<BoundaryLink> BuildBoundaryLinks(
-            IReadOnlyList<LBMElement> elements,
-            IReadOnlyDictionary<int, int> elementIndexLookup,
-            out Dictionary<int, List<int>> linksByInterior)
-        {
-            var links = new List<BoundaryLink>();
-            linksByInterior = new Dictionary<int, List<int>>();
-
-            for (int idx = 0; idx < elements.Count; idx++)
-            {
-                var element = elements[idx];
-                // Skip ghost and wall cells unconditionally; walls should never emit flux links.
-                if (element.GhostElement || element.IsWall)
-                    continue;
-
-                for (int dir = 1; dir < LatticeBoltzmannConstants.Directions.Length; dir++)
-                {
-                    var neighbor = element.Neighbors[dir];
-                    if (neighbor is null || !neighbor.GhostElement)
-                        continue;
-
-                    if (!elementIndexLookup.TryGetValue(neighbor.Id, out int ghostIndex))
-                        continue;
-
-                    int linkIndex = links.Count;
-                    links.Add(new BoundaryLink(idx, ghostIndex, dir));
-
-                    if (!linksByInterior.TryGetValue(idx, out var perCell))
-                    {
-                        perCell = new List<int>();
-                        linksByInterior[idx] = perCell;
-                    }
-
-                    perCell.Add(linkIndex);
-                }
-            }
-
-            return links;
-        }
-
         /// <summary>
         /// Computes electrode flux densities j_n for each boundary link.  Relation (b) (Krüger et al. for unit
         /// conversion, Gebäck &amp; Heintz for the Neumann BC) distributes currents as flux densities so that
         /// (j_n Δx)/σ is invariant between physical and lattice units.
         /// </summary>
         private static double[] ComputeFluxPerLink(
-            IReadOnlyList<BoundaryLink> links,
-            Dictionary<int, List<int>> linksByInterior,
+            IReadOnlyList<LBMBoundaryLink> links,
+            IReadOnlyDictionary<int, IReadOnlyList<int>> linksByInterior,
             IReadOnlyList<ElectrodeRuntimeData> electrodes)
         {
             var flux = new double[links.Count];
@@ -515,8 +461,9 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             if (groundCellId < 0 && runtimeElectrodes.Count > 0)
                 groundCellId = runtimeElectrodes[0].Element.Id;
 
-            var boundaryLinks = BuildBoundaryLinks(elements, elementIndexLookup, out var linksByInterior);
-            var fluxPerLink = ComputeFluxPerLink(boundaryLinks, linksByInterior, runtimeElectrodes);
+            var boundaryTopology = lbmGrid.BoundaryTopology;
+            var boundaryLinks = boundaryTopology.Links;
+            var fluxPerLink = ComputeFluxPerLink(boundaryLinks, boundaryTopology.LinksByInterior, runtimeElectrodes);
 
             // Synchronise conductivity and initialise the discrete populations.
             var conductivity = lbmGrid.GetConductivityDistribution();
@@ -879,8 +826,9 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             if (groundCellId >= 0 && topology.IdToIndex.TryGetValue(groundCellId, out var idxGround))
                 groundIndex = idxGround;
 
-            var boundaryLinks = BuildBoundaryLinks(elements, topology.IdToIndex, out var linksByInterior);
-            var fluxPerLink = ComputeFluxPerLink(boundaryLinks, linksByInterior, runtimeElectrodes);
+            var boundaryTopology = lbmGrid.BoundaryTopology;
+            var boundaryLinks = boundaryTopology.Links;
+            var fluxPerLink = ComputeFluxPerLink(boundaryLinks, boundaryTopology.LinksByInterior, runtimeElectrodes);
 
             var conductivity = lbmGrid.GetConductivityDistribution();
             var initialPotential = lbmGrid.GetPotentialDistribution();
@@ -1440,7 +1388,9 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 .Select((element, idx) => new { element.Id, idx })
                 .ToDictionary(item => item.Id, item => item.idx);
 
-            var boundaryLinks = BuildBoundaryLinks(elements, elementIndexLookup, out var linksByInterior);
+            var boundaryTopology = cpuGrid.BoundaryTopology;
+            var boundaryLinks = boundaryTopology.Links;
+            var linksByInterior = boundaryTopology.LinksByInterior;
 
             var gridElectrodes = cpuGrid.GetElectrodes().Cast<LBMElectrode>().ToList();
             var bcElectrodes = cpuBoundary.GetElectrodes().Cast<LBMElectrode>().ToList();


### PR DESCRIPTION
## Summary
- cache the LBM boundary links and per-cell lookup on the grid itself (with a new `LBMBoundaryTopology`) so cloned discretizations reuse the same ghost/boundary data
- switch the Lattice Boltzmann solver (CPU, CUDA, and diagnostics) to consume the cached topology instead of rebuilding ad-hoc arrays, ensuring measurement and reconstruction paths share identical boundary link definitions

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: `dotnet` command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a60155f048333b9f8bfc6da84288a)