### PR TITLE
Improve LBM boundary flux calculations

### DIFF
--- a/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMBoundaryTopology.cs
+++ b/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMBoundaryTopology.cs
@@ -10,13 +10,15 @@ namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
             int ghostIndex,
             int direction,
             double interfaceLengthLu,
-            double interfaceLengthPhys)
+            double interfaceLengthPhys,
+            int electrodeId)
         {
             InteriorIndex = interiorIndex;
             GhostIndex = ghostIndex;
             Direction = direction;
             InterfaceLengthLU = interfaceLengthLu;
             InterfaceLengthPhys = interfaceLengthPhys;
+            ElectrodeId = electrodeId;
         }
 
         public int InteriorIndex { get; }
@@ -34,6 +36,13 @@ namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
         /// value when the simulation operates entirely in lattice space.
         /// </summary>
         public double InterfaceLengthPhys { get; }
+
+        /// <summary>
+        /// Identifier of the electrode that owns this boundary link.  Links attached to insulating
+        /// portions of the boundary carry -1.  The field lets boundary-condition assembly attribute
+        /// flux contributions without having to re-run topological searches.
+        /// </summary>
+        public int ElectrodeId { get; }
     }
 
     public sealed class LBMBoundaryTopology

--- a/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMGrid.cs
+++ b/Utility/Classes/Discretizer/LatticeBoltzmannGrid/LBMGrid.cs
@@ -16,8 +16,8 @@ namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
         private const int _defaultNy = 15;
 
         /// <summary>
-        /// Toggle diagonal boundary links.  Keeping this mutable (rather than const) lets
-        /// debug scenarios disable diagonals when investigating stability regressions.
+        /// Toggle diagonal boundary links.  Setting this to <c>false</c> disables √2 links entirely
+        /// which is useful when debugging regressions or comparing to purely axis-aligned schemes.
         /// </summary>
         internal static bool UseDiagonalBoundaryLinks = true;
 
@@ -616,8 +616,8 @@ namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
 
             double deltaX_LU = LatticeBoltzmannConstants.DeltaX;
             double deltaXPhys = LBUnitConverter.DeltaXPhys;
