### PR TITLE
Fix LBM measurement topology alignment

### DIFF
--- a/ServiceLayer/IMeasurementService.cs
+++ b/ServiceLayer/IMeasurementService.cs
@@ -11,7 +11,8 @@ namespace ServiceLayer
         void Initialize(IDiscretization discretization,
                         EITReconstructionParameters parameters,
                         DrivePattern drivePattern,
-                        Func<IDifferentialEquationSolver?> solverAccessor);
+                        Func<IDifferentialEquationSolver?> solverAccessor,
+                        ConductivityDistribution? measurementConductivity = null);
 
         void SyncMeasurementSource();
         void EnsureMeasurements(double excitationAmplitude);

--- a/ServiceLayer/MeasurementService.cs
+++ b/ServiceLayer/MeasurementService.cs
@@ -41,6 +41,7 @@ namespace ServiceLayer
         private MeasurementPattern? _measurementPattern;
         private VirtualElectrodeSettings _virtualSettings = new();
         private int _framesPerCycle = 1;
+        private ConductivityDistribution? _measurementConductivity;
 
         public MeasurementService(IMeasurementPersistence measurementPersistence, ILogger logger)
         {
@@ -62,7 +63,8 @@ namespace ServiceLayer
         public void Initialize(IDiscretization discretization,
                                EITReconstructionParameters parameters,
                                DrivePattern drivePattern,
-                               Func<IDifferentialEquationSolver?> solverAccessor)
+                               Func<IDifferentialEquationSolver?> solverAccessor,
+                               ConductivityDistribution? measurementConductivity = null)
         {
             _discretization = discretization ?? throw new ArgumentNullException(nameof(discretization));
 
@@ -79,6 +81,7 @@ namespace ServiceLayer
             _noiseAmplitude = parameters.MeasurementNoiseAmplitude;
             _usePotentialDifferences = parameters.UsePotentialDifferences;
             _virtualSettings = parameters.VirtualElectrodeSettings ?? new VirtualElectrodeSettings();
+            _measurementConductivity = measurementConductivity;
 
             _measurementSource = Workspace.GetMeasurementSource();
             _measurementPattern = null;
@@ -153,26 +156,54 @@ namespace ServiceLayer
             if (solver == null)
                 throw new InvalidOperationException("Differential equation solver is not available for measurement simulation.");
 
-            MeasurementSimulationResult simulation = _discretization switch
+            ConductivityDistribution? savedConductivity = null;
+            PotentialDistribution? savedPotential = null;
+            bool restoreState = false;
+
+            if (_measurementConductivity != null)
             {
-                // Delegate the heavy lifting to the measurement persistence implementation
-                // which mirrors the old reconstruction persistence helpers.
-                FEMMesh fem => _measurementPersistence.SimulateFemMeasurements(fem,
-                                                                               excitationAmplitude,
-                                                                               _drivePattern,
-                                                                               _usePotentialDifferences,
-                                                                               solver,
-                                                                               _measurementSetup,
-                                                                               _virtualSettings),
-                LBMGrid lbm => _measurementPersistence.SimulateLbmMeasurements(lbm,
-                                                                               excitationAmplitude,
-                                                                               _drivePattern,
-                                                                               _usePotentialDifferences,
-                                                                               solver,
-                                                                               _measurementSetup,
-                                                                               _virtualSettings),
-                _ => throw new InvalidOperationException($"Unsupported discretization type {_discretization.GetType().Name} for measurement simulation.")
-            };
+                savedConductivity = CloneConductivityDistribution(_discretization.GetConductivityDistribution());
+                var currentPotential = _discretization.GetPotentialDistribution();
+                savedPotential = currentPotential != null ? ClonePotentialDistribution(currentPotential) : null;
+                _discretization.SetConductivityDistribution(CloneConductivityDistribution(_measurementConductivity));
+                restoreState = true;
+            }
+
+            MeasurementSimulationResult simulation;
+
+            try
+            {
+                simulation = _discretization switch
+                {
+                    // Delegate the heavy lifting to the measurement persistence implementation
+                    // which mirrors the old reconstruction persistence helpers.
+                    FEMMesh fem => _measurementPersistence.SimulateFemMeasurements(fem,
+                                                                                   excitationAmplitude,
+                                                                                   _drivePattern,
+                                                                                   _usePotentialDifferences,
+                                                                                   solver,
+                                                                                   _measurementSetup,
+                                                                                   _virtualSettings),
+                    LBMGrid lbm => _measurementPersistence.SimulateLbmMeasurements(lbm,
+                                                                                   excitationAmplitude,
+                                                                                   _drivePattern,
+                                                                                   _usePotentialDifferences,
+                                                                                   solver,
+                                                                                   _measurementSetup,
+                                                                                   _virtualSettings),
+                    _ => throw new InvalidOperationException($"Unsupported discretization type {_discretization.GetType().Name} for measurement simulation.")
+                };
+            }
+            finally
+            {
+                if (restoreState)
+                {
+                    if (savedConductivity != null)
+                        _discretization.SetConductivityDistribution(savedConductivity);
+                    if (savedPotential != null)
+                        _discretization.SetPotentialDistribution(savedPotential);
+                }
+            }
 
             _measurements.Clear();
             _measurements.AddRange(simulation.Frames.Select(frame => (double[])frame.Clone()));
