### PR TITLE
Enhance reconstruction configuration editor interactions

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text.Json;
 using Utility.Classes.Application;
 using Utility.Classes.Configurations.ReconstructionConfiguration;
+using Utility.Classes.Configurations.ReconstructionConfiguration.Rules;
 using Utility.Classes.ReconstructionParameters;
 
 namespace ElectricalImpedanceTomography.ViewModels
@@ -28,6 +29,10 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         [ObservableProperty]
         private ReconstructionConnection? selectedConnection;
+
+        public ObservableCollection<string> DebugLines { get; } = new();
+
+        public ObservableCollection<string> ValidationIssues { get; } = new();
 
         // Connection rules: when empty, any block can connect to any other block.
         private readonly Dictionary<BlockType, HashSet<BlockType>> _connectionRules = new();
@@ -51,6 +56,8 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
 
             ApplyConfigurationToWorkspace();
+            Blocks.CollectionChanged += (_, __) => UpdateDiagnostics();
+            Connections.CollectionChanged += (_, __) => UpdateDiagnostics();
         }
 
         /// <summary>
@@ -81,6 +88,14 @@ namespace ElectricalImpedanceTomography.ViewModels
         private void RegisterBlock(ReconstructionConfigurationBlock block)
         {
             block.ParametersChanged += _ => ApplyConfigurationToWorkspace();
+            block.PropertyChanged += (_, args) =>
+            {
+                if (args.PropertyName == nameof(ReconstructionConfigurationBlock.X) ||
+                    args.PropertyName == nameof(ReconstructionConfigurationBlock.Y))
+                {
+                    ApplyConfigurationToWorkspace();
+                }
+            };
         }
 
         [RelayCommand]
@@ -158,9 +173,22 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             if (source == null || target == null || source == target) return;
             if (!CanConnect(source.Type, target.Type)) return;
+            if (!ReconstructionConfigurationRules.HasAvailableOutput(source, Connections))
+            {
+                TrackIssue($"{source.Title} has no remaining output connectors.");
+                return;
+            }
+
+            if (!ReconstructionConfigurationRules.HasAvailableInput(target, Connections))
+            {
+                TrackIssue($"{target.Title} cannot accept more inputs.");
+                return;
+            }
+
             if (!Connections.Any(c => c.Source == source && c.Target == target))
             {
                 Connections.Add(new ReconstructionConnection { Source = source, Target = target });
+                ApplyConfigurationToWorkspace();
             }
         }
 
