### PR TITLE
Add conductivity export to MATLAB mesh JSON and allow saving loaded meshes

### DIFF
--- a/DataAccessLayer/MeshRepository.cs
+++ b/DataAccessLayer/MeshRepository.cs
@@ -172,6 +172,11 @@ namespace DataAccessLayer
                 }
             }
 
+            var elementConductivities = mesh.ElementsTyped
+                .OrderBy(e => e.Id)
+                .Select(e => e.Conductivity)
+                .ToList();
+
             // Generate electrode excitation/ground pairs based on the chosen drive pattern.
             var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
             var drivePatternPairs = new List<int[]>();
@@ -193,7 +198,8 @@ namespace DataAccessLayer
                 electrodeVertexCoordinates,
                 matlabElectrodeVertexIds,
                 drivePatternPairs,
-                stlVertexOrder = matlabVertexOrder
+                stlVertexOrder = matlabVertexOrder,
+                inhomogenousPhantomElemData = elementConductivities
 
             };
 

--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using ServiceLayer;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using Utility.Classes;
 using Utility.Classes.Factories;
 using Utility.Classes.Discretizer;
@@ -126,6 +127,8 @@ namespace ElectricalImpedanceTomography.ViewModels
             _currentDiscretization = SelectedMeshType == DiscretizationType.FEM
                 ? _daqService.LoadFEMMesh(filePath)
                 : _daqService.LoadLBMGrid(filePath);
+
+            Name = Path.GetFileNameWithoutExtension(filePath);
 
             Workspace.SetDiscretization(_currentDiscretization);
             Workspace.SetOriginalDiscretization(_currentDiscretization.DeepCopy());


### PR DESCRIPTION
## Summary
- default mesh save name to the loaded file name so saving loaded meshes succeeds
- include per-element conductivity values in MATLAB export JSON for FEM meshes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692487d9d720833387d94b1569a39f43)