### PR TITLE
Mirror boundary bounce-back in CUDA LBM streaming

### DIFF
--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
@@ -1137,7 +1137,15 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                     ref double bounceDestination = ref fiNext[baseIndex + opp];
                     Atomic.Exchange(ref bounceDestination, value); // Atomic add for multiple bounces
                 }
-                // If neighborIndex < 0, distribution leaves domain (absorbed at boundary)
+                // If neighbourIndex < 0, we hit a physical boundary.  Mirror the
+                // population just like the CPU path does when neighbour == null so
+                // mass is conserved and CUDA/CPU solutions stay in lockstep.
+                else if (neighborIndex < 0)
+                {
+                    int opp = opposite[k];
+                    ref double bounceDestination = ref fiNext[baseIndex + opp];
+                    Atomic.Exchange(ref bounceDestination, value);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- reflect streaming populations at domain boundaries in the CUDA LBM kernel to match CPU behavior
- preserve mass conservation when running GPU forward solves

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692054354e70833391beeac0502a0fb8)