### PR TITLE
Centralize reconstruction block configuration

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -5,7 +5,9 @@ using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using Utility.Classes.Application;
 using Utility.Classes.Configurations.ReconstructionConfiguration;
+using Utility.Classes.ReconstructionParameters;
 
 namespace ElectricalImpedanceTomography.ViewModels
 {
@@ -30,11 +32,25 @@ namespace ElectricalImpedanceTomography.ViewModels
         // Connection rules: when empty, any block can connect to any other block.
         private readonly Dictionary<BlockType, HashSet<BlockType>> _connectionRules = new();
 
-        public ObservableCollection<BlockType> BlockTypes { get; } = new(Enum.GetValues<BlockType>());
+        public ObservableCollection<BlockType> BlockTypes { get; } = new(ReconstructionBlockRegistry.BlockTypes);
 
         public ReconstructionConfigurationPageViewModel()
         {
-            AddBlock(BlockType.Initialization, 50, 50);
+            var workspaceBlocks = Workspace.GetReconstructionBlocks();
+            if (workspaceBlocks.Any())
+            {
+                foreach (var block in workspaceBlocks)
+                {
+                    RegisterBlock(block);
+                    Blocks.Add(block);
+                }
+            }
+            else
+            {
+                AddBlock(BlockType.Initialization, 50, 50);
+            }
+
+            ApplyConfigurationToWorkspace();
         }
 
         /// <summary>
@@ -55,11 +71,16 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public void AddBlock(BlockType type, double x, double y)
         {
-            string title = GetBlockTypeName(type);
-            var newBlock = new ReconstructionConfigurationBlock(title, type, x, y);
+            var newBlock = ReconstructionBlockRegistry.CreateBlock(type, x, y);
+            RegisterBlock(newBlock);
             Blocks.Add(newBlock);
-            // Don't auto-select if doing bulk operations, but for single add it's fine.
             SelectBlock(newBlock);
+            ApplyConfigurationToWorkspace();
+        }
+
+        private void RegisterBlock(ReconstructionConfigurationBlock block)
+        {
+            block.ParametersChanged += _ => ApplyConfigurationToWorkspace();
         }
 
         [RelayCommand]
@@ -93,41 +114,21 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public void UpdateSelection(Rect selectionRect)
         {
-            // Iterate blocks
             foreach (var block in Blocks)
             {
-                // Assuming block size approx 200x80 for hit testing
-                // Better if View passes bounds, but estimation works for VM logic if coords match
                 var blockRect = new Rect(block.X, block.Y, 200, 80);
                 block.IsSelected = selectionRect.IntersectsWith(blockRect);
             }
 
-            // Iterate connections (Simplified: check if endpoints are in rect)
             foreach (var conn in Connections)
             {
-                // Logic: If source or target block is selected, or the line is contained?
-                // Let's stick to: If center point is in rect, or if both nodes are selected.
-                // For simplicity in "box select", usually we select nodes. 
-                // If nodes are selected, we might implicitly select connections or just leave them.
-                // Let's strictly select connections if their "midpoint" is in the box.
                 var midX = (conn.Source.X + 214 + conn.Target.X) / 2;
                 var midY = (conn.Source.Y + 30 + conn.Target.Y + 30) / 2;
-                if (selectionRect.Contains(midX, midY))
-                {
-                    conn.IsSelected = true;
-                }
-                else
-                {
-                    // Don't deselect if it was manually selected? 
-                    // For box drag, usually we strictly set state based on box.
-                    conn.IsSelected = false;
-                }
+                conn.IsSelected = selectionRect.Contains(midX, midY);
             }
 
-            // Update 'SelectedBlock' to the first selected one to show properties, or null if multiple
             var selectedBlocks = Blocks.Where(b => b.IsSelected).ToList();
-            if (selectedBlocks.Count == 1) SelectedBlock = selectedBlocks[0];
-            else SelectedBlock = null;
+            SelectedBlock = selectedBlocks.Count == 1 ? selectedBlocks[0] : null;
         }
 
         [RelayCommand]
@@ -136,7 +137,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             var blocksToRemove = Blocks.Where(b => b.IsSelected).ToList();
             var connectionsToRemove = Connections.Where(c => c.IsSelected).ToList();
 
-            // Also remove connections attached to removed blocks
             foreach (var block in blocksToRemove)
             {
                 var attached = Connections.Where(c => c.Source == block || c.Target == block).ToList();
@@ -151,6 +151,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             SelectedBlock = null;
             SelectedConnection = null;
+            ApplyConfigurationToWorkspace();
         }
 
         public void AddConnection(ReconstructionConfigurationBlock source, ReconstructionConfigurationBlock target)
@@ -175,7 +176,6 @@ namespace ElectricalImpedanceTomography.ViewModels
                 return allowedTargets.Count == 0 || allowedTargets.Contains(target);
             }
 
