### PR TITLE
Improve enum parsing for reconstruction blocks

### DIFF
--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
@@ -263,8 +263,22 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
 
         private static T ParseEnum<T>(string friendly) where T : struct, Enum
         {
-            var raw = friendly.Replace(" ", string.Empty);
-            if (Enum.TryParse<T>(raw, out var parsed))
+            if (string.IsNullOrWhiteSpace(friendly))
+                return default;
+
+            static string Normalize(string value) =>
+                new string(value.Where(char.IsLetterOrDigit).ToArray()).ToUpperInvariant();
+
+            var normalizedInput = Normalize(friendly);
+
+            foreach (var name in Enum.GetNames(typeof(T)))
+            {
+                // Match either the raw enum name or its friendly-formatted variant.
+                if (Normalize(name) == normalizedInput || Normalize(FriendlyName(name)) == normalizedInput)
+                    return Enum.Parse<T>(name, true);
+            }
+
+            if (Enum.TryParse<T>(friendly, true, out var parsed))
                 return parsed;
 
             return default;


### PR DESCRIPTION
## Summary
- make reconstruction enum parsing tolerant to punctuation and friendly names

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d3d0f0d883338e48f5d07b6adb46)