-            if (double.IsNaN(deltaXPhys) || deltaXPhys <= 0.0)
-                deltaXPhys = deltaX_LU; // Fall back to LU spacing when physical scaling is undefined.
+            if (!double.IsFinite(deltaXPhys) || deltaXPhys <= 0.0)
+                deltaXPhys = deltaX_LU; // Δx_phys must always be positive; fall back to LU spacing otherwise.
 
             for (int idx = 0; idx < _elements.Count; idx++)
             {
@@ -641,12 +641,19 @@ namespace Utility.Classes.Discretizer.LatticeBoltzmannGrid
                     if (!existing.Add((idx, dir)))
                         continue; // Deduplicate within each (interior, direction) pair.
 
+                    // Diagonal links intersect the interface at 45°, so the surface measure scales with √2.
                     double metricScale = isDiagonal ? Math.Sqrt(2.0) : 1.0;
                     double interfaceLu = deltaX_LU * metricScale;
                     double interfacePhys = deltaXPhys * metricScale;
 
                     int linkIndex = links.Count;
-                    links.Add(new LBMBoundaryLink(idx, ghostIndex, dir, interfaceLu, interfacePhys));
+                    links.Add(new LBMBoundaryLink(
+                        idx,
+                        ghostIndex,
+                        dir,
+                        interfaceLu,
+                        interfacePhys,
+                        _elements[idx].ElectrodeId));
 
                     if (!perInterior.TryGetValue(idx, out var perCell))
                     {

--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LBUnitConverter.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LBUnitConverter.cs
@@ -16,6 +16,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
 
         /// <summary>
         /// Number of lattice nodes along X.  The physical spacing follows Δx_phys = LxPhys / (Nx - 1).
+        /// Stored so that callers have a single source of truth for the discretisation metrics.
         /// </summary>
         public static int Nx { get; private set; } = 1;
 
@@ -26,7 +27,14 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
         public static double SigmaRefPhys { get; private set; } = 1.0;
 
         /// <summary>
-        /// Physical time step [s].
+        /// Physical lattice spacing Δx expressed in metres.  Numerics run with Δx_LU = 1 and use this
+        /// value solely for input/output conversions.
+        /// </summary>
+        public static double DeltaXPhys { get; private set; } = 1.0;
+
+        /// <summary>
+        /// Physical time step [s].  Numerics run with Δt_LU = 1 and use this scaling factor when
+        /// mapping physical quantities (conductivity, flux density) into lattice units.
         /// </summary>
         public static double DeltaTPhys { get; private set; } = 1.0;
 
@@ -36,11 +44,6 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
         /// </summary>
         public static bool InputsArePhysical { get; private set; }
             = false;
-
-        /// <summary>
-        /// Derived physical lattice spacing [m].  Returns zero-safe value when Nx == 1.
-        /// </summary>
-        public static double DeltaXPhys => LxPhys / Math.Max(1, Nx - 1);
 
         /// <summary>
         /// Lattice spacing in LU.  Numerics are implemented with Δx_LU = 1.
@@ -69,6 +72,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             Nx = nx;
             SigmaRefPhys = sigmaRefPhys;
             DeltaTPhys = deltaTPhys;
+            DeltaXPhys = lxPhys / Math.Max(1, nx - 1);
             InputsArePhysical = inputsArePhysical;
         }
 

--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannOperators.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannOperators.cs
@@ -22,6 +22,14 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
         private static Action<Index1D, ArrayView<double>, ArrayView<double>, ArrayView<int>, ArrayView<int>, ArrayView<double>>? _divergenceKernel;
 
         /// <summary>
+        /// Relation (a) from Krüger et al.: D = c_s^2 (τ − 1/2) Δt.  With Δt_LU = 1 the conversion
+        /// simplifies to τ = D / c_s^2 + 1/2.  Centralising this helper ensures the CPU and CUDA paths
+        /// use identical relaxation times for a given diffusivity.
+        /// </summary>
+        internal static double ComputeTauFromDiffusivityLU(double diffusivityLu)
+            => diffusivityLu / LatticeBoltzmannConstants.CsSquared + 0.5;
+
+        /// <summary>
         /// CPU implementation of central difference gradient operator on D2Q9 mesh.
         /// Computes ∇φ = (∂φ/∂x, ∂φ/∂y) using neighboring values in cardinal directions.
         /// Handles boundary conditions by using one-sided differences at domain edges.

--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
@@ -159,25 +159,13 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
         }
 
         /// <summary>
-        /// Converts a diffusion coefficient (conductivity) to the BGK relaxation time τ.
-        /// Relation (a): D = c_s^2 (τ − 1/2) Δt, so τ = D / (c_s^2 Δt) + 1/2.
-        /// c_s^2 from <see cref="LatticeBoltzmannConstants.CsSquared"/> only appears in this relation.
-        /// </summary>
-        /// <param name="diffusionCoefficient">Diffusion coefficient expressed in lattice units (relation (a), Krüger et al.).</param>
-        internal static double ComputeTauFromDiffusivityLU(double diffusionCoefficient)
-        {
-            // Δt_LU = 1 ⇒ τ = D / c_s^2 + 1/2 per relation (a).
-            return diffusionCoefficient / LatticeBoltzmannConstants.CsSquared + 0.5;
-        }
-
-        /// <summary>
         /// Computes BGK relaxation time from material conductivity and clamps it for stability.
         /// </summary>
         /// <param name="conductivity">Material electrical conductivity (diffusion coefficient).</param>
         /// <returns>Relaxation time ensuring numerical stability.</returns>
         private static double ComputeRelaxationTime(double conductivity)
         {
-            double tau = ComputeTauFromDiffusivityLU(conductivity);
+            double tau = LatticeBoltzmannOperators.ComputeTauFromDiffusivityLU(conductivity);
 
             // Enforce minimum relaxation time to prevent numerical instability
             // Values below 0.5 can cause negative distribution functions
@@ -300,54 +288,70 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                             throw new InvalidOperationException($"Boundary link {linkIndex} referenced by electrodes {owner} and {group.Key}.");
 
                         linkOwnership[linkIndex] = group.Key;
+
+                        var link = links[linkIndex];
+                        Debug.Assert(link.ElectrodeId < 0 || link.ElectrodeId == group.Key,
+                            $"Boundary link {linkIndex} tagged for electrode {link.ElectrodeId} but assigned to {group.Key}.");
                     }
                 }
 
                 if (perElectrodeLinks.Count == 0)
