### PR TITLE
Use arc-length ground cost for Wasserstein metrics

### DIFF
--- a/Utility/Classes/Reconstruction/ErrorMetrics/ArcLengthGroundCostHelper.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/ArcLengthGroundCostHelper.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+
+namespace Utility.Classes.Reconstruction.ErrorMetrics
+{
+    /// <summary>
+    /// Utility helpers to build Wasserstein ground costs based on arc-length
+    /// distances along the closed electrode curve instead of raw Euclidean
+    /// distances.
+    /// </summary>
+    internal static class ArcLengthGroundCostHelper
+    {
+        private const double Tiny = 1e-12;
+
+        /// <summary>
+        /// Builds a squared-distance ground cost matrix using arc-length
+        /// distances measured along the closed curve defined by
+        /// <paramref name="coords"/>.
+        /// </summary>
+        public static double[,] BuildArcLengthCost((double x, double y)[] coords)
+        {
+            var (parameters, totalLength) = BuildArcLengthParameterization(coords);
+            return BuildArcLengthCost(parameters, totalLength);
+        }
+
+        /// <summary>
+        /// Builds the cumulative arc-length parameterization for the provided
+        /// coordinates. The first coordinate has parameter 0 and the perimeter
+        /// wraps so that the final edge closes the curve.
+        /// </summary>
+        public static (double[] Parameters, double TotalLength) BuildArcLengthParameterization((double x, double y)[] coords)
+        {
+            int n = coords.Length;
+            if (n == 0)
+                return (Array.Empty<double>(), 0.0);
+
+            var parameters = new double[n];
+            double total = 0.0;
+
+            for (int i = 1; i < n; i++)
+            {
+                total += Distance(coords[i - 1], coords[i]);
+                parameters[i] = total;
+            }
+
+            if (n > 1)
+                total += Distance(coords[n - 1], coords[0]);
+
+            return (parameters, total);
+        }
+
+        /// <summary>
+        /// Builds a squared arc-length ground cost matrix from a precomputed
+        /// parameterization and total perimeter length.
+        /// </summary>
+        public static double[,] BuildArcLengthCost(IReadOnlyList<double> parameters, double totalLength)
+        {
+            int n = parameters.Count;
+            var matrix = new double[n, n];
+            if (n == 0 || totalLength <= Tiny)
+                return matrix;
+
+            for (int i = 0; i < n; i++)
+            {
+                matrix[i, i] = 0.0;
+                for (int j = i + 1; j < n; j++)
+                {
+                    double diff = Math.Abs(parameters[i] - parameters[j]);
+                    double distance = Math.Min(diff, totalLength - diff);
+                    double value = distance * distance;
+                    matrix[i, j] = value;
+                    matrix[j, i] = value;
+                }
+            }
+
+            return matrix;
+        }
+
+        /// <summary>
+        /// Extracts a submatrix from a full cost matrix according to the
+        /// provided indices. This allows reusing a cached all-electrode matrix
+        /// for arbitrary subsets without recomputation.
+        /// </summary>
+        public static double[,] SliceCostMatrix(double[,] fullCost, IReadOnlyList<int> indices)
+        {
+            int n = indices.Count;
+            var result = new double[n, n];
+            for (int i = 0; i < n; i++)
+            {
+                int ii = indices[i];
+                for (int j = 0; j < n; j++)
+                {
+                    int jj = indices[j];
+                    result[i, j] = fullCost[ii, jj];
+                }
+            }
+            return result;
+        }
+
+        private static double Distance((double x, double y) a, (double x, double y) b)
+        {
+            double dx = a.x - b.x;
+            double dy = a.y - b.y;
+            return Math.Sqrt(dx * dx + dy * dy);
+        }
+    }
+}

--- a/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/ConductivityAwareW2Metric.cs
@@ -89,7 +89,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         /// Geometric ground cost matrix: c_geo(i,j) = |x_i - x_j|^2 for all electrodes on the
         /// current discretization (global electrode index space).
         /// </summary>
