### PR TITLE
Add measurement block to reconstruction flow editor

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -32,6 +32,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         public ObservableCollection<BlockType> BlockTypes { get; } = new()
         {
             BlockType.Initialization,
+            BlockType.Measurement,
             BlockType.Solver,
             BlockType.Regularizer,
             BlockType.ErrorMetric,

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/BlockType.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/BlockType.cs
@@ -12,6 +12,11 @@
         Initialization,
 
         /// <summary>
+        /// Block describing the incoming measurements and their preprocessing.
+        /// </summary>
+        Measurement,
+
+        /// <summary>
         /// Block for the forward problem solver (e.g., FEM, LBM).
         /// </summary>
         Solver,

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Utility.Classes.Factories;
+using Utility.Classes.Measurement;
 using Utility.Classes.ReconstructionParameters;
 
 namespace Utility.Classes.Configurations.ReconstructionConfiguration
@@ -88,6 +89,7 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
             IconColor = Type switch
             {
                 BlockType.Initialization => "#FFD166", // Yellow
+                BlockType.Measurement => "#4ECDC4",    // Teal
                 BlockType.Solver => "#06D6A0",         // Green
                 BlockType.Regularizer => "#118AB2",    // Blue
                 BlockType.ErrorMetric => "#EF476F",    // Red
@@ -135,6 +137,33 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                     });
                     Parameters.Add(new NumberParameter { Name = "FEM Order", Key = "fem_order", Value = 1, Min = 1, Max = 2, Step = 1 });
                     Parameters.Add(new NumberParameter { Name = "LBM Relaxation Time (tau)", Key = "lbm_tau", Value = 0.51, Min = 0.50001, Step = 0.01 });
+                    break;
+
+                case BlockType.Measurement:
+                    Parameters.Add(new ChoiceParameter
+                    {
+                        Name = "Measurement Source",
+                        Key = "measurement_source",
+                        Options = Enum.GetNames(typeof(MeasurementSourceOption)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(MeasurementSourceOption.Simulated))
+                    });
+                    Parameters.Add(new ChoiceParameter
+                    {
+                        Name = "Electrode Setup",
+                        Key = "electrode_setup",
+                        Options = Enum.GetNames(typeof(ElectrodeMeasurementSetup)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(ElectrodeMeasurementSetup.Active))
+                    });
+                    Parameters.Add(new BoolParameter { Name = "Use Potential Differences", Key = "use_potential_differences", Value = false });
+                    Parameters.Add(new BoolParameter { Name = "Apply Measurement Noise", Key = "apply_noise", Value = false });
+                    Parameters.Add(new ChoiceParameter
+                    {
+                        Name = "Noise Type",
+                        Key = "noise_type",
+                        Options = Enum.GetNames(typeof(MeasurementNoiseType)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(MeasurementNoiseType.None))
+                    });
+                    Parameters.Add(new NumberParameter { Name = "Noise Amplitude / dB", Key = "noise_amplitude", Value = 0.0, Min = 0.0, Step = 0.1 });
                     break;
 
                 case BlockType.Regularizer:


### PR DESCRIPTION
## Summary
- add a measurement block type to the reconstruction configuration flow
- expose measurement source, electrode setup, representation, and noise parameters consistent with the reconstruction page
- include the new block in the available component list with distinct styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69247e620fe48333a31a52617a988736)