-                    continue;
+                    throw new InvalidOperationException($"Electrode {group.Key} does not touch the ghost boundary.");
 
-                double boundaryMeasure = 0.0;
+                double boundaryMeasureLu = 0.0;
+                double boundaryMeasurePhys = 0.0;
+
                 foreach (int linkIndex in perElectrodeLinks)
                 {
                     var link = links[linkIndex];
-                    boundaryMeasure += LBUnitConverter.InputsArePhysical
-                        ? link.InterfaceLengthPhys
-                        : link.InterfaceLengthLU;
+                    boundaryMeasureLu += link.InterfaceLengthLU;
+                    boundaryMeasurePhys += link.InterfaceLengthPhys;
                 }
 
-                if (boundaryMeasure <= 0.0)
+                double activeMeasure = LBUnitConverter.InputsArePhysical ? boundaryMeasurePhys : boundaryMeasureLu;
+                if (activeMeasure <= 0.0)
                     throw new InvalidOperationException($"Electrode {group.Key} has zero boundary measure.");
+
+                double fluxDensityLu;
+                double fluxDensityPhys;
 
                 if (LBUnitConverter.InputsArePhysical)
                 {
-                    double jPhys = totalCurrent / boundaryMeasure;
-                    double jLu = LBUnitConverter.FluxDensityPhysToLU(jPhys);
+                    fluxDensityPhys = totalCurrent / boundaryMeasurePhys;
+                    fluxDensityLu = LBUnitConverter.FluxDensityPhysToLU(fluxDensityPhys);
+                }
+                else
+                {
+                    fluxDensityLu = totalCurrent / boundaryMeasureLu;
+                    fluxDensityPhys = fluxDensityLu * (LBUnitConverter.DeltaXPhys / LBUnitConverter.DeltaTPhys);
+                }
 
-                    foreach (int linkIndex in perElectrodeLinks)
-                        flux[linkIndex] = jLu;
+                foreach (int linkIndex in perElectrodeLinks)
+                    flux[linkIndex] = fluxDensityLu; // Store link-wise flux density in LU.
 
-                    double closure = 0.0;
-                    foreach (int linkIndex in perElectrodeLinks)
-                        closure += jPhys * links[linkIndex].InterfaceLengthPhys;
-
+                if (LBUnitConverter.InputsArePhysical)
+                {
+                    double closure = fluxDensityPhys * boundaryMeasurePhys;
                     double tol = Math.Max(1e-12, Math.Abs(totalCurrent) * 1e-10);
+                    if (Math.Abs(closure - totalCurrent) > tol)
+                        throw new InvalidOperationException($"Flux closure violated for electrode {group.Key}: expected {totalCurrent:G6}, got {closure:G6}.");
+
                     Debug.Assert(Math.Abs(closure - totalCurrent) <= tol,
                         $"Flux closure violated for electrode {group.Key}: expected {totalCurrent:G6}, got {closure:G6}.");
                 }
                 else
                 {
-                    double fluxDensity = totalCurrent / boundaryMeasure;
-
-                    foreach (int linkIndex in perElectrodeLinks)
-                        flux[linkIndex] = fluxDensity;
-
-                    double closure = 0.0;
-                    foreach (int linkIndex in perElectrodeLinks)
-                        closure += fluxDensity * links[linkIndex].InterfaceLengthLU;
+                    double closure = fluxDensityLu * boundaryMeasureLu;
+                    if (Math.Abs(closure - totalCurrent) > 1e-12)
+                        throw new InvalidOperationException($"Flux closure violated for electrode {group.Key}: expected {totalCurrent:G6}, got {closure:G6}.");
 
                     Debug.Assert(Math.Abs(closure - totalCurrent) <= 1e-12,
                         $"Flux closure violated for electrode {group.Key}: expected {totalCurrent:G6}, got {closure:G6}.");
                 }
+
+                double logMeasure = LBUnitConverter.InputsArePhysical ? boundaryMeasurePhys : boundaryMeasureLu;
+                double logFlux = LBUnitConverter.InputsArePhysical ? fluxDensityPhys : fluxDensityLu;
+                Debug.WriteLine($"[LBM] Electrode {group.Key}: links={perElectrodeLinks.Count}, ΣΔs={(logMeasure):G6}, I={totalCurrent:G6}, j={(logFlux):G6} {(LBUnitConverter.InputsArePhysical ? "[phys]" : "[LU]")}");
             }
 
             return flux;