-        private double[,]? _euclideanCost;
+        private double[,]? _arcLengthCost;
 
         /// <summary>
         /// Conductivity-aware ground cost matrix C_sigma(i,j) ~ scaled (conductive geodesic)^2.
@@ -483,7 +483,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             if (!_useConductivityAware)
                 return;
 
-            bool rebuild = _cPhysAmp == null || _euclideanCost == null;
+            bool rebuild = _cPhysAmp == null || _arcLengthCost == null;
             if (!rebuild && _lastCostBuildIter >= 0 &&
                 (_solveCounter - _lastCostBuildIter) >= Math.Max(1, _config.RecomputeEvery))
                 rebuild = true;
@@ -509,7 +509,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
 
             lock (_costLock)
             {
-                bool need = _cPhysAmp == null || _euclideanCost == null;
+                bool need = _cPhysAmp == null || _arcLengthCost == null;
                 if (!need && _lastCostBuildIter >= 0 &&
                     (_solveCounter - _lastCostBuildIter) >= Math.Max(1, _config.RecomputeEvery))
                     need = true;
@@ -541,7 +541,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                     positions[i] = getCoord(electrodes[i]);
 
                 // Geometric cost: c_geo(i,j) = |x_i - x_j|^2.
-                _euclideanCost ??= ComputeEuclideanCost(positions);
+                _arcLengthCost ??= ComputeArcLengthCost(positions);
 
                 // Conductivity-aware distances: d_sigma(i,j).
                 double[,] dsigma = mesh switch
@@ -555,7 +555,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 };
 
                 // Scale d_sigma^2 so its median matches median(c_geo).
-                double medE = ComputeMedian(_euclideanCost);
+                double medE = ComputeMedian(_arcLengthCost);
                 double medD = ComputeMedianSquared(dsigma); // median of d_sigma^2 (ignoring tiny distances).
                 _scale = medD <= Tiny ? 1.0 : medE / medD;
 
@@ -620,25 +620,12 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         }
 
         /// <summary>
-        /// Compute geometric squared distances between electrode positions.
+        /// Compute arc-length-based squared distances between electrode positions.
         /// </summary>
-        private static double[,] ComputeEuclideanCost(IReadOnlyList<(double x, double y)> positions)
+        private static double[,] ComputeArcLengthCost(IReadOnlyList<(double x, double y)> positions)
         {
-            int k = positions.Count;
-            var cost = new double[k, k];
-            for (int i = 0; i < k; i++)
-            {
-                cost[i, i] = 0.0;
-                for (int j = i + 1; j < k; j++)
-                {
-                    double dx = positions[i].x - positions[j].x;
-                    double dy = positions[i].y - positions[j].y;
-                    double d2 = dx * dx + dy * dy;
-                    cost[i, j] = d2;
-                    cost[j, i] = d2;
-                }
-            }
-            return cost;
+            var coords = positions.ToArray();
+            return ArcLengthGroundCostHelper.BuildArcLengthCost(coords);
         }
 
         /// <summary>

--- a/Utility/Classes/Reconstruction/ErrorMetrics/UnbalancedWasserstein2Metric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/UnbalancedWasserstein2Metric.cs
@@ -119,6 +119,12 @@ public sealed class UnbalancedWasserstein2Metric : IErrorMetric
     // while still supporting concurrent rentals within a single evaluation.
     private readonly Dictionary<int, Stack<double[]>> _vectorPool = new();
 
+    // Cached arc-length ground cost for the current electrode geometry.
+    private readonly object _costLock = new();
+    private IDiscretization? _cachedDiscretization;
+    private int[]? _cachedElectrodeIds;
+    private double[,]? _cachedArcCost;
+
     /// <summary>
     /// Initialises the metric with optional custom configuration.
     /// </summary>
