### PR TITLE
Refine discretization usage for reconstruction exports

### DIFF
--- a/DataAccessLayer/ReconstructionExportRepository.cs
+++ b/DataAccessLayer/ReconstructionExportRepository.cs
@@ -33,9 +33,11 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
             var originalMetadata = CreateRangeMetadata(latestSnapshot.Result.OriginalConductivityDistribution);
             AppendSetupMetadata(originalMetadata, request.MeasurementPattern, request.Configuration);
 
+            var originalDiscretization = ResolveDiscretization(latestSnapshot.Result, request.Discretization);
+
             ReconstructionVideoRenderer.SaveDistributionSnapshot(request.TargetDirectory,
                                      "original_distribution.png",
-                                     request.Discretization,
+                                     originalDiscretization,
                                      GetFrameForResult(latestSnapshot.Result, request.RenderFrame),
                                      latestSnapshot.Result,
                                      ReconstructionVideoRenderer.DistributionSnapshotType.Original,
@@ -56,9 +58,11 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
             }
             AppendSetupMetadata(initialMetadata, request.MeasurementPattern, request.Configuration);
 
+            var initialDiscretization = ResolveDiscretization(initialResult, request.Discretization);
+
             ReconstructionVideoRenderer.SaveDistributionSnapshot(request.TargetDirectory,
                                      "initial_distribution.png",
-                                     request.Discretization,
+                                     initialDiscretization,
                                      GetFrameForResult(firstSnapshot.Result, request.RenderFrame),
                                      initialResult,
                                      ReconstructionVideoRenderer.DistributionSnapshotType.Initial,
@@ -79,9 +83,11 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
             finalMetadata.Add(("Correlation", FormatDouble(latestSnapshot.Correlation)));
             AppendSetupMetadata(finalMetadata, request.MeasurementPattern, request.Configuration);
 
+            var latestDiscretization = ResolveDiscretization(latestSnapshot.Result, request.Discretization);
+
             ReconstructionVideoRenderer.SaveDistributionSnapshot(request.TargetDirectory,
                                      "reconstructed_distribution_latest.png",
-                                     request.Discretization,
+                                     latestDiscretization,
                                      GetFrameForResult(latestSnapshot.Result, request.RenderFrame),
                                      latestSnapshot.Result,
                                      ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
@@ -141,7 +147,7 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
     }
 
     private static void SaveBestMetricSnapshots(string directory,
-                                                IDiscretization discretization,
+                                                IDiscretization fallbackDiscretization,
                                                 ReconstructionFrame fallbackFrame,
                                                 IReadOnlyList<ReconstructionIterationSnapshot> snapshots,
                                                 PotentialDisplayMode mode,
@@ -159,6 +165,8 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
             if (maeSnapshot.Result != null)
             {
+                var snapshotDiscretization = maeSnapshot.Result.Discretization ?? fallbackDiscretization;
+
                 var metrics = maeSnapshot.Metrics!.Value;
                 var metadata = new List<(string, string)>
                 {
@@ -174,7 +182,7 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
                 ReconstructionVideoRenderer.SaveDistributionSnapshot(directory,
                                          "best_mae_distribution.png",
-                                         discretization,
+                                         snapshotDiscretization,
                                          GetFrameForResult(maeSnapshot.Result, fallbackFrame),
                                          maeSnapshot.Result,
                                          ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
@@ -190,6 +198,8 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
             if (ssimSnapshot.Result != null)
             {
+                var snapshotDiscretization = ssimSnapshot.Result.Discretization ?? fallbackDiscretization;
+
                 var metrics = ssimSnapshot.Metrics!.Value;
                 var metadata = new List<(string, string)>
                 {
@@ -205,7 +215,7 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
                 ReconstructionVideoRenderer.SaveDistributionSnapshot(directory,
                                          "best_ssim_distribution.png",
-                                         discretization,
+                                         snapshotDiscretization,
                                          GetFrameForResult(ssimSnapshot.Result, fallbackFrame),
                                          ssimSnapshot.Result,
                                          ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
@@ -221,6 +231,8 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
         if (residualSnapshot.Result != null)
         {
+            var snapshotDiscretization = residualSnapshot.Result.Discretization ?? fallbackDiscretization;
+
             var metadata = new List<(string, string)>
             {
                 ("Iteration", residualSnapshot.Iteration.ToString(CultureInfo.InvariantCulture)),
@@ -240,7 +252,7 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
             ReconstructionVideoRenderer.SaveDistributionSnapshot(directory,
                                      "best_residual_distribution.png",
-                                     discretization,
+                                     snapshotDiscretization,
                                      GetFrameForResult(residualSnapshot.Result, fallbackFrame),
                                      residualSnapshot.Result,
                                      ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
@@ -256,6 +268,8 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
         if (correlationSnapshot.Result != null)
         {
+            var snapshotDiscretization = correlationSnapshot.Result.Discretization ?? fallbackDiscretization;
+
             var metadata = new List<(string, string)>
             {
                 ("Iteration", correlationSnapshot.Iteration.ToString(CultureInfo.InvariantCulture)),
@@ -275,7 +289,7 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
             ReconstructionVideoRenderer.SaveDistributionSnapshot(directory,
                                      "best_correlation_distribution.png",
-                                     discretization,
+                                     snapshotDiscretization,
                                      GetFrameForResult(correlationSnapshot.Result, fallbackFrame),
                                      correlationSnapshot.Result,
                                      ReconstructionVideoRenderer.DistributionSnapshotType.Reconstructed,
@@ -376,6 +390,9 @@ public sealed class ReconstructionExportRepository : IReconstructionExportReposi
 
     private static ReconstructionFrame GetFrameForResult(ReconstructionResult result, ReconstructionFrame fallback)
         => result.Frames.LastOrDefault() ?? fallback;
+
+    private static IDiscretization ResolveDiscretization(ReconstructionResult result, IDiscretization fallback)
+        => result.Discretization ?? fallback;
 
     private static List<(string Label, string Value)> CreateRangeMetadata(ConductivityDistribution distribution)
     {

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -1652,14 +1652,17 @@ namespace ElectricalImpedanceTomography.ViewModels
             if (frames.Count == 0)
                 return VideoExportResult.CreateFailure("No Frames", "There are no reconstruction frames to export.");
 
-            var discretization = Workspace.GetDiscretization();
-            if (discretization == null)
-                return VideoExportResult.CreateFailure("No Mesh", "Unable to determine the discretization for rendering.");
-
             progress?.Report(new VideoExportProgressReport(0.0,
                                                             "Preparing reconstruction frames for video generation..."));
 
             var results = Workspace.GetReconstructionResults().ToList();
+            var fallbackDiscretization = results.Select(r => r.Discretization)
+                                                .FirstOrDefault(d => d != null)
+                                        ?? Workspace.GetDiscretization();
+
+            if (fallbackDiscretization == null)
+                return VideoExportResult.CreateFailure("No Mesh", "Unable to determine the discretization for rendering.");
+
             var residualHistory = results
                 .Select(CalculateResidual)
                 .ToList();
@@ -1715,7 +1718,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 
                             using var image = ReconstructionVideoRenderer.RenderFrameSnapshot(frames[i],
                                                                                                context,
-                                                                                               discretization,
+                                                                                               fallbackDiscretization,
                                                                                                residualHistory,
                                                                                                residualCount,
                                                                                                distributionSize,

--- a/ServiceLayer/ReconstructionExportService.cs
+++ b/ServiceLayer/ReconstructionExportService.cs
@@ -31,7 +31,10 @@ public sealed class ReconstructionExportService : IReconstructionExportService
         if (results.Count == 0)
             return Task.FromResult(DataExportResult.CreateFailure("No Results", "There are no reconstruction results to export."));
 
-        var discretization = Workspace.GetDiscretization();
+        var discretization = results.Select(r => r.Discretization)
+                                    .FirstOrDefault(d => d != null)
+                            ?? Workspace.GetDiscretization();
+
         if (discretization == null)
             return Task.FromResult(DataExportResult.CreateFailure("No Mesh", "Unable to determine the discretization for rendering."));
 

--- a/Utility/Classes/ReconstructionFrame.cs
+++ b/Utility/Classes/ReconstructionFrame.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using Utility.Classes.Discretizer;
 
 namespace Utility.Classes
 {
     public sealed class ReconstructionFrame
     {
-        public static Discretization? Mesh { get; private set; }
         public ConductivityDistribution ConductivityGradient;           // The gradient calculated of the distribution
         public PotentialDistribution CalculatedPotentialDistribution;   // The current calculated potential distribution of the model
         public PotentialDistribution CalculatedAdjointDistribution;     // The current adjoin (\mu) field calculated by the model which is somewhat a potential distribution

--- a/Utility/Rendering/ReconstructionVideoRenderer.cs
+++ b/Utility/Rendering/ReconstructionVideoRenderer.cs
@@ -116,7 +116,7 @@ public static class ReconstructionVideoRenderer
     public static void SaveDistributionSnapshot(
         string directory,
         string fileName,
-        IDiscretization discretization,
+        IDiscretization? fallbackDiscretization,
         ReconstructionFrame frame,
         ReconstructionResult? context,
         DistributionSnapshotType snapshotType,
@@ -140,6 +140,10 @@ public static class ReconstructionVideoRenderer
             DistributionSnapshotType.Initial => DistributionSection.Initial,
             _ => DistributionSection.Reconstructed
         };
+
+        var discretization = context?.Discretization ?? fallbackDiscretization
+            ?? throw new ArgumentNullException(nameof(fallbackDiscretization),
+                "A discretization is required to render reconstruction distributions.");
 
         using var contentImage = RenderDistributionImage(section, discretization, frame, context, contentSize, mode);
         using var colorbarImage = RenderColorbarImage(section, discretization, frame, context, colorbarSize, mode);
@@ -215,7 +219,7 @@ public static class ReconstructionVideoRenderer
     [Obsolete]
     public static SKImage RenderFrameSnapshot(ReconstructionFrame frame,
                                               ReconstructionResult? context,
-                                              IDiscretization discretization,
+                                              IDiscretization? fallbackDiscretization,
                                               IReadOnlyList<double> residualHistory,
                                               int residualCount,
                                               SKSizeI distributionSize,
@@ -223,6 +227,10 @@ public static class ReconstructionVideoRenderer
                                               SKSizeI residualSize,
                                               PotentialDisplayMode mode)
     {
+        var discretization = context?.Discretization ?? fallbackDiscretization
+            ?? throw new ArgumentNullException(nameof(fallbackDiscretization),
+                "A discretization is required to render reconstruction frames.");
+
         int cellWidth = Math.Max(distributionSize.Width, 1);
         int cellHeight = Math.Max(distributionSize.Height, 1);
         int colorbarHeight = Math.Max(colorbarSize.Height, 1);


### PR DESCRIPTION
## Summary
- remove unused discretization storage from reconstruction frames
- rely on reconstruction results for discretization when rendering exports and snapshots
- adjust video export path to select discretization context per frame and use result metadata

## Testing
- not run (dotnet CLI unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ddf1845c8333890979c94d18df38)