### PR TITLE
Fix measurement block availability in reconstruction configuration

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -1,5 +1,6 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
@@ -29,16 +30,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         // Connection rules: when empty, any block can connect to any other block.
         private readonly Dictionary<BlockType, HashSet<BlockType>> _connectionRules = new();
 
-        public ObservableCollection<BlockType> BlockTypes { get; } = new()
-        {
-            BlockType.Initialization,
-            BlockType.Measurement,
-            BlockType.Solver,
-            BlockType.Regularizer,
-            BlockType.ErrorMetric,
-            BlockType.Optimizer,
-            BlockType.PostProcessing
-        };
+        public ObservableCollection<BlockType> BlockTypes { get; } = new(Enum.GetValues<BlockType>());
 
         public ReconstructionConfigurationPageViewModel()
         {


### PR DESCRIPTION
## Summary
- build the reconstruction configuration block type list from the enum so new block types (including Measurement) appear in the toolbar
- update usings accordingly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69248a5a448c8333ac2ed9a9d79c01bf)