@@ -194,6 +200,7 @@ public sealed class UnbalancedWasserstein2Metric : IErrorMetric
         Func<Electrode, (double x, double y)> coordinateProvider)
     {
         int count = Math.Min(measured.Length, electrodes.Count);
+        EnsureArcLengthCost(discretization, electrodes, coordinateProvider);
         var include = new List<int>(count);
         for (int i = 0; i < count; i++)
         {
@@ -205,18 +212,16 @@ public sealed class UnbalancedWasserstein2Metric : IErrorMetric
         if (include.Count == 0)
             return new OptimalTransportResult(measured, simulated, 0.0, new double[count]);
 
-        var coords = new (double x, double y)[include.Count];
         var simValues = new double[include.Count];
         var measValues = new double[include.Count];
         for (int i = 0; i < include.Count; i++)
         {
             int idx = include[i];
-            coords[i] = coordinateProvider(electrodes[idx]);
             simValues[i] = ClampNonNegative(simulated[idx]);
             measValues[i] = ClampNonNegative(measured[idx]);
         }
 
-        var cost = BuildEuclideanCost(coords, _amplitudeCostScratch);
+        var cost = GetSubsetCost(discretization, electrodes, coordinateProvider, include, _amplitudeCostScratch);
         var result = ComputeSinkhorn(simValues, measValues, cost);
 
         var gradient = new double[count];
@@ -238,6 +243,7 @@ public sealed class UnbalancedWasserstein2Metric : IErrorMetric
             throw new ArgumentException("Measured and simulated difference vectors must share the same length.");
 
         int differenceCount = measured.Length;
+        EnsureArcLengthCost(discretization, electrodes, coordinateProvider);
         var include = new List<int>(differenceCount);
         for (int i = 0; i < differenceCount; i++)
         {
@@ -250,13 +256,13 @@ public sealed class UnbalancedWasserstein2Metric : IErrorMetric
             return new OptimalTransportResult(measured, simulated, 0.0, new double[differenceCount]);
 
         var activePattern = pattern != null && pattern.SanitizedLength == differenceCount ? pattern : null;
-        var (simValues, coords, mapping, _) = BuildDifferenceDistribution(simulated, electrodes, coordinateProvider, include, activePattern);
+        var (simValues, coords, mapping, leftIndices) = BuildDifferenceDistribution(simulated, electrodes, coordinateProvider, include, activePattern);
         var (measValues, _, _, _) = BuildDifferenceDistribution(measured, electrodes, coordinateProvider, include, activePattern);
 
         if (simValues.Length == 0)
             return new OptimalTransportResult(measured, simulated, 0.0, new double[differenceCount]);
 
-        var cost = BuildEuclideanCost(coords, _differenceCostScratch);
+        var cost = GetSubsetCost(discretization, electrodes, coordinateProvider, leftIndices, _differenceCostScratch);
         var result = ComputeDifference(measValues, simValues, coords, mapping, cost);
 
         var gradient = new double[differenceCount];
@@ -570,22 +576,51 @@ public sealed class UnbalancedWasserstein2Metric : IErrorMetric
         return buffers;
     }
 
-    private static double[,] BuildEuclideanCost((double x, double y)[] coords, Dictionary<int, double[,]> scratchPool)
+    private void EnsureArcLengthCost(IDiscretization discretization, IReadOnlyList<Electrode> electrodes,
+        Func<Electrode, (double x, double y)> coordinateProvider)
     {
-        int n = coords.Length;
-        var matrix = GetScratchMatrix(scratchPool, n);
-        Parallel.For(0, n, i =>
+        lock (_costLock)
         {
-            matrix[i, i] = 0.0;
-            for (int j = i + 1; j < n; j++)
+            bool reuse = _cachedArcCost != null && _cachedElectrodeIds != null &&
+                         ReferenceEquals(_cachedDiscretization, discretization) &&
+                         _cachedElectrodeIds.Length == electrodes.Count;
+
+            if (reuse)
             {
-                double dx = coords[i].x - coords[j].x;
-                double dy = coords[i].y - coords[j].y;
-                double value = dx * dx + dy * dy;
-                matrix[i, j] = value;
-                matrix[j, i] = value;
+                for (int i = 0; i < electrodes.Count; i++)
+                {
+                    if (_cachedElectrodeIds[i] != electrodes[i].Id)
+                    {
+                        reuse = false;
+                        break;
+                    }
+                }
             }
-        });
+
+            if (reuse)
+                return;
+
+            var coords = electrodes.Select(coordinateProvider).ToArray();
+            _cachedArcCost = ArcLengthGroundCostHelper.BuildArcLengthCost(coords);
+            _cachedElectrodeIds = electrodes.Select(e => e.Id).ToArray();
+            _cachedDiscretization = discretization;
+        }
+    }
+
+    private double[,] GetSubsetCost(IDiscretization discretization, IReadOnlyList<Electrode> electrodes,
+        Func<Electrode, (double x, double y)> coordinateProvider, IReadOnlyList<int> indices,
+        Dictionary<int, double[,]> scratchPool)
+    {
+        EnsureArcLengthCost(discretization, electrodes, coordinateProvider);
+        var matrix = GetScratchMatrix(scratchPool, indices.Count);
+        for (int i = 0; i < indices.Count; i++)
+        {
+            int ii = indices[i];
+            for (int j = 0; j < indices.Count; j++)
+            {
+                matrix[i, j] = _cachedArcCost![ii, indices[j]];
+            }
+        }
         return matrix;
     }
 

--- a/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
+++ b/Utility/Classes/Reconstruction/ErrorMetrics/Wasserstein2ErrorMetric.cs
@@ -26,6 +26,12 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         // Cache last result to reuse gradient when EvaluateAdjointSource() follows Evaluate().
         private OptimalTransportResult? _last;
 
+        // Cached arc-length ground cost for the current geometry.
+        private readonly object _costCacheLock = new();
+        private IDiscretization? _cachedDiscretization;
+        private int[]? _cachedElectrodeIds;
+        private double[,]? _cachedArcLengthCost;
+
         /// <summary>
         /// Standalone W₂ routine used both by the error metric and unit tests.
         /// Inputs are raw (unnormalized, possibly signed) masses and the
@@ -35,8 +41,17 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         public static OTResult w2_misfit_and_grad(double[] mPred, double[] dObs,
             (double x, double y)[] x, (double x, double y)[] y)
         {
-            if (mPred.Length != x.Length || dObs.Length != y.Length)
-                throw new ArgumentException("Mass and coordinate arrays must align.");
+            if (x.Length != y.Length)
+                throw new ArgumentException("Arc-length ground cost requires matching supports.");
+
+            var cost = ArcLengthGroundCostHelper.BuildArcLengthCost(x);
+            return w2_misfit_and_grad(mPred, dObs, cost);
+        }
+
+        public static OTResult w2_misfit_and_grad(double[] mPred, double[] dObs, double[,] costMatrix)
+        {
+            if (mPred.Length != costMatrix.GetLength(0) || dObs.Length != costMatrix.GetLength(1))
+                throw new ArgumentException("Mass arrays must align with the ground cost matrix dimensions.");
 
             // Stable nonnegativity: shift by minimum and clamp.
             double[] a = (double[])mPred.Clone();
@@ -115,12 +130,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                     row[i].SetCoefficient(plan[i, j], 1.0);
                     col[j].SetCoefficient(plan[i, j], 1.0);
 
-                    double dx = x[i].x - y[j].x;
-                    double dy = x[i].y - y[j].y;
-
-                    double cij = dx * dx + dy * dy;
-
-                    obj.SetCoefficient(plan[i, j], cij);
+                    obj.SetCoefficient(plan[i, j], costMatrix[i, j]);
                 }
             }
 