@@ -1065,7 +1069,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
 
             // Calculate relaxation time from material conductivity.
             // Relation (a): D = c_s^2 (τ − 1/2) handled centrally in ComputeTauFromDiffusivityLU.
-            double tau = ComputeTauFromDiffusivityLU(conductivity[index]);
+            double tau = LatticeBoltzmannOperators.ComputeTauFromDiffusivityLU(conductivity[index]);
 
             // Enforce minimum relaxation time for numerical stability
             if (tau < minTau)
@@ -1241,9 +1245,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             const double deltaTPhys = 1e-6; // [s]
             const double driveCurrent = 2e-3; // [A]
 
-            LBUnitConverter.Configure(lxPhys, nx, sigmaPhys, deltaTPhys, inputsArePhysical: true);
-
-            (LBMGrid Grid, LBMBoundaryCondition Boundary) CreateSetup()
+            (LBMGrid Grid, LBMBoundaryCondition Boundary) CreateSetup(double electrodeCurrent)
             {
                 var grid = new LBMGrid(nx, nx);
                 grid.ApplyCircularDomain((nx - 1) / 2.0, (nx - 1) / 2.0, (nx - 3) / 2.0);
@@ -1269,8 +1271,8 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
 
                 var electrodes = new List<LBMElectrode>
                 {
-                    new LBMElectrode(id: 0, gridId: drive.Id, current: driveCurrent, potential: 0.0, contactImpedance: 0.0, isExcitation: true, isGround: false),
-                    new LBMElectrode(id: 1, gridId: sink.Id, current: -driveCurrent, potential: 0.0, contactImpedance: 0.0, isExcitation: false, isGround: true)
+                    new LBMElectrode(id: 0, gridId: drive.Id, current: electrodeCurrent, potential: 0.0, contactImpedance: 0.0, isExcitation: true, isGround: false),
+                    new LBMElectrode(id: 1, gridId: sink.Id, current: -electrodeCurrent, potential: 0.0, contactImpedance: 0.0, isExcitation: false, isGround: true)
                 };
 
                 grid.SetElectrodes(electrodes);
@@ -1278,7 +1280,7 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 return (grid, bc);
             }
 
-            void PopulateUniformConductivity(LBMGrid grid)
+            void PopulateUniformConductivity(LBMGrid grid, double conductivityValue)
             {
                 var conductivity = grid.GetConductivityDistribution();
                 foreach (var element in grid.GetElements().Cast<LBMElement>())
@@ -1286,8 +1288,8 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                     if (element.IsWall)
                         continue;
 
-                    conductivity.Conductivities[element.Id] = sigmaPhys;
-                    element.Conductivity = sigmaPhys;
+                    conductivity.Conductivities[element.Id] = conductivityValue;
+                    element.Conductivity = conductivityValue;
                 }
 
                 grid.UpdateGhostConductivityFromNeighbors();
@@ -1339,52 +1341,61 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 }
             }
 
