### PR TITLE
Improve reconstruction configuration interactions

### DIFF
--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
@@ -39,7 +39,17 @@
                 <VerticalStackLayout Grid.Row="0" Spacing="10">
                     <Label Text="DOMAIN PREVIEW" FontSize="11" FontAttributes="Bold" TextColor="{StaticResource TextMuted}" />
                     <Border HeightRequest="160" BackgroundColor="#111" Stroke="#444" StrokeShape="RoundRectangle 6">
-                        <Label Text="FEM Mesh Preview" FontSize="10" TextColor="#666" HorizontalOptions="Center" VerticalOptions="Center"/>
+                        <Grid>
+                            <skia:SKCanvasView x:Name="MeshPreviewCanvas"
+                                               PaintSurface="OnMeshPreviewPaintSurface"
+                                               IgnorePixelScaling="True"/>
+                            <Label x:Name="MeshPreviewPlaceholder"
+                                   Text="No mesh loaded in workspace"
+                                   FontSize="10"
+                                   TextColor="#666"
+                                   HorizontalOptions="Center"
+                                   VerticalOptions="Center"/>
+                        </Grid>
                     </Border>
                 </VerticalStackLayout>
 
@@ -81,10 +91,11 @@
             <BoxView Color="#232330" Opacity="0.5"/>
 
             <!-- SkiaSharp Layer: Touch Enabled -->
-            <skia:SKCanvasView x:Name="ConnectionsCanvas" 
-                               PaintSurface="OnCanvasPaintSurface" 
+            <skia:SKCanvasView x:Name="ConnectionsCanvas"
+                               PaintSurface="OnCanvasPaintSurface"
                                EnableTouchEvents="True"
                                Touch="OnCanvasTouch"
+                               IgnorePixelScaling="True"
                                InputTransparent="False" />
 
             <!-- Container for blocks -->

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
@@ -3,7 +3,11 @@ using Microsoft.Maui.Controls.Shapes;
 using SkiaSharp;
 using SkiaSharp.Views.Maui;
 using System.Collections.Specialized;
+using System.Linq;
+using Utility.Classes.Application;
 using Utility.Classes.Configurations.ReconstructionConfiguration;
+using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 
 namespace ElectricalImpedanceTomography.Views
 {
@@ -27,6 +31,17 @@ namespace ElectricalImpedanceTomography.Views
         private const double OutputPortXOffset = 214;
         private const double InputPortXOffset = 0;
 
+        // Mesh preview drawing helpers
+        private readonly SKPaint _lbmFill = new() { Style = SKPaintStyle.Fill, Color = SKColors.Black };
+        private readonly SKPaint _lbmWall = new() { Style = SKPaintStyle.Fill, Color = SKColors.White };
+        private readonly SKPaint _lbmElectrode = new() { Style = SKPaintStyle.Fill, Color = SKColors.Orange };
+        private readonly SKPaint _lbmStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.LightGray, StrokeWidth = 1 };
+
+        private readonly SKPaint _femStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.Black, StrokeWidth = 1 };
+        private readonly SKPaint _femFill = new() { Style = SKPaintStyle.Fill };
+        private readonly SKPaint _electrodeFill = new() { Style = SKPaintStyle.Fill, Color = SKColors.Yellow };
+        private readonly SKPaint _electrodeSegmentStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.Gold, StrokeWidth = 3, IsAntialias = true };
+
         public ReconstructionConfigurationPage()
         {
             InitializeComponent();
@@ -37,6 +52,12 @@ namespace ElectricalImpedanceTomography.Views
             _viewModel.Connections.CollectionChanged += (s, e) => ConnectionsCanvas.InvalidateSurface();
 
             RefreshNodeContainer();
+        }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            MeshPreviewCanvas?.InvalidateSurface();
         }
 
         private void OnBlocksChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -72,17 +93,26 @@ namespace ElectricalImpedanceTomography.Views
             var mainStack = new VerticalStackLayout();
             var headerGrid = new Grid { BackgroundColor = headerColor.WithAlpha(0.15f), Padding = 10, HeightRequest = 40 };
             headerGrid.Add(new BoxView { Color = headerColor, WidthRequest = 4, HorizontalOptions = LayoutOptions.Start, VerticalOptions = LayoutOptions.Fill });