@@ -204,10 +214,12 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             }
 
             if (usingDifferences)
-                return SolveDifferenceOT2(measured, simulated, all, coord, pattern);
+                return SolveDifferenceOT2(discretization, measured, simulated, all, coord, pattern);
 
             if (all.Count != measured.Length || all.Count != simulated.Length)
                 throw new ArgumentException("Electrode count must match data length when using direct potentials.");
+
+            EnsureArcLengthCost(discretization, all, coord);
 
             // Determine which electrodes carry valid measurements.  Include
             // an electrode if the corresponding measured value is finite,
@@ -219,13 +231,14 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 if (double.IsFinite(measured[i]))
                     include.Add(i);
 
-            var (aRaw, aLoc, aMap) = BuildDistribution(simulated, all, coord, include);
-            var (bRaw, bLoc, _) = BuildDistribution(measured, all, coord, include);
+            var (aRaw, aIdx, aMap) = BuildDistribution(simulated, all, include);
+            var (bRaw, _, _) = BuildDistribution(measured, all, include);
 
             if (aRaw.Length == 0 || bRaw.Length == 0)
                 return new OptimalTransportResult(measured, simulated, 0.0, new double[all.Count]);
 
-            var res = w2_misfit_and_grad(aRaw, bRaw, aLoc, bLoc);
+            var cost = GetSubsetCost(discretization, all, coord, aIdx);
+            var res = w2_misfit_and_grad(aRaw, bRaw, cost);
             var gradFull = new double[all.Count];
             foreach (var (srcIdx, electrodeIdx) in aMap)
                 gradFull[electrodeIdx] = res.Grad[srcIdx];