@@ -196,6 +224,19 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             try
             {
+                var issues = ReconstructionConfigurationRules.Validate(Blocks, Connections);
+                ValidationIssues.Clear();
+                foreach (var issue in issues)
+                {
+                    ValidationIssues.Add(issue);
+                }
+
+                if (issues.Any())
+                {
+                    await Shell.Current.DisplayAlert("Cannot Save", string.Join("\n", issues), "OK");
+                    return;
+                }
+
                 var dto = new ConfigurationDto
                 {
                     Blocks = Blocks.Select(b => new BlockDto
@@ -294,7 +335,14 @@ namespace ElectricalImpedanceTomography.ViewModels
         private void ApplyConfigurationToWorkspace()
         {
             ReconstructionBlockRegistry.ApplyBlocksToWorkspace(Blocks);
+            UpdateDiagnostics();
         }
+
+        public bool HasOutputCapacity(ReconstructionConfigurationBlock block) =>
+            ReconstructionConfigurationRules.HasAvailableOutput(block, Connections);
+
+        public bool HasInputCapacity(ReconstructionConfigurationBlock block) =>
+            ReconstructionConfigurationRules.HasAvailableInput(block, Connections);
 
         private string GetParamValue(ConfigurationParameter p) => p switch
         {
@@ -315,6 +363,49 @@ namespace ElectricalImpedanceTomography.ViewModels
                 else if (p is ChoiceParameter c) c.SelectedOption = value;
             }
             catch { }
+        }
+
+        public void NotifyLayoutChanged() => ApplyConfigurationToWorkspace();
+
+        private void UpdateDiagnostics()
+        {
+            DebugLines.Clear();
+            var blockSummary = string.Join(", ", Blocks
+                .GroupBy(b => b.Type)
+                .Select(g => $"{g.Key}({g.Count()})"));
+            DebugLines.Add(string.IsNullOrWhiteSpace(blockSummary)
+                ? "Blocks: none"
+                : $"Blocks: {blockSummary}");
+
+            if (Connections.Any())
+            {
+                foreach (var conn in Connections.Take(6))
+                {
+                    DebugLines.Add($"Connection: {conn.Source.Title} -> {conn.Target.Title}");
+                }
+                if (Connections.Count > 6)
+                {
+                    DebugLines.Add($"(+{Connections.Count - 6} more)");
+                }
+            }
+            else
+            {
+                DebugLines.Add("Connections: none");
+            }
+
+            ValidationIssues.Clear();
+            foreach (var issue in ReconstructionConfigurationRules.Validate(Blocks, Connections))
+            {
+                ValidationIssues.Add(issue);
+            }
+        }
+
+        private void TrackIssue(string message)
+        {
+            if (!ValidationIssues.Contains(message))
+            {
+                ValidationIssues.Add(message);
+            }
         }
 
         public class ConfigurationDto

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
@@ -90,6 +90,12 @@
         <Grid Grid.Column="1" BackgroundColor="#1E1E2E">
             <BoxView Color="#232330" Opacity="0.5"/>
 
+            <!-- Dotted background grid -->
+            <skia:SKCanvasView x:Name="GridCanvas"
+                               PaintSurface="OnGridPaintSurface"
+                               InputTransparent="True"
+                               IgnorePixelScaling="True" />
+
             <!-- SkiaSharp Layer: Touch Enabled -->
             <skia:SKCanvasView x:Name="ConnectionsCanvas"
                                PaintSurface="OnCanvasPaintSurface"
@@ -111,6 +117,29 @@
                      IsVisible="False"
                      HorizontalOptions="Start"
                      VerticalOptions="Start"/>
+
+            <!-- Debug window -->
+            <Border BackgroundColor="#111827" StrokeThickness="1" Stroke="#2C2C3A" CornerRadius="10"
+                    HorizontalOptions="Center" VerticalOptions="End" Margin="0,0,0,20" Padding="12"
+                    WidthRequest="420">
+                <VerticalStackLayout Spacing="4">
+                    <Label Text="DEBUG" FontSize="12" FontAttributes="Bold" TextColor="#9CA3AF" HorizontalOptions="Center"/>
+                    <StackLayout BindableLayout.ItemsSource="{Binding DebugLines}" Spacing="2">
+                        <BindableLayout.ItemTemplate>
+                            <DataTemplate>
+                                <Label Text="{Binding .}" FontSize="11" TextColor="#E5E7EB"/> 
+                            </DataTemplate>
+                        </BindableLayout.ItemTemplate>
+                    </StackLayout>
+                    <StackLayout BindableLayout.ItemsSource="{Binding ValidationIssues}" Spacing="2" Margin="0,6,0,0">
+                        <BindableLayout.ItemTemplate>
+                            <DataTemplate>
+                                <Label Text="{Binding .}" FontSize="11" TextColor="#FCA5A5"/> 
+                            </DataTemplate>
+                        </BindableLayout.ItemTemplate>
+                    </StackLayout>
+                </VerticalStackLayout>
+            </Border>
         </Grid>
 
         <!-- RIGHT SIDE: PROPERTIES -->

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
@@ -8,6 +8,7 @@ using Utility.Classes.Application;
 using Utility.Classes.Configurations.ReconstructionConfiguration;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Classes.Configurations.ReconstructionConfiguration.Rules;
 
 namespace ElectricalImpedanceTomography.Views
 {
@@ -18,7 +19,7 @@ namespace ElectricalImpedanceTomography.Views
     public partial class ReconstructionConfigurationPage : ContentPage
     {
         private readonly ReconstructionConfigurationPageViewModel _viewModel;
-        private readonly Dictionary<string, Point> _dragStartPositions = new();
+        private readonly Dictionary<ReconstructionConfigurationBlock, Point> _dragStartPositions = new();
 
         private Point? _tempConnectionStart;
         private Point? _tempConnectionEnd;
@@ -31,7 +32,6 @@ namespace ElectricalImpedanceTomography.Views
         // Dragging state
         private ReconstructionConfigurationBlock? _draggedBlock;
         private Point _dragStartPoint;
-        private Point _dragStartBlockPosition;
 
         private const double PortCenterY = 30;
         private const double OutputPortXOffset = 214;
@@ -136,7 +136,8 @@ namespace ElectricalImpedanceTomography.Views
                 StrokeThickness = 1,
                 HorizontalOptions = LayoutOptions.Start,
                 VerticalOptions = LayoutOptions.Start,
-                Margin = new Thickness(-7, 23, 0, 0)
+                Margin = new Thickness(-7, 23, 0, 0),
+                IsVisible = ReconstructionConfigurationRules.GetConnectionConstraint(block.Type).MaxInputs > 0
             };
 
             var outPort = new Border
@@ -192,23 +193,51 @@ namespace ElectricalImpedanceTomography.Views
             switch (e.StatusType)
             {
                 case GestureStatus.Started:
-                    _dragStartPositions[block.Id] = new Point(block.X, block.Y);
+                    PrepareDragPositions(block);
                     break;
                 case GestureStatus.Running:
-                    if (_dragStartPositions.TryGetValue(block.Id, out Point start))
+                    foreach (var kvp in _dragStartPositions)
                     {
-                        double newX = start.X + e.TotalX;
-                        double newY = start.Y + e.TotalY;
-                        block.X = newX;
-                        block.Y = newY;
-                        AbsoluteLayout.SetLayoutBounds(view, new Rect(newX, newY, AbsoluteLayout.AutoSize, AbsoluteLayout.AutoSize));
-                        ConnectionsCanvas.InvalidateSurface();
+                        var start = kvp.Value;
+                        var newX = start.X + e.TotalX;
+                        var newY = start.Y + e.TotalY;
+                        UpdateBlockPosition(kvp.Key, newX, newY);
                     }
+                    ConnectionsCanvas.InvalidateSurface();
                     break;
                 case GestureStatus.Completed:
                 case GestureStatus.Canceled:
-                    _dragStartPositions.Remove(block.Id);
+                    _dragStartPositions.Clear();
+                    _viewModel.NotifyLayoutChanged();
                     break;
+            }
+        }
+
+        private void PrepareDragPositions(ReconstructionConfigurationBlock block)
+        {
+            _dragStartPositions.Clear();
+            var selected = _viewModel.Blocks.Where(b => b.IsSelected).ToList();
+            if (!selected.Any())
+            {
+                selected.Add(block);
+            }
+
+            foreach (var b in selected.Distinct())
+            {
+                _dragStartPositions[b] = new Point(b.X, b.Y);
+            }
+        }
+
+        private void UpdateBlockPosition(ReconstructionConfigurationBlock block, double newX, double newY)
+        {
+            block.X = newX;
+            block.Y = newY;
+            var view = NodeContainer.Children
+                .OfType<View>()
+                .FirstOrDefault(c => ReferenceEquals(c.BindingContext, block));
+            if (view != null)
+            {
+                AbsoluteLayout.SetLayoutBounds(view, new Rect(newX, newY, AbsoluteLayout.AutoSize, AbsoluteLayout.AutoSize));
             }
         }
 
@@ -217,6 +246,10 @@ namespace ElectricalImpedanceTomography.Views
             switch (e.StatusType)
             {
                 case GestureStatus.Started:
+                    if (!_viewModel.HasOutputCapacity(sourceBlock))
+                    {
+                        return;
+                    }
                     double startX = sourceBlock.X + OutputPortXOffset;
                     double startY = sourceBlock.Y + PortCenterY;
                     _tempConnectionSource = sourceBlock;
@@ -253,6 +286,11 @@ namespace ElectricalImpedanceTomography.Views
         {
             foreach (var block in _viewModel.Blocks)
             {
+                if (!_viewModel.HasInputCapacity(block))
+                {
+                    continue;
+                }
+
                 double targetX = block.X + InputPortXOffset;
                 double targetY = block.Y + PortCenterY;
                 if (Math.Abs(location.X - targetX) < 40 && Math.Abs(location.Y - targetY) < 40)
@@ -315,6 +353,11 @@ namespace ElectricalImpedanceTomography.Views
                 return false;
             }
 
+            if (!_viewModel.HasOutputCapacity(block))
+            {
+                return false;
+            }
+
             var portCenter = new Point(block.X + OutputPortXOffset, block.Y + PortCenterY);
             if (Distance(viewPoint, portCenter) <= 16)
             {
@@ -338,8 +381,20 @@ namespace ElectricalImpedanceTomography.Views
 
             _draggedBlock = block;
             _dragStartPoint = viewPoint;
-            _dragStartBlockPosition = new Point(block.X, block.Y);
-            _viewModel.SelectBlock(block);
+
+            _dragStartPositions.Clear();
+            var blocksToMove = _viewModel.Blocks.Where(b => b.IsSelected).ToList();
+            if (!blocksToMove.Any())
+            {
+                _viewModel.SelectBlock(block);
+                blocksToMove.Add(block);
+            }
+
+            foreach (var b in blocksToMove.Distinct())
+            {
+                _dragStartPositions[b] = new Point(b.X, b.Y);
+            }
+
             return true;
         }
 
@@ -367,17 +422,14 @@ namespace ElectricalImpedanceTomography.Views
             if (_draggedBlock != null)
             {
                 var delta = new Point(viewPoint.X - _dragStartPoint.X, viewPoint.Y - _dragStartPoint.Y);
-                var newX = _dragStartBlockPosition.X + delta.X;
-                var newY = _dragStartBlockPosition.Y + delta.Y;
-                _draggedBlock.X = newX;
-                _draggedBlock.Y = newY;
-                var view = NodeContainer.Children
-                    .OfType<View>()
-                    .FirstOrDefault(c => ReferenceEquals(c.BindingContext, _draggedBlock));
-                if (view != null)
+
+                foreach (var kvp in _dragStartPositions)
                 {
-                    AbsoluteLayout.SetLayoutBounds(view, new Rect(newX, newY, AbsoluteLayout.AutoSize, AbsoluteLayout.AutoSize));
+                    var newX = kvp.Value.X + delta.X;
+                    var newY = kvp.Value.Y + delta.Y;
+                    UpdateBlockPosition(kvp.Key, newX, newY);
                 }
+
                 ConnectionsCanvas.InvalidateSurface();
                 return;
             }
@@ -413,6 +465,8 @@ namespace ElectricalImpedanceTomography.Views
             if (_draggedBlock != null)
             {
                 _draggedBlock = null;
+                _dragStartPositions.Clear();
+                _viewModel.NotifyLayoutChanged();
                 return;
             }
 
@@ -481,6 +535,28 @@ namespace ElectricalImpedanceTomography.Views
                 return true;
             }
             return false;
+        }
+
+        private void OnGridPaintSurface(object sender, SKPaintSurfaceEventArgs e)
+        {
+            var canvas = e.Surface.Canvas;
+            canvas.Clear();
+
+            const int spacing = 32;
+            using var dotPaint = new SKPaint
+            {
+                Style = SKPaintStyle.Fill,
+                Color = SKColor.Parse("#2F3640"),
+                IsAntialias = true
+            };
+
+            for (int x = spacing / 2; x < e.Info.Width; x += spacing)
+            {
+                for (int y = spacing / 2; y < e.Info.Height; y += spacing)
+                {
+                    canvas.DrawCircle(x, y, 1.5f, dotPaint);
+                }
+            }
         }
 
         private void OnCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
@@ -108,6 +108,11 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
             {
                 toggle.PropertyChanged += (_, __) => ParametersChanged?.Invoke(this);
             }
+
+            foreach (var text in Parameters.OfType<TextParameter>())
+            {
+                text.PropertyChanged += (_, __) => ParametersChanged?.Invoke(this);
+            }
         }
 
         private void UpdateHighlightedOption()

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/Rules/ReconstructionConfigurationRules.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/Rules/ReconstructionConfigurationRules.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Utility.Classes.Configurations.ReconstructionConfiguration.Rules
+{
+    public record BlockConnectionConstraint(int MaxInputs, int MaxOutputs)
+    {
+        public static BlockConnectionConstraint Unlimited { get; } = new(int.MaxValue, int.MaxValue);
+    }
+
+    /// <summary>
+    /// Contains all editor-side constraints and validation logic for reconstruction configuration.
+    /// Keep rules centralized here so they are easy to evolve.
+    /// </summary>
+    public static class ReconstructionConfigurationRules
+    {
+        private static readonly Dictionary<BlockType, BlockConnectionConstraint> ConnectionConstraints = new()
+        {
+            { BlockType.Initialization, new BlockConnectionConstraint(0, int.MaxValue) },
+            { BlockType.Measurement, new BlockConnectionConstraint(0, int.MaxValue) },
+            { BlockType.ErrorMetric, BlockConnectionConstraint.Unlimited },
+            { BlockType.Optimizer, BlockConnectionConstraint.Unlimited },
+            { BlockType.PostProcessing, BlockConnectionConstraint.Unlimited },
+            { BlockType.Regularizer, BlockConnectionConstraint.Unlimited },
+            { BlockType.Solver, BlockConnectionConstraint.Unlimited }
+        };
+
+        public static BlockConnectionConstraint GetConnectionConstraint(BlockType type) =>
+            ConnectionConstraints.TryGetValue(type, out var constraint)
+                ? constraint
+                : BlockConnectionConstraint.Unlimited;
+
+        public static bool HasAvailableInput(ReconstructionConfigurationBlock block, IEnumerable<ReconstructionConnection> connections)
+        {
+            var constraint = GetConnectionConstraint(block.Type);
+            if (constraint.MaxInputs == int.MaxValue) return true;
+            return connections.Count(c => c.Target == block) < constraint.MaxInputs;
+        }
+
+        public static bool HasAvailableOutput(ReconstructionConfigurationBlock block, IEnumerable<ReconstructionConnection> connections)
+        {
+            var constraint = GetConnectionConstraint(block.Type);
+            if (constraint.MaxOutputs == int.MaxValue) return true;
+            return connections.Count(c => c.Source == block) < constraint.MaxOutputs;
+        }
+
+        /// <summary>
+        /// Validate current graph and return a list of actionable issues.
+        /// </summary>
+        public static IReadOnlyList<string> Validate(IEnumerable<ReconstructionConfigurationBlock> blocks, IEnumerable<ReconstructionConnection> connections)
+        {
+            var issues = new List<string>();
+
+            foreach (var block in blocks)
+            {
+                var constraint = GetConnectionConstraint(block.Type);
+                var incoming = connections.Count(c => c.Target == block);
+                var outgoing = connections.Count(c => c.Source == block);
+
+                if (constraint.MaxInputs < int.MaxValue && incoming > constraint.MaxInputs)
+                {
+                    issues.Add($"{block.Title} exceeds its allowed number of inputs ({constraint.MaxInputs}).");
+                }
+
+                if (constraint.MaxOutputs < int.MaxValue && outgoing > constraint.MaxOutputs)
+                {
+                    issues.Add($"{block.Title} exceeds its allowed number of outputs ({constraint.MaxOutputs}).");
+                }
+            }
+
+            foreach (var errorMetric in blocks.Where(b => b.Type == BlockType.ErrorMetric))
+            {
+                var hasMeasurement = connections.Any(c => c.Target == errorMetric && c.Source.Type == BlockType.Measurement);
+                if (!hasMeasurement)
+                {
+                    issues.Add($"Error Metric '{errorMetric.Title}' must be connected to a Measurement block.");
+                }
+            }
+
+            return issues;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add multi-block dragging, dotted canvas background, and hide input ports on initialization/measurement blocks
- Persist block parameter changes while editing and surface a bottom debug panel with live summaries and issues
- Centralize connection rules/validation (including measurement-to-error requirements) and enforce per-block connector limits

## Testing
- `dotnet build ElectricalImpedanceTomography.sln` *(fails: `dotnet` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d87a14348333a9c120db80e8fe02)