-            headerGrid.Add(new Label
+            var titleLabel = new Label
             {
-                Text = block.Title,
                 FontSize = 13,
                 FontAttributes = FontAttributes.Bold,
                 TextColor = Color.FromArgb("#F0F0F0"),
                 VerticalOptions = LayoutOptions.Center,
-                Margin = new Thickness(10, 0, 0, 0)
-            });
+                Margin = new Thickness(10, 0, 0, 0),
+                BindingContext = block
+            };
+            titleLabel.SetBinding(Label.TextProperty, nameof(ReconstructionConfigurationBlock.Title));
+            headerGrid.Add(titleLabel);
 
-            var contentLabel = new Label { Text = $"{block.Type}", FontSize = 11, TextColor = Color.FromArgb("#999"), Margin = 10 };
+            var contentLabel = new Label
+            {
+                FontSize = 11,
+                TextColor = Color.FromArgb("#999"),
+                Margin = 10,
+                BindingContext = block
+            };
+            contentLabel.SetBinding(Label.TextProperty, nameof(ReconstructionConfigurationBlock.HighlightedOption));
 
             mainStack.Add(headerGrid);
             mainStack.Add(contentLabel);
@@ -127,7 +157,7 @@ namespace ElectricalImpedanceTomography.Views
             connectGesture.PanUpdated += (s, e) => OnConnectionPanUpdated(block, e);
             outPort.GestureRecognizers.Add(connectGesture);
 
-            var container = new Grid { WidthRequest = 214 };
+            var container = new Grid { WidthRequest = 214, BindingContext = block };
             container.InputTransparent = false;
             container.Add(border);
             container.Add(inPort);