@@ -233,7 +246,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return new OptimalTransportResult(measured, simulated, res.Cost, gradFull);
         }
 
-        private OptimalTransportResult SolveDifferenceOT(double[] measured, double[] simulated,
+        private OptimalTransportResult SolveDifferenceOT(IDiscretization discretization, double[] measured, double[] simulated,
             IReadOnlyList<Electrode> electrodes,
             Func<Electrode, (double x, double y)> getCoord,
             MeasurementPattern? pattern)
@@ -242,6 +255,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 throw new ArgumentException("Measured and simulated difference arrays must have identical length.");
 
             int differenceCount = measured.Length;
+            EnsureArcLengthCost(discretization, electrodes, getCoord);
             var include = new List<int>();
             for (int i = 0; i < differenceCount; i++)
                 if (double.IsFinite(measured[i]) && double.IsFinite(simulated[i]))
@@ -254,13 +268,14 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 ? pattern
                 : null;
 
-            var (aRaw, aLoc, aMap) = BuildDifferenceDistribution(simulated, electrodes, getCoord, include, activePattern);
-            var (bRaw, bLoc, _) = BuildDifferenceDistribution(measured, electrodes, getCoord, include, activePattern);
+            var (aRaw, aIdx, aMap) = BuildDifferenceDistribution(simulated, electrodes, include, activePattern);
+            var (bRaw, _, _) = BuildDifferenceDistribution(measured, electrodes, include, activePattern);
 
             if (aRaw.Length == 0 || bRaw.Length == 0)
                 return new OptimalTransportResult(measured, simulated, 0.0, new double[differenceCount]);
 
-            var res = w2_misfit_and_grad(aRaw, bRaw, aLoc, bLoc);
+            var cost = GetSubsetCost(discretization, electrodes, getCoord, aIdx);
+            var res = w2_misfit_and_grad(aRaw, bRaw, cost);
 
             var grad = new double[differenceCount];
             foreach (var (srcIdx, diffIdx) in aMap)
@@ -269,7 +284,8 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             return new OptimalTransportResult(measured, simulated, res.Cost, grad);
         }
 
-        private OptimalTransportResult SolveDifferenceOT2(double[] measured, double[] simulated,
+        private OptimalTransportResult SolveDifferenceOT2(IDiscretization discretization,
+                                                        double[] measured, double[] simulated,
                                                         IReadOnlyList<Electrode> electrodes,
                                                         Func<Electrode, (double x, double y)> getCoord,
                                                         MeasurementPattern? pattern)
@@ -278,6 +294,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 throw new ArgumentException("Measured and simulated difference arrays must have identical length.");
 
             int differenceCount = measured.Length;
+            EnsureArcLengthCost(discretization, electrodes, getCoord);
 
             // Use only channels that are finite on both sides (your existing logic).
             var include = new List<int>(differenceCount);
@@ -293,8 +310,8 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             var activePattern = pattern != null && pattern.SanitizedLength == differenceCount ? pattern : null;
 
             // Build raw values and channel coordinates (aligned) + back-map
-            var (aRaw, aLoc, aMap) = BuildDifferenceDistribution(simulated, electrodes, getCoord, include, activePattern);
-            var (bRaw, bLoc, _) = BuildDifferenceDistribution(measured, electrodes, getCoord, include, activePattern);
+            var (aRaw, aIdx, aMap) = BuildDifferenceDistribution(simulated, electrodes, include, activePattern);
+            var (bRaw, _, _) = BuildDifferenceDistribution(measured, electrodes, include, activePattern);
 
             if (aRaw.Length == 0 || bRaw.Length == 0)
                 return new OptimalTransportResult(measured, simulated, 0.0, new double[differenceCount]);
@@ -317,8 +334,9 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             // Run two ordinary W2 solves (your existing routine) on the SAME coords.
             // NOTE: w2_misfit_and_grad internally normalizes to unit mass and returns
             // a gradient in "raw" units (scaled by 1/sum of its input), so we reweight.
-            var resPlus = w2_misfit_and_grad(aPlus, bPlus, aLoc, bLoc);
-            var resMinus = w2_misfit_and_grad(aMinus, bMinus, aLoc, bLoc);
+            var cost = GetSubsetCost(discretization, electrodes, getCoord, aIdx);
+            var resPlus = w2_misfit_and_grad(aPlus, bPlus, cost);
+            var resMinus = w2_misfit_and_grad(aMinus, bMinus, cost);
 
             // Reweight by original masses so the two pieces contribute proportionally.
             double massPlusA = aPlus.Sum();
@@ -350,6 +368,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
         // and optional contrast shaping on magnitudes.
         // Place inside Wasserstein2ErrorMetric (same class as your other Solve* methods).
         private OptimalTransportResult SolveDifferencesOt2WithExtension(
+            IDiscretization discretization,
             double[] measured,
             double[] simulated,
             IReadOnlyList<Electrode> electrodes,
@@ -365,6 +384,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 throw new ArgumentException("Measured and simulated difference arrays must have identical length.");
 
             int differenceCount = measured.Length;
+            EnsureArcLengthCost(discretization, electrodes, getCoord);
 
             // Keep only finite channels on both sides
             var include = new List<int>(differenceCount);
@@ -377,8 +397,8 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
 
             // Build per-channel values and coordinates (uses your existing helper).
             // IMPORTANT: ensure BuildDifferenceDistribution uses LEFT-electrode coordinates (not midpoints).
-            var (aRaw, aLoc, aMap) = BuildDifferenceDistribution(simulated, electrodes, getCoord, include, pattern);
-            var (bRaw, bLoc, _) = BuildDifferenceDistribution(measured, electrodes, getCoord, include, pattern);
+            var (aRaw, aIdx, aMap) = BuildDifferenceDistribution(simulated, electrodes, include, pattern);
+            var (bRaw, _, _) = BuildDifferenceDistribution(measured, electrodes, include, pattern);
 
             int m = aRaw.Length;
             if (m == 0)
@@ -423,11 +443,13 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
             // If one side has ~zero mass on both measured+simulated, skip its call and set grad=0, cost=0.
             (double Cost, double[] Grad) resPlus, resMinus;
 
+            var cost = GetSubsetCost(discretization, electrodes, getCoord, aIdx);
+
             if (massPlusA < eps && massPlusB < eps)
                 resPlus = (0.0, new double[m]);
             else
             {
-                var otRes = w2_misfit_and_grad(aPlus, bPlus, aLoc, bLoc);
+                var otRes = w2_misfit_and_grad(aPlus, bPlus, cost);
                 resPlus = (otRes.Cost, otRes.Grad);
             }
 
@@ -435,7 +457,7 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 resMinus = (0.0, new double[m]);
             else
             {
-                var otRes = w2_misfit_and_grad(aPlus, bPlus, aLoc, bLoc);
+                var otRes = w2_misfit_and_grad(aPlus, bPlus, cost);
                 resMinus = (otRes.Cost, otRes.Grad);
             }
 
@@ -495,13 +517,50 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
 
 
 
-        private static (double[] raw, (double x, double y)[] loc, List<(int srcIdx, int electrodeIdx)> indexMap)
-            BuildDistribution(double[] raw, List<Electrode> electrodes,
-                Func<Electrode, (double x, double y)> getCoord, List<int> include)
+        private void EnsureArcLengthCost(IDiscretization discretization, IReadOnlyList<Electrode> electrodes,
+            Func<Electrode, (double x, double y)> getCoord)
+        {
+            lock (_costCacheLock)
+            {
+                bool reuse = _cachedArcLengthCost != null && _cachedElectrodeIds != null &&
+                             ReferenceEquals(_cachedDiscretization, discretization) &&
+                             _cachedElectrodeIds.Length == electrodes.Count;
+
+                if (reuse)
+                {
+                    for (int i = 0; i < electrodes.Count; i++)
+                    {
+                        if (_cachedElectrodeIds[i] != electrodes[i].Id)
+                        {
+                            reuse = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (reuse)
+                    return;
+
+                var coords = electrodes.Select(getCoord).ToArray();
+                _cachedArcLengthCost = ArcLengthGroundCostHelper.BuildArcLengthCost(coords);
+                _cachedElectrodeIds = electrodes.Select(e => e.Id).ToArray();
+                _cachedDiscretization = discretization;
+            }
+        }
+
+        private double[,] GetSubsetCost(IDiscretization discretization, IReadOnlyList<Electrode> electrodes,
+            Func<Electrode, (double x, double y)> getCoord, IReadOnlyList<int> electrodeIndices)
+        {
+            EnsureArcLengthCost(discretization, electrodes, getCoord);
+            return ArcLengthGroundCostHelper.SliceCostMatrix(_cachedArcLengthCost!, electrodeIndices);
+        }
+
+        private static (double[] raw, int[] electrodeIndices, List<(int srcIdx, int electrodeIdx)> indexMap)
+            BuildDistribution(double[] raw, List<Electrode> electrodes, List<int> include)
         {
             var vals = new List<double>(include.Count);
-            var coords = new List<(double, double)>(include.Count);
             var map = new List<(int, int)>(include.Count);
+            var indices = new List<int>(include.Count);
 
             foreach (int i in include)
             {
@@ -509,24 +568,22 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                 if (!double.IsFinite(v))
                     continue;
 
-                var e = electrodes[i];
                 vals.Add(v);
-                coords.Add(getCoord(e));
+                indices.Add(i);
                 map.Add((vals.Count - 1, i));
             }
-            return (vals.ToArray(), coords.ToArray(), map);
+            return (vals.ToArray(), indices.ToArray(), map);
         }
 
-        private static (double[] raw, (double x, double y)[] loc, List<(int srcIdx, int diffIdx)> indexMap)
+        private static (double[] raw, int[] electrodeIndices, List<(int srcIdx, int diffIdx)> indexMap)
             BuildDifferenceDistribution(double[] raw,
                                         IReadOnlyList<Electrode> electrodes,
-                                        Func<Electrode, (double x, double y)> getCoord,
                                         List<int> include,
                                         MeasurementPattern? pattern)
         {
             var vals = new List<double>(include.Count);
-            var coords = new List<(double, double)>(include.Count);
             var map = new List<(int, int)>(include.Count);
+            var indices = new List<int>(include.Count);
 
             foreach (int diffIdx in include)
             {
@@ -556,11 +613,11 @@ namespace Utility.Classes.Reconstruction.ErrorMetrics
                     continue;
 
                 vals.Add(v);
-                coords.Add(getCoord(electrodes[left]));
+                indices.Add(left);
                 map.Add((vals.Count - 1, diffIdx));
             }
 
-            return (vals.ToArray(), coords.ToArray(), map);
+            return (vals.ToArray(), indices.ToArray(), map);
         }
 
         private static (double x, double y) ToXY(LBMGrid mesh, int gridId) =>


### PR DESCRIPTION
## Summary
- add shared arc-length ground cost helper for electrode perimeter distances
- update Wasserstein-2, unbalanced, and conductivity-aware metrics to cache and reuse arc-length cost matrices aligned to electrode ordering
- route optimal transport solvers to use the cached arc-length ground costs instead of Euclidean distances

## Testing
- dotnet test Utility/Utility.csproj -c Release *(fails: dotnet command not available in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692497f1d2d0833389120d279a479d6c)