-            foreach (bool useDiagonals in new[] { true, false })
+            foreach (bool inputsArePhysical in new[] { true, false })
             {
-                bool previousToggle = LBMGrid.UseDiagonalBoundaryLinks;
-                try
+                LBUnitConverter.Configure(lxPhys, nx, sigmaPhys, deltaTPhys, inputsArePhysical);
+                double conductivityValue = inputsArePhysical ? sigmaPhys : LBUnitConverter.ConductivityPhysToLU(sigmaPhys);
+                double electrodeCurrent = inputsArePhysical
+                    ? driveCurrent
+                    : driveCurrent * (LBUnitConverter.DeltaTPhys / (LBUnitConverter.DeltaXPhys * LBUnitConverter.DeltaXPhys));
+
+                foreach (bool useDiagonals in new[] { true, false })
                 {
-                    LBMGrid.UseDiagonalBoundaryLinks = useDiagonals;
-
-                    var (cpuGrid, cpuBoundary) = CreateSetup();
-                    PopulateUniformConductivity(cpuGrid);
-                    ValidateFlux(cpuGrid, cpuBoundary);
-
-                    var solverCpu = new LatticeBoltzmannSolver(4000, 1e-12, 50, useCuda: false);
-                    var cpuResult = solverCpu.SolveForward(cpuGrid, cpuBoundary);
-
-                    PotentialDistribution? gpuResult = null;
+                    bool previousToggle = LBMGrid.UseDiagonalBoundaryLinks;
                     try
                     {
-                        var (gpuGrid, gpuBoundary) = CreateSetup();
-                        PopulateUniformConductivity(gpuGrid);
-                        var solverGpu = new LatticeBoltzmannSolver(4000, 1e-12, 50, useCuda: true);
-                        gpuResult = solverGpu.SolveForward(gpuGrid, gpuBoundary);
+                        LBMGrid.UseDiagonalBoundaryLinks = useDiagonals;
+
+                        var (cpuGrid, cpuBoundary) = CreateSetup(electrodeCurrent);
+                        PopulateUniformConductivity(cpuGrid, conductivityValue);
+                        ValidateFlux(cpuGrid, cpuBoundary);
+
+                        var solverCpu = new LatticeBoltzmannSolver(4000, 1e-12, 50, useCuda: false);
+                        var cpuResult = solverCpu.SolveForward(cpuGrid, cpuBoundary);
+
+                        PotentialDistribution? gpuResult = null;
+                        try
+                        {
+                            var (gpuGrid, gpuBoundary) = CreateSetup(electrodeCurrent);
+                            PopulateUniformConductivity(gpuGrid, conductivityValue);
+                            var solverGpu = new LatticeBoltzmannSolver(4000, 1e-12, 50, useCuda: true);
+                            gpuResult = solverGpu.SolveForward(gpuGrid, gpuBoundary);
+                        }
+                        catch (InvalidOperationException ex) when (ex.Message.Contains("CUDA"))
+                        {
+                            continue; // CUDA unavailable in this debug session.
+                        }
+
+                        var cpuPotentials = cpuResult.Potentials;
+                        var gpuPotentials = gpuResult!.Potentials;
+                        double maxDiff = 0.0;
+
+                        foreach (var element in cpuGrid.GetElements().Cast<LBMElement>())
+                        {
+                            if (element.IsWall || element.GhostElement)
+                                continue;
+
+                            double diff = Math.Abs(cpuPotentials[element.Id] - gpuPotentials[element.Id]);
+                            maxDiff = Math.Max(maxDiff, diff);
+                        }
+
+                        Debug.Assert(maxDiff < 1e-10,
+                            $"CPU/CUDA mismatch ({(inputsArePhysical ? "phys" : "LU")}, {(useDiagonals ? "diagonals" : "axis only")}): Δφ_max = {maxDiff:G3}");
                     }
-                    catch (InvalidOperationException ex) when (ex.Message.Contains("CUDA"))
+                    finally
                     {
-                        continue; // CUDA unavailable in this debug session.
+                        LBMGrid.UseDiagonalBoundaryLinks = previousToggle;
                     }
-
-                    var cpuPotentials = cpuResult.Potentials;
-                    var gpuPotentials = gpuResult!.Potentials;
-                    double maxDiff = 0.0;
-
-                    foreach (var element in cpuGrid.GetElements().Cast<LBMElement>())
-                    {
-                        if (element.IsWall || element.GhostElement)
-                            continue;
-
-                        double diff = Math.Abs(cpuPotentials[element.Id] - gpuPotentials[element.Id]);
-                        maxDiff = Math.Max(maxDiff, diff);
-                    }
-
-                    Debug.Assert(maxDiff < 1e-10,
-                        $"CPU/CUDA mismatch ({(useDiagonals ? "diagonals" : "axis only")}): Δφ_max = {maxDiff:G3}");
-                }
-                finally
-                {
-                    LBMGrid.UseDiagonalBoundaryLinks = previousToggle;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add geometry-aware boundary links carrying axis/diagonal interface lengths and owning electrode metadata
- convert electrode currents into per-link flux densities via the centralised unit converter and enforce the ghost-node Neumann scheme identically on CPU and CUDA
- unify relaxation-time computation and expand the debug self-test to cover both physical and lattice-unit modes while checking CUDA/CPU parity

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c8aa82d4c833382ec71792afe00d0)