@@ -228,37 +258,38 @@ namespace ElectricalImpedanceTomography.Views
         private void OnCanvasTouch(object sender, SKTouchEventArgs e)
         {
             // Coordinate conversion if needed, assuming Canvas scale is 1:1 with MAUI Points
-            var pt = e.Location;
+            var viewPoint = ToViewPoint(e.Location);
+            var viewSkPoint = new SKPoint((float)viewPoint.X, (float)viewPoint.Y);
 
             switch (e.ActionType)
             {
                 case SKTouchAction.Pressed:
                     // Try selecting a connection first
-                    if (TrySelectConnection(pt))
+                    if (TrySelectConnection(viewSkPoint))
                     {
                         _isSelecting = false;
                     }
                     else
                     {
                         // Start Selection Rectangle
-                        _selectionStart = new Point(pt.X, pt.Y);
+                        _selectionStart = viewPoint;
                         _isSelecting = true;
                         _viewModel.ClearSelection();
 
                         SelectionBox.IsVisible = true;
                         SelectionBox.WidthRequest = 0;
                         SelectionBox.HeightRequest = 0;
-                        SelectionBox.Margin = new Thickness(pt.X, pt.Y, 0, 0);
+                        SelectionBox.Margin = new Thickness(viewPoint.X, viewPoint.Y, 0, 0);
                     }
                     break;
 
                 case SKTouchAction.Moved:
                     if (_isSelecting && _selectionStart.HasValue)
                     {
-                        double x = Math.Min(_selectionStart.Value.X, pt.X);
-                        double y = Math.Min(_selectionStart.Value.Y, pt.Y);
-                        double w = Math.Abs(_selectionStart.Value.X - pt.X);
-                        double h = Math.Abs(_selectionStart.Value.Y - pt.Y);
+                        double x = Math.Min(_selectionStart.Value.X, viewPoint.X);
+                        double y = Math.Min(_selectionStart.Value.Y, viewPoint.Y);
+                        double w = Math.Abs(_selectionStart.Value.X - viewPoint.X);
+                        double h = Math.Abs(_selectionStart.Value.Y - viewPoint.Y);
 
                         // Update Visual Rect
                         SelectionBox.Margin = new Thickness(x, y, 0, 0);
@@ -374,6 +405,22 @@ namespace ElectricalImpedanceTomography.Views
             }
         }
 
+        private Point ToViewPoint(SKPoint skPoint)
+        {
+            var canvasSize = ConnectionsCanvas.CanvasSize;
+            var viewWidth = ConnectionsCanvas.Width;
+            var viewHeight = ConnectionsCanvas.Height;
+
+            if (canvasSize.Width <= 0 || canvasSize.Height <= 0 || viewWidth <= 0 || viewHeight <= 0)
+            {
+                return new Point(skPoint.X, skPoint.Y);
+            }
+
+            double x = skPoint.X * viewWidth / canvasSize.Width;
+            double y = skPoint.Y * viewHeight / canvasSize.Height;
+            return new Point(x, y);
+        }
+
         private void DrawConnectionCurve(SKCanvas canvas, SKPaint paint, float x1, float y1, float x2, float y2)
         {
             using var path = new SKPath();
@@ -382,6 +429,118 @@ namespace ElectricalImpedanceTomography.Views
             float cp2X = x2 - 60;
             path.CubicTo(cp1X, y1, cp2X, y2, x2, y2);
             canvas.DrawPath(path, paint);
+        }
+
+        private void OnMeshPreviewPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+        {
+            var canvas = e.Surface.Canvas;
+            var info = e.Info;
+            canvas.Clear(SKColors.Black.WithAlpha(20));
+
+            var discretization = Workspace.GetDiscretization();
+            MeshPreviewPlaceholder.IsVisible = discretization == null;
+            if (discretization == null)
+                return;
+
+            if (discretization is LBMGrid lbm)
+            {
+                DrawLbmPreview(canvas, info, lbm);
+            }
+            else if (discretization is FEMMesh fem)
+            {
+                DrawFemPreview(canvas, info, fem);
+            }
+        }
+
+        private void DrawLbmPreview(SKCanvas canvas, SKImageInfo info, LBMGrid grid)
+        {
+            float cellW = (float)info.Width / grid.Nx;
+            float cellH = (float)info.Height / grid.Ny;
+
+            for (int y = 0; y < grid.Ny; y++)
+            {
+                for (int x = 0; x < grid.Nx; x++)
+                {
+                    var el = grid.GetElementAt(x, y);
+                    SKPaint fill = el.IsElectrode
+                        ? _lbmElectrode
+                        : el.IsWall
+                            ? _lbmWall
+                            : _lbmFill;
+                    var r = SKRect.Create(x * cellW, y * cellH, cellW, cellH);
+                    canvas.DrawRect(r, fill);
+                    canvas.DrawRect(r, _lbmStroke);
+                }
+            }
+        }
+
+        private static SKColor ColorForValue(double val, double min, double max)
+        {
+            double mid = (min + max) * 0.5;
+            if (val >= mid)
+            {
+                float t = (float)((val - mid) / (max - mid));
+                t = Math.Clamp(t, 0f, 1f);
+                byte r = (byte)(255 * t);
+                return new SKColor(r, 0, 0);
+            }
+            else
+            {
+                float t = (float)((mid - val) / (mid - min));
+                t = Math.Clamp(t, 0f, 1f);
+                byte b = (byte)(255 * t);
+                return new SKColor(0, 0, b);
+            }
+        }
+
+        private void DrawFemPreview(SKCanvas canvas, SKImageInfo info, FEMMesh mesh)
+        {
+            const float pad = 6f;
+            float availW = info.Width - 2 * pad;
+            float availH = info.Height - 2 * pad;
+            var verts = mesh.Vertices;
+            float minX = (float)verts.Min(v => v.X);
+            float minY = (float)verts.Min(v => v.Y);
+            var maxX = (float)verts.Max(v => v.X);
+            var maxY = (float)verts.Max(v => v.Y);
+            float meshWidth = maxX - minX;
+            float meshHeight = maxY - minY;
+            float scale = Math.Min(availW / meshWidth, availH / meshHeight);
+            float usedW = meshWidth * scale;
+            float usedH = meshHeight * scale;
+            float marginX = pad + (availW - usedW) / 2f;
+            float marginY = pad + (availH - usedH) / 2f;
+
+            SKPoint ToCanvas(Utility.Classes.Discretizer.FiniteElementMesh.FEMVertex v)
+                => new((float)(v.X - minX) * scale + marginX,
+                        info.Height - ((float)(v.Y - minY) * scale + marginY));
+
+            var elements = mesh.ElementsTyped;
+            double min = elements.Min(el => el.Conductivity);
+            double max = elements.Max(el => el.Conductivity);
+
+            using var path = new SKPath();
+            foreach (var el in elements)
+            {
+                var p1 = ToCanvas(el.Vertices[0]);
+                var p2 = ToCanvas(el.Vertices[1]);
+                var p3 = ToCanvas(el.Vertices[2]);
+                path.Reset();
+                path.MoveTo(p1); path.LineTo(p2); path.LineTo(p3); path.Close();
+                _femFill.Color = ColorForValue(el.Conductivity, min, max);
+                canvas.DrawPath(path, _femFill);
+                canvas.DrawPath(path, _femStroke);
+            }
+
+            foreach (var segment in mesh.GetElectrodeSegments())
+            {
+                var start = ToCanvas(segment.Start);
+                var end = ToCanvas(segment.End);
+                canvas.DrawLine(start, end, _electrodeSegmentStroke);
+            }
+
+            foreach (var v in mesh.Vertices.Where(v => v.IsElectrode))
+                canvas.DrawCircle(ToCanvas(v), 3f, _electrodeFill);
         }
 
         private void OnAddBlockClicked(object sender, EventArgs e)

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
@@ -1,5 +1,8 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.ObjectModel;
+using System.Linq;
+using Utility.Classes.Factories;
+using Utility.Classes.ReconstructionParameters;
 
 namespace Utility.Classes.Configurations.ReconstructionConfiguration
 {
@@ -28,6 +31,12 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
         /// Hex color code for the block's UI representation.
         /// </summary>
         public string IconColor { get; set; }
+
+        private string _highlightedOption = string.Empty;
+        /// <summary>
+        /// Short text shown on the block card to reflect the key selection (e.g., chosen solver).
+        /// </summary>
+        public string HighlightedOption { get => _highlightedOption; set => SetProperty(ref _highlightedOption, value); }
 
         private double _x;
         /// <summary>
@@ -67,6 +76,8 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
             Y = y;
             SetColor();
             InitializeDefaultParameters();
+            HookParameterChanges();
+            UpdateHighlightedOption();
         }
 
         /// <summary>
@@ -97,31 +108,32 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                 case BlockType.Initialization:
                     Parameters.Add(new ChoiceParameter
                     {
-                        Name = "Initialization Method",
+                        Name = "Initial Distribution",
                         Key = "init_method",
-                        Options = new List<string> { "Homogeneous", "Random", "CloseToTarget", "Pre-calculated (CIM)", "Phase-Informed (Takens)" },
-                        SelectedOption = "Homogeneous"
+                        Options = Enum.GetNames(typeof(InitialDistributionTypes)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(InitialDistributionTypes.Homogeneous))
                     });
-                    Parameters.Add(new NumberParameter { Name = "Background Conductivity (S/m)", Key = "bg_cond", Value = 1.0, Min = 0.0001 });
-                    Parameters.Add(new NumberParameter { Name = "Randomization Noise Level", Key = "rand_noise", Value = 0.1, Min = 0, Max = 1 });
-
-                    // Parameters for Takens' Theorem phase-space reconstruction
-                    Parameters.Add(new NumberParameter { Name = "Takens: Embedding Dimension (d)", Key = "takens_dim", Value = 6, Min = 1, Step = 1 });
-                    Parameters.Add(new NumberParameter { Name = "Takens: Time Delay (tau)", Key = "takens_tau", Value = 5, Min = 1, Step = 1 });
+                    Parameters.Add(new NumberParameter { Name = "Random Max Conductivity", Key = "rand_max", Value = 1.0, Min = 0.0 });
+                    Parameters.Add(new NumberParameter { Name = "Slight Scaling", Key = "slight_scale", Value = 0.95, Min = 0.0, Max = 1.0, Step = 0.05 });
+                    Parameters.Add(new NumberParameter { Name = "Random Differing Count", Key = "rand_diff_count", Value = 5, Min = 0, Step = 1 });
                     break;
 
                 case BlockType.Solver:
                     Parameters.Add(new ChoiceParameter
                     {
-                        Name = "DE Solver Type",
+                        Name = "Differential Equation Solver",
                         Key = "solver_type",
-                        Options = new List<string> { "FEM (Finite Element Method)", "LBM (Lattice Boltzmann Method)", "Graph-Based (CIM)" },
-                        SelectedOption = "FEM"
+                        Options = Enum.GetNames(typeof(DifferentialEquationSolver)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(DifferentialEquationSolver.FEM))
+                    });
+                    Parameters.Add(new ChoiceParameter
+                    {
+                        Name = "Numeric Solver",
+                        Key = "numeric_solver",
+                        Options = Enum.GetNames(typeof(NumericSolver)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(NumericSolver.GMRES))
                     });
                     Parameters.Add(new NumberParameter { Name = "FEM Order", Key = "fem_order", Value = 1, Min = 1, Max = 2, Step = 1 });
-
-                    // Parameters for Lattice Boltzmann Method
-                    Parameters.Add(new ChoiceParameter { Name = "LBM Lattice Structure", Key = "lbm_domain", Options = new List<string> { "D2Q9", "D3Q19" }, SelectedOption = "D2Q9" });
                     Parameters.Add(new NumberParameter { Name = "LBM Relaxation Time (tau)", Key = "lbm_tau", Value = 0.51, Min = 0.50001, Step = 0.01 });
                     break;
 
@@ -130,17 +142,11 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                     {
                         Name = "Regularization Technique",
                         Key = "reg_tech",
-                        Options = new List<string> { "None", "Tikhonov (0-order)", "Tikhonov (1st-order)", "Total Variation (TV)", "Laplace", "Graph Consistency (Tether)", "D-Bar (Direct)" },
-                        SelectedOption = "Tikhonov (1st-order)"
+                        Options = Enum.GetNames(typeof(RegularizationTechnique)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(RegularizationTechnique.FirstOrderTikhonov))
                     });