@@ -251,6 +282,12 @@ namespace ServiceLayer
                 return 1;
             return Math.Max(1, _drivePatternStrategy.GetCycleLength(electrodeCount));
         }
+
+        private static ConductivityDistribution CloneConductivityDistribution(ConductivityDistribution source)
+            => new ConductivityDistribution(source.Conductivities);
+
+        private static PotentialDistribution ClonePotentialDistribution(PotentialDistribution source)
+            => new PotentialDistribution(source.Potentials);
 
         private static int GetDriveElectrodeCount(IEnumerable<Electrode> electrodes)
         {

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -117,14 +117,15 @@ namespace ServiceLayer
                 _originalSigma = Workspace.GetOriginalDiscretization()?.GetConductivityDistribution()
                                  ?? discretization.DeepCopy().GetConductivityDistribution();
 
-                // Measurement simulation must reuse the exact lattice that will later be used
-                // for reconstruction otherwise the LBM solver rebuilds a different set of
-                // boundary links/ghost cells.  Clone the active discretization rather than the
-                // copy stored on the workspace to guarantee that the topology (element order,
-                // ghost ring, electrode ordering) matches the solver's reconstruction state and
-                // only replace the conductivity distribution with the ground truth.
-                var measurementDiscretization = discretization.DeepCopy();
-                if (_originalSigma != null)
+                // LBM measurement simulations must run on the same lattice instance that will
+                // later be used for reconstruction to prevent the ghost layer/boundary topology
+                // from being rebuilt. FEM meshes can be safely cloned.
+                bool shareMeasurementGrid = discretization is LBMGrid;
+                IDiscretization measurementDiscretization = shareMeasurementGrid
+                    ? discretization
+                    : discretization.DeepCopy();
+
+                if (!shareMeasurementGrid && _originalSigma != null)
                 {
                     measurementDiscretization.SetConductivityDistribution(_originalSigma);
                 }
@@ -174,7 +175,8 @@ namespace ServiceLayer
                 _measurementService.Initialize(measurementDiscretization,
                                                parameters,
                                                _drivePattern,
-                                               () => _reconstructionPersistence.GetDifferentialEquationSolver());
+                                               () => _reconstructionPersistence.GetDifferentialEquationSolver(),
+                                               shareMeasurementGrid ? _originalSigma : null);
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
## Summary
- share the active LBM grid instance with the measurement service so simulated frames and reconstruction runs use the same boundary topology
- extend the measurement service to temporarily swap in the original conductivity distribution while simulating measurements and then restore the reconstruction state
- plumb the conductivity override through the reconstruction and measurement service interface so FEM paths remain unchanged while the LBM path stays topologically consistent

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: `dotnet` CLI is not available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ba2f2adb483338d8ed519781be0e8)