-            // No explicit rule for this source, allow by default.
             return true;
         }
 
@@ -186,9 +186,11 @@ namespace ElectricalImpedanceTomography.ViewModels
             Blocks.Clear();
             SelectedBlock = null;
             SelectedConnection = null;
+            ApplyConfigurationToWorkspace();
         }
 
-        public string GetBlockTypeName(BlockType type) => type.ToString();
+        public string GetBlockTypeName(BlockType type) => ReconstructionBlockRegistry.GetDefinition(type).Title;
+
         [RelayCommand]
         public async Task SaveConfiguration()
         {
@@ -217,21 +219,10 @@ namespace ElectricalImpedanceTomography.ViewModels
 
                 string json = JsonSerializer.Serialize(dto, new JsonSerializerOptions { WriteIndented = true });
 
-                // Save to file
                 string fileName = $"config_{DateTime.Now:yyyyMMdd_HHmm}.json";
-                var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
-
-                // Using FileSaver (CommunityToolkit) or just writing to AppData for simplicity in this demo context?
-                // The user asked for "Save Option", implied File Picker.
-                // Since FileSaver is platform specific setup, I'll use a simpler approach or assume FileSaver is available.
-                // I will output to AppData and show an alert for this implementation to be dependency-light.
-
                 string path = Path.Combine(FileSystem.AppDataDirectory, fileName);
                 await File.WriteAllTextAsync(path, json);
 
-                // Notify (In a real app, use a Service)
-                // Console.WriteLine($"Saved to {path}"); 
-                // We can't easily show alert from VM without service, but the View can subscribe or we use Shell.
                 await Shell.Current.DisplayAlert("Success", $"Configuration saved to: {path}", "OK");
             }
             catch (Exception ex)
@@ -264,56 +255,22 @@ namespace ElectricalImpedanceTomography.ViewModels
 
                 if (dto == null) return;
 
-                ClearAll();
-
-                // Reconstruct Blocks
-                foreach (var bDto in dto.Blocks)
-                {
-                    AddBlock(bDto.Type, bDto.X, bDto.Y);
-                    var newBlock = Blocks.Last();
-                    // Restore parameters
-                    foreach (var pDto in bDto.Parameters)
-                    {
-                        var param = newBlock.Parameters.FirstOrDefault(p => p.Key == pDto.Key);
-                        if (param != null) SetParamValue(param, pDto.Value);
-                    }
-                }
-
-                // Reconstruct Connections
-                foreach (var cDto in dto.Connections)
-                {
-                    var source = Blocks.FirstOrDefault(b => b.Id == cDto.SourceId); // Note: ID generation might mismatch if we don't persist IDs.
-                    // Fix: We need to match by position or order? Or persist IDs.
-                    // The Block constructor generates new GUIDs. 
-                    // Real implementation should allow setting ID or we map by index if order preserved.
-                    // Let's update Block model to allow ID set or map by visual index for this demo?
-                    // Better: Update DTO to use index or matching logic. 
-                    // Actually, since `Blocks` is ordered, let's use ID matching BUT we need to ensure we can find the blocks we just created.
-                    // Issue: `AddBlock` generates new ID.
-                    // Fix: I will rely on the order. Or better, update AddBlock to return the block so I can map old IDs to new Objects.
-                }
-
-                // Refined Load Logic for Connections:
-                // We need a mapping from File-ID to Runtime-Block-Object.
-                var idMap = new Dictionary<string, ReconstructionConfigurationBlock>();
-
-                // Clear again to be safe
                 Blocks.Clear();
                 Connections.Clear();
 
+                var idMap = new Dictionary<string, ReconstructionConfigurationBlock>();
+
                 foreach (var bDto in dto.Blocks)
                 {
-                    // Manually create to capture object
-                    string title = GetBlockTypeName(bDto.Type);
-                    var blk = new ReconstructionConfigurationBlock(title, bDto.Type, bDto.X, bDto.Y);
+                    var blk = ReconstructionBlockRegistry.CreateBlock(bDto.Type, bDto.X, bDto.Y, bDto.Id);
 
-                    // Restore params
                     foreach (var pDto in bDto.Parameters)
                     {
                         var param = blk.Parameters.FirstOrDefault(p => p.Key == pDto.Key);
                         if (param != null) SetParamValue(param, pDto.Value);
                     }
 
+                    RegisterBlock(blk);
                     Blocks.Add(blk);
                     idMap[bDto.Id] = blk;
                 }