-                    Parameters.Add(new ChoiceParameter { Name = "Weight Calculation Mode", Key = "weight_mode", Options = new List<string> { "Static", "L-Curve", "Heuristic", "Spatially Adaptive" }, SelectedOption = "Static" });
                     Parameters.Add(new NumberParameter { Name = "Lambda (Regularization Weight)", Key = "lambda", Value = 0.01, Min = 0, Step = 0.001 });
-
-                    // Parameter for D-Bar method
-                    Parameters.Add(new NumberParameter { Name = "D-Bar: Cutoff Frequency (k0)", Key = "dbar_cutoff", Value = 4.0, Min = 0.1 });
-
-                    // Parameter for Graph Consistency regularization
-                    Parameters.Add(new NumberParameter { Name = "Graph Tether Weight", Key = "graph_tether", Value = 0.1, Min = 0 });
+                    Parameters.Add(new BoolParameter { Name = "Spatial Weighting", Key = "spatial_weighting", Value = false });
                     break;
 
                 case BlockType.ErrorMetric:
@@ -148,21 +154,9 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                     {
                         Name = "Error Metric",
                         Key = "metric_type",
-                        Options = new List<string> { "L2 (Least Squares)", "Wasserstein-2 (Geometric)", "Wasserstein-2 (Conductivity Aware)", "Wasserstein-2 (Spectral)", "Energy-Based W2" },
-                        SelectedOption = "Wasserstein-2 (Geometric)"
+                        Options = Enum.GetNames(typeof(ErrorMetric)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(ErrorMetric.Wasserstein2))
                     });
-
-                    // Parameters for Conductivity Aware Wasserstein metric
-                    Parameters.Add(new ChoiceParameter { Name = "Ground Cost Type", Key = "ground_cost", Options = new List<string> { "Euclidean", "Geodesic (Weighted)", "Effective Resistance" }, SelectedOption = "Euclidean" });
-                    Parameters.Add(new NumberParameter { Name = "Geodesic Beta Exponent", Key = "geo_beta", Value = 1.0, Min = 0.1 });
-
-                    // Parameter for Spectral Wasserstein metric
-                    Parameters.Add(new NumberParameter { Name = "Spectral Eigenvalues Count (r)", Key = "spec_r", Value = 10, Min = 1, Step = 1 });
-
-                    // Parameter for Convex combination of metrics
-                    Parameters.Add(new NumberParameter { Name = "Convex Weight (Alpha)", Key = "alpha", Value = 0.5, Min = 0, Max = 1, Step = 0.1 });
-
-                    // Parameter for Energy-Based metric with ROI
                     Parameters.Add(new BoolParameter { Name = "Use ROI Focusing", Key = "use_roi", Value = false });
                     break;
 
@@ -171,8 +165,8 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                     {
                         Name = "Optimization Algorithm",
                         Key = "opt_algo",
-                        Options = new List<string> { "Gradient Descent", "Gauss-Newton", "L-BFGS", "ADAM", "Nesterov Accelerated Gradient" },
-                        SelectedOption = "ADAM"
+                        Options = Enum.GetNames(typeof(NumericOptimizer)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(NumericOptimizer.ADAM))
                     });
                     Parameters.Add(new NumberParameter { Name = "Max Iterations", Key = "max_iter", Value = 50, Min = 1, Step = 10 });
                     Parameters.Add(new NumberParameter { Name = "Convergence Tolerance", Key = "conv_tol", Value = 1e-4, Min = 1e-9 });
@@ -185,6 +179,26 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                     Parameters.Add(new NumberParameter { Name = "Kernel Size", Key = "kernel_size", Value = 3, Min = 1, Step = 2 });
                     break;
             }
+        }
+
+        private static string FriendlyName(string raw)
+            => string.Concat(raw.Select((c, i) => i > 0 && char.IsUpper(c) && !char.IsUpper(raw[i - 1]) ? $" {c}" : c.ToString()));
+
+        private void HookParameterChanges()
+        {
+            foreach (var choice in Parameters.OfType<ChoiceParameter>())
+            {
+                choice.PropertyChanged += (_, args) =>
+                {
+                    if (args.PropertyName == nameof(ChoiceParameter.SelectedOption))
+                        UpdateHighlightedOption();
+                };
+            }
+        }
+
+        private void UpdateHighlightedOption()
+        {
+            HighlightedOption = Parameters.OfType<ChoiceParameter>().FirstOrDefault()?.SelectedOption ?? Type.ToString();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Align selection interactions with device-independent coordinates and render the current workspace mesh in the configuration preview.
- Keep spline previews attached to output drags and highlight chosen block options directly on each block.
- Refresh block parameter sets to mirror available reconstruction methods and clean up inconsistent options.

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet CLI is unavailable in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244374dbb48333822df8178f9ee2d5)