@@ -325,6 +282,8 @@ namespace ElectricalImpedanceTomography.ViewModels
                         Connections.Add(new ReconstructionConnection { Source = src, Target = tgt });
                     }
                 }
+
+                ApplyConfigurationToWorkspace();
             }
             catch (Exception ex)
             {
@@ -332,7 +291,11 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
         }
 
-        // Helper to get value as string
+        private void ApplyConfigurationToWorkspace()
+        {
+            ReconstructionBlockRegistry.ApplyBlocksToWorkspace(Blocks);
+        }
+
         private string GetParamValue(ConfigurationParameter p) => p switch
         {
             TextParameter t => t.Value,
@@ -342,7 +305,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             _ => ""
         };
 
-        // Helper to set value from string
         private void SetParamValue(ConfigurationParameter p, string value)
         {
             try
@@ -355,7 +317,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             catch { }
         }
 
-        // DTO Classes
         public class ConfigurationDto
         {
             public List<BlockDto> Blocks { get; set; }

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
@@ -6,6 +7,7 @@ using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Measurement;
 using Utility.Classes.Reconstruction;
 using Utility.Classes.ReconstructionParameters;
+using Utility.Classes.Configurations.ReconstructionConfiguration;
 
 namespace Utility.Classes.Application
 {
@@ -29,6 +31,7 @@ namespace Utility.Classes.Application
 
         private static List<ReconstructionResult> _reconstructionResults = [];
         private static List<ReconstructionFrame> _reconstructionFrames = [];
+        private static List<ReconstructionConfigurationBlock> _reconstructionBlocks = [];
         private static List<WorkspaceMessage> _messages = [];
         private static ConductivityDistribution? _originalConductivityDistribution = null;
         private static ConductivityDistribution? _initialConductivityDistribution = null;
@@ -82,6 +85,7 @@ namespace Utility.Classes.Application
         public static void SetInitialDiscretization(IDiscretization? initialDiscretization) => _initialDiscretization = initialDiscretization;
         public static void SetReconstructionResults(List<ReconstructionResult> results) => _reconstructionResults = results;
         public static void SetReconstructionFrames(List<ReconstructionFrame> frames) => _reconstructionFrames = frames;
+        public static void SetReconstructionBlocks(List<ReconstructionConfigurationBlock> blocks) => _reconstructionBlocks = blocks;
         public static void SetOriginalConductivityDistribution(ConductivityDistribution? sigma) => _originalConductivityDistribution = sigma;
         public static void SetInitialConductivityDistribution(ConductivityDistribution? sigma) => _initialConductivityDistribution = sigma;
 
@@ -92,6 +96,7 @@ namespace Utility.Classes.Application
         public static IDiscretization? GetInitialDiscretization() => _initialDiscretization;
         public static List<ReconstructionResult> GetReconstructionResults() => _reconstructionResults;
         public static List<ReconstructionFrame> GetReconstructionFrames() => _reconstructionFrames;
+        public static IReadOnlyList<ReconstructionConfigurationBlock> GetReconstructionBlocks() => _reconstructionBlocks;
         public static ConductivityDistribution? GetOriginalConductivityDistribution() => _originalConductivityDistribution;
         public static ConductivityDistribution? GetInitialConductivityDistribution() => _initialConductivityDistribution;
 

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockDefinition.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockDefinition.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using Utility.Classes.ReconstructionParameters;
+
+namespace Utility.Classes.Configurations.ReconstructionConfiguration
+{
+    /// <summary>
+    /// Describes a reconstruction block option exposed in the UI and the
+    /// corresponding application logic to apply the selected values.
+    /// </summary>
+    public class ReconstructionBlockDefinition
+    {
+        public ReconstructionBlockDefinition(
+            BlockType type,
+            string title,
+            string iconColor,
+            Func<IEnumerable<ConfigurationParameter>> parameterFactory,
+            Action<ReconstructionConfigurationBlock, EITReconstructionParameters>? applyParameters = null)
+        {
+            Type = type;
+            Title = title;
+            IconColor = iconColor;
+            ParameterFactory = parameterFactory;
+            ApplyParameters = applyParameters ?? ((_, _) => { });
+        }
+
+        public BlockType Type { get; }
+        public string Title { get; }
+        public string IconColor { get; }
+        public Func<IEnumerable<ConfigurationParameter>> ParameterFactory { get; }
+        public Action<ReconstructionConfigurationBlock, EITReconstructionParameters> ApplyParameters { get; }
+    }
+}

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes.Application;
+using Utility.Classes.Discretizer;
+using Utility.Classes.Measurement;
+using Utility.Classes.ReconstructionParameters;
+
+namespace Utility.Classes.Configurations.ReconstructionConfiguration
+{
+    /// <summary>
+    /// Central catalog that defines which reconstruction blocks are available,
+    /// how they are rendered, and how they synchronize with the workspace.
+    /// </summary>
+    public static class ReconstructionBlockRegistry
+    {
+        private static readonly Dictionary<BlockType, ReconstructionBlockDefinition> Definitions =
+            new(CreateDefaultDefinitions().ToDictionary(def => def.Type, def => def));
+
+        public static IReadOnlyCollection<BlockType> BlockTypes => Definitions.Keys;
+
+        public static ReconstructionConfigurationBlock CreateBlock(BlockType type, double x, double y, string? id = null)
+        {
+            if (!Definitions.TryGetValue(type, out var definition))
+                throw new ArgumentException($"No block definition found for type {type}.", nameof(type));
+
+            var parameters = definition.ParameterFactory.Invoke();
+            return new ReconstructionConfigurationBlock(
+                id ?? Guid.NewGuid().ToString(),
+                definition.Title,
+                type,
+                definition.IconColor,
+                x,
+                y,
+                parameters);
+        }
+
+        public static void ApplyBlocksToWorkspace(IEnumerable<ReconstructionConfigurationBlock> blocks)
+        {
+            var parameters = Workspace.GetReconstructionParameters();
+
+            foreach (var block in blocks)
+            {
+                if (Definitions.TryGetValue(block.Type, out var definition))
+                {
+                    definition.ApplyParameters(block, parameters);
+                }
+            }
+
+            Workspace.SetReconstructionParameters(parameters);
+            Workspace.SetReconstructionBlocks(blocks.ToList());
+        }
+
+        public static ReconstructionBlockDefinition GetDefinition(BlockType type) => Definitions[type];
+
+        private static IEnumerable<ReconstructionBlockDefinition> CreateDefaultDefinitions()
+        {
+            yield return new ReconstructionBlockDefinition(
+                BlockType.Initialization,
+                "Initialization",
+                "#FFD166",
+                () =>
+                {
+                    return new List<ConfigurationParameter>
+                    {
+                        new ChoiceParameter
+                        {
+                            Name = "Initial Distribution",
+                            Key = "init_method",
+                            Options = Enum.GetNames(typeof(InitialDistributionTypes)).Select(FriendlyName).ToList(),
+                            SelectedOption = FriendlyName(nameof(InitialDistributionTypes.Homogeneous))
+                        },
+                        new NumberParameter { Name = "Random Max Conductivity", Key = "rand_max", Value = 1.0, Min = 0.0 },
+                        new NumberParameter { Name = "Slight Scaling", Key = "slight_scale", Value = 0.95, Min = 0.0, Max = 1.0, Step = 0.05 },
+                        new NumberParameter { Name = "Random Differing Count", Key = "rand_diff_count", Value = 5, Min = 1, Step = 1 }
+                    };
+                },
+                (block, target) =>
+                {
+                    var selected = block.Parameters.OfType<ChoiceParameter>().FirstOrDefault(p => p.Key == "init_method");
+                    if (selected != null)
+                        target.InitialDistributionType = ParseEnum<InitialDistributionTypes>(selected.SelectedOption);
+                });
+
+            yield return new ReconstructionBlockDefinition(
+                BlockType.Measurement,
+                "Measurement",
+                "#4ECDC4",
+                () => new List<ConfigurationParameter>
+                {
+                    new ChoiceParameter
+                    {
+                        Name = "Measurement Source",
+                        Key = "measurement_source",
+                        Options = Enum.GetNames(typeof(MeasurementSourceOption)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(MeasurementSourceOption.Simulated))
+                    },
+                    new ChoiceParameter
+                    {
+                        Name = "Electrode Setup",
+                        Key = "electrode_setup",
+                        Options = Enum.GetNames(typeof(ElectrodeMeasurementSetup)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(ElectrodeMeasurementSetup.Active))
+                    },
+                    new BoolParameter { Name = "Use Potential Differences", Key = "use_potential_differences", Value = false },
+                    new BoolParameter { Name = "Apply Measurement Noise", Key = "apply_noise", Value = false },
+                    new ChoiceParameter
+                    {
+                        Name = "Noise Type",
+                        Key = "noise_type",
+                        Options = Enum.GetNames(typeof(MeasurementNoiseType)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(MeasurementNoiseType.None))
+                    },
+                    new NumberParameter { Name = "Noise Amplitude / dB", Key = "noise_amplitude", Value = 0.0, Min = 0.0, Step = 0.1 }
+                },
+                (block, target) =>
+                {
+                    Workspace.SetMeasurementSource(ParseEnumFromChoice<MeasurementSourceOption>(block, "measurement_source"));
+                    Workspace.SetElectrodeMeasurementSetup(ParseEnumFromChoice<ElectrodeMeasurementSetup>(block, "electrode_setup"));
+
+                    var usePotential = block.Parameters.OfType<BoolParameter>().FirstOrDefault(p => p.Key == "use_potential_differences")?.Value ?? false;
+                    target.UsePotentialDifferences = usePotential;
+
+                    var noiseTypeChoice = block.Parameters.OfType<ChoiceParameter>().FirstOrDefault(p => p.Key == "noise_type");
+                    var noiseType = noiseTypeChoice != null ? ParseEnum<MeasurementNoiseType>(noiseTypeChoice.SelectedOption) : MeasurementNoiseType.None;
+                    target.MeasurementNoiseType = noiseType;
+
+                    var noiseAmplitude = block.Parameters.OfType<NumberParameter>().FirstOrDefault(p => p.Key == "noise_amplitude")?.Value ?? 0.0;
+                    var applyNoise = block.Parameters.OfType<BoolParameter>().FirstOrDefault(p => p.Key == "apply_noise")?.Value ?? false;
+                    target.MeasurementNoiseAmplitude = applyNoise ? noiseAmplitude : 0.0;
+                });
+
+            yield return new ReconstructionBlockDefinition(
+                BlockType.Solver,
+                "Solver",
+                "#06D6A0",
+                () => new List<ConfigurationParameter>
+                {
+                    new ChoiceParameter
+                    {
+                        Name = "Differential Equation Solver",
+                        Key = "solver_type",
+                        Options = Enum.GetNames(typeof(DifferentialEquationSolver)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(DifferentialEquationSolver.FEM))
+                    },
+                    new ChoiceParameter
+                    {
+                        Name = "Numeric Solver",
+                        Key = "numeric_solver",
+                        Options = Enum.GetNames(typeof(NumericSolver)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(NumericSolver.GMRES))
+                    },
+                    new NumberParameter { Name = "FEM Order", Key = "fem_order", Value = 1, Min = 1, Max = 2, Step = 1 },
+                    new NumberParameter { Name = "LBM Relaxation Time (tau)", Key = "lbm_tau", Value = 0.51, Min = 0.50001, Step = 0.01 }
+                },
+                (block, target) =>
+                {
+                    target.DifferentialEquationSolver = ParseEnumFromChoice<DifferentialEquationSolver>(block, "solver_type");
+                    target.NumericSolver = ParseEnumFromChoice<NumericSolver>(block, "numeric_solver");
+                    target.Mesh = target.DifferentialEquationSolver == DifferentialEquationSolver.FEM
+                        ? DiscretizationType.FEM
+                        : DiscretizationType.LBM;
+                });
+
+            yield return new ReconstructionBlockDefinition(
+                BlockType.Regularizer,
+                "Regularizer",
+                "#118AB2",
+                () => new List<ConfigurationParameter>
+                {
+                    new ChoiceParameter
+                    {
+                        Name = "Regularization Technique",
+                        Key = "reg_tech",
+                        Options = Enum.GetNames(typeof(RegularizationTechnique)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(RegularizationTechnique.FirstOrderTikhonov))
+                    },
+                    new ChoiceParameter
+                    {
+                        Name = "Weight Mode",
+                        Key = "reg_weight_mode",
+                        Options = new List<string> { "Static", "D-Bar" },
+                        SelectedOption = "Static"
+                    },
+                    new NumberParameter { Name = "Lambda (Regularization Weight)", Key = "lambda", Value = 0.01, Min = 0, Step = 0.001 },
+                    new BoolParameter { Name = "Spatial Weighting", Key = "spatial_weighting", Value = false }
+                },
+                (block, target) =>
+                {
+                    target.RegularizationTechnique = ParseEnumFromChoice<RegularizationTechnique>(block, "reg_tech");
+                    var lambdaParam = block.Parameters.OfType<NumberParameter>().FirstOrDefault(p => p.Key == "lambda");
+                    var mode = block.Parameters.OfType<ChoiceParameter>().FirstOrDefault(p => p.Key == "reg_weight_mode")?.SelectedOption ?? "Static";
+
+                    // Map weight selection back to the workspace. "D-Bar" can be used to signal
+                    // a dynamic strategy; here we default to the provided lambda for static mode
+                    // and fall back to a small stabilizer otherwise.
+                    Workspace.RegularizationWeight = mode == "Static" ? lambdaParam?.Value ?? Workspace.RegularizationWeight : Math.Max(lambdaParam?.Value ?? 1e-3, 1e-4);
+                });
+
+            yield return new ReconstructionBlockDefinition(
+                BlockType.ErrorMetric,
+                "Error Metric",
+                "#EF476F",
+                () => new List<ConfigurationParameter>
+                {
+                    new ChoiceParameter
+                    {
+                        Name = "Error Metric",
+                        Key = "metric_type",
+                        Options = Enum.GetNames(typeof(ErrorMetric)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(ErrorMetric.Wasserstein2))
+                    },
+                    new BoolParameter { Name = "Use ROI Focusing", Key = "use_roi", Value = false }
+                },
+                (block, target) =>
+                {
+                    target.ErrorMetric = ParseEnumFromChoice<ErrorMetric>(block, "metric_type");
+                });
+
+            yield return new ReconstructionBlockDefinition(
+                BlockType.Optimizer,
+                "Optimizer",
+                "#9D4EDD",
+                () => new List<ConfigurationParameter>
+                {
+                    new ChoiceParameter
+                    {
+                        Name = "Optimization Algorithm",
+                        Key = "opt_algo",
+                        Options = Enum.GetNames(typeof(NumericOptimizer)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(NumericOptimizer.ADAM))
+                    },
+                    new NumberParameter { Name = "Max Iterations", Key = "max_iter", Value = 50, Min = 1, Step = 10 },
+                    new NumberParameter { Name = "Convergence Tolerance", Key = "conv_tol", Value = 1e-4, Min = 1e-9 },
+                    new NumberParameter { Name = "Step Size (Learning Rate)", Key = "step_size", Value = 0.01, Step = 0.001 }
+                },
+                (block, target) =>
+                {
+                    target.NumericOptimizer = ParseEnumFromChoice<NumericOptimizer>(block, "opt_algo");
+                    Workspace.MaxIterationCount = (int)(block.Parameters.OfType<NumberParameter>().FirstOrDefault(p => p.Key == "max_iter")?.Value ?? Workspace.MaxIterationCount);
+                    Workspace.StepSize = block.Parameters.OfType<NumberParameter>().FirstOrDefault(p => p.Key == "step_size")?.Value ?? Workspace.StepSize;
+                });
+
+            yield return new ReconstructionBlockDefinition(
+                BlockType.PostProcessing,
+                "Post-Processing",
+                "#073B4C",
+                () => new List<ConfigurationParameter>
+                {
+                    new ChoiceParameter { Name = "Filter Type", Key = "post_filter", Options = new List<string> { "None", "Median", "Gaussian", "Anisotropic Diffusion" }, SelectedOption = "Median" },
+                    new ChoiceParameter { Name = "Morphological Operation", Key = "morph", Options = new List<string> { "None", "Erosion", "Dilatation", "Opening", "Closing" }, SelectedOption = "None" },
+                    new NumberParameter { Name = "Kernel Size", Key = "kernel_size", Value = 3, Min = 1, Step = 2 }
+                },
+                (_, _) => { });
+        }
+
+        private static T ParseEnumFromChoice<T>(ReconstructionConfigurationBlock block, string key)
+            where T : struct, Enum
+        {
+            var choice = block.Parameters.OfType<ChoiceParameter>().FirstOrDefault(p => p.Key == key);
+            return choice == null ? default : ParseEnum<T>(choice.SelectedOption);
+        }
+
+        private static T ParseEnum<T>(string friendly) where T : struct, Enum
+        {
+            var raw = friendly.Replace(" ", string.Empty);
+            if (Enum.TryParse<T>(raw, out var parsed))
+                return parsed;
+
+            return default;
+        }
+
+        private static string FriendlyName(string raw)
+            => string.Concat(raw.Select((c, i) => i > 0 && char.IsUpper(c) && !char.IsUpper(raw[i - 1]) ? $" {c}" : c.ToString()));
+    }
+}

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
@@ -1,4 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Utility.Classes.Factories;
@@ -13,10 +15,30 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
     /// </summary>
     public class ReconstructionConfigurationBlock : ObservableObject
     {
+        public ReconstructionConfigurationBlock(
+            string id,
+            string title,
+            BlockType type,
+            string iconColor,
+            double x,
+            double y,
+            IEnumerable<ConfigurationParameter> parameters)
+        {
+            Id = id;
+            Title = title;
+            Type = type;
+            IconColor = iconColor;
+            X = x;
+            Y = y;
+            Parameters = new ObservableCollection<ConfigurationParameter>(parameters);
+            HookParameterChanges();
+            UpdateHighlightedOption();
+        }
+
         /// <summary>
         /// Unique identifier for the block instance.
         /// </summary>
-        public string Id { get; } = Guid.NewGuid().ToString();
+        public string Id { get; }
 
         /// <summary>
         /// The display title of the block.
@@ -62,156 +84,7 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
         /// </summary>
         public ObservableCollection<ConfigurationParameter> Parameters { get; set; } = new();
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ReconstructionConfigurationBlock"/> class.
-        /// </summary>
-        /// <param name="title">The display title.</param>
-        /// <param name="type">The block type.</param>
-        /// <param name="x">Initial X position.</param>
-        /// <param name="y">Initial Y position.</param>
-        public ReconstructionConfigurationBlock(string title, BlockType type, double x, double y)
-        {
-            Title = title;
-            Type = type;
-            X = x;
-            Y = y;
-            SetColor();
-            InitializeDefaultParameters();
-            HookParameterChanges();
-            UpdateHighlightedOption();
-        }
-
-        /// <summary>
-        /// Sets the icon color based on the block type for visual distinction.
-        /// </summary>
-        private void SetColor()
-        {
-            IconColor = Type switch
-            {
-                BlockType.Initialization => "#FFD166", // Yellow
-                BlockType.Measurement => "#4ECDC4",    // Teal
-                BlockType.Solver => "#06D6A0",         // Green
-                BlockType.Regularizer => "#118AB2",    // Blue
-                BlockType.ErrorMetric => "#EF476F",    // Red
-                BlockType.Optimizer => "#9D4EDD",      // Purple
-                BlockType.PostProcessing => "#073B4C", // Dark Blue
-                _ => "#CCCCCC"
-            };
-        }
-
-        /// <summary>
-        /// Populates the <see cref="Parameters"/> collection with default values based on the <see cref="BlockType"/>.
-        /// The parameters are derived from the advanced methods described in the thesis.
-        /// </summary>
-        private void InitializeDefaultParameters()
-        {
-            switch (Type)
-            {
-                case BlockType.Initialization:
-                    Parameters.Add(new ChoiceParameter
-                    {
-                        Name = "Initial Distribution",
-                        Key = "init_method",
-                        Options = Enum.GetNames(typeof(InitialDistributionTypes)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(InitialDistributionTypes.Homogeneous))
-                    });
-                    Parameters.Add(new NumberParameter { Name = "Random Max Conductivity", Key = "rand_max", Value = 1.0, Min = 0.0 });
-                    Parameters.Add(new NumberParameter { Name = "Slight Scaling", Key = "slight_scale", Value = 0.95, Min = 0.0, Max = 1.0, Step = 0.05 });
-                    Parameters.Add(new NumberParameter { Name = "Random Differing Count", Key = "rand_diff_count", Value = 5, Min = 0, Step = 1 });
-                    break;
-
-                case BlockType.Solver:
-                    Parameters.Add(new ChoiceParameter
-                    {
-                        Name = "Differential Equation Solver",
-                        Key = "solver_type",
-                        Options = Enum.GetNames(typeof(DifferentialEquationSolver)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(DifferentialEquationSolver.FEM))
-                    });
-                    Parameters.Add(new ChoiceParameter
-                    {
-                        Name = "Numeric Solver",
-                        Key = "numeric_solver",
-                        Options = Enum.GetNames(typeof(NumericSolver)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(NumericSolver.GMRES))
-                    });
-                    Parameters.Add(new NumberParameter { Name = "FEM Order", Key = "fem_order", Value = 1, Min = 1, Max = 2, Step = 1 });
-                    Parameters.Add(new NumberParameter { Name = "LBM Relaxation Time (tau)", Key = "lbm_tau", Value = 0.51, Min = 0.50001, Step = 0.01 });
-                    break;
-
-                case BlockType.Measurement:
-                    Parameters.Add(new ChoiceParameter
-                    {
-                        Name = "Measurement Source",
-                        Key = "measurement_source",
-                        Options = Enum.GetNames(typeof(MeasurementSourceOption)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(MeasurementSourceOption.Simulated))
-                    });
-                    Parameters.Add(new ChoiceParameter
-                    {
-                        Name = "Electrode Setup",
-                        Key = "electrode_setup",
-                        Options = Enum.GetNames(typeof(ElectrodeMeasurementSetup)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(ElectrodeMeasurementSetup.Active))
-                    });
-                    Parameters.Add(new BoolParameter { Name = "Use Potential Differences", Key = "use_potential_differences", Value = false });
-                    Parameters.Add(new BoolParameter { Name = "Apply Measurement Noise", Key = "apply_noise", Value = false });
-                    Parameters.Add(new ChoiceParameter
-                    {
-                        Name = "Noise Type",
-                        Key = "noise_type",
-                        Options = Enum.GetNames(typeof(MeasurementNoiseType)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(MeasurementNoiseType.None))
-                    });
-                    Parameters.Add(new NumberParameter { Name = "Noise Amplitude / dB", Key = "noise_amplitude", Value = 0.0, Min = 0.0, Step = 0.1 });
-                    break;
-
-                case BlockType.Regularizer:
-                    Parameters.Add(new ChoiceParameter
-                    {
-                        Name = "Regularization Technique",
-                        Key = "reg_tech",
-                        Options = Enum.GetNames(typeof(RegularizationTechnique)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(RegularizationTechnique.FirstOrderTikhonov))
-                    });
-                    Parameters.Add(new NumberParameter { Name = "Lambda (Regularization Weight)", Key = "lambda", Value = 0.01, Min = 0, Step = 0.001 });
-                    Parameters.Add(new BoolParameter { Name = "Spatial Weighting", Key = "spatial_weighting", Value = false });
-                    break;
-
-                case BlockType.ErrorMetric:
-                    Parameters.Add(new ChoiceParameter
-                    {
-                        Name = "Error Metric",
-                        Key = "metric_type",
-                        Options = Enum.GetNames(typeof(ErrorMetric)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(ErrorMetric.Wasserstein2))
-                    });
-                    Parameters.Add(new BoolParameter { Name = "Use ROI Focusing", Key = "use_roi", Value = false });
-                    break;
-
-                case BlockType.Optimizer:
-                    Parameters.Add(new ChoiceParameter
-                    {
-                        Name = "Optimization Algorithm",
-                        Key = "opt_algo",
-                        Options = Enum.GetNames(typeof(NumericOptimizer)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(NumericOptimizer.ADAM))
-                    });
-                    Parameters.Add(new NumberParameter { Name = "Max Iterations", Key = "max_iter", Value = 50, Min = 1, Step = 10 });
-                    Parameters.Add(new NumberParameter { Name = "Convergence Tolerance", Key = "conv_tol", Value = 1e-4, Min = 1e-9 });
-                    Parameters.Add(new NumberParameter { Name = "Step Size (Learning Rate)", Key = "step_size", Value = 0.01, Step = 0.001 });
-                    break;
-
-                case BlockType.PostProcessing:
-                    Parameters.Add(new ChoiceParameter { Name = "Filter Type", Key = "post_filter", Options = new List<string> { "None", "Median", "Gaussian", "Anisotropic Diffusion" }, SelectedOption = "Median" });
-                    Parameters.Add(new ChoiceParameter { Name = "Morphological Operation", Key = "morph", Options = new List<string> { "None", "Erosion", "Dilatation", "Opening", "Closing" }, SelectedOption = "None" });
-                    Parameters.Add(new NumberParameter { Name = "Kernel Size", Key = "kernel_size", Value = 3, Min = 1, Step = 2 });
-                    break;
-            }
-        }
-
-        private static string FriendlyName(string raw)
-            => string.Concat(raw.Select((c, i) => i > 0 && char.IsUpper(c) && !char.IsUpper(raw[i - 1]) ? $" {c}" : c.ToString()));
+        public event Action<ReconstructionConfigurationBlock>? ParametersChanged;
 
         private void HookParameterChanges()
         {
@@ -221,7 +94,19 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                 {
                     if (args.PropertyName == nameof(ChoiceParameter.SelectedOption))
                         UpdateHighlightedOption();
+
+                    ParametersChanged?.Invoke(this);
                 };
+            }
+
+            foreach (var number in Parameters.OfType<NumberParameter>())
+            {
+                number.PropertyChanged += (_, __) => ParametersChanged?.Invoke(this);
+            }
+
+            foreach (var toggle in Parameters.OfType<BoolParameter>())
+            {
+                toggle.PropertyChanged += (_, __) => ParametersChanged?.Invoke(this);
             }
         }
 


### PR DESCRIPTION
## Summary
- add a registry of reconstruction block definitions with parameter metadata and workspace mapping
- refactor configuration blocks and view model to source options from the registry and sync changes into the workspace
- persist reconstruction block layouts in the workspace for reuse across pages

## Testing
- dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj *(fails: dotnet CLI not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924c2dd6bd48333afb9a73467d8b728)