### PR TITLE
Add reconstruction configuration constraints

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -173,6 +173,12 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             if (source == null || target == null || source == target) return;
             if (!CanConnect(source.Type, target.Type)) return;
+            if (!ReconstructionConfigurationRules.IsConnectionAllowed(source.Type, target.Type, out var reason))
+            {
+                if (!string.IsNullOrWhiteSpace(reason))
+                    TrackIssue($"{source.Title} -> {target.Title}: {reason}");
+                return;
+            }
             if (!ReconstructionConfigurationRules.HasAvailableOutput(source, Connections))
             {
                 TrackIssue($"{source.Title} has no remaining output connectors.");

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
@@ -26,28 +26,28 @@
             <converters:IsNullConverter x:Key="IsNullConverter"/>
 
             <DataTemplate x:Key="TextParameterTemplate" x:DataType="models:TextParameter">
-                <VerticalStackLayout Spacing="6">
+                <VerticalStackLayout Spacing="6" IsVisible="{Binding IsVisible}">
                     <Label Text="{Binding Name}" TextColor="{StaticResource TextMain}" FontSize="13" FontAttributes="Bold"/>
                     <Entry Text="{Binding Value}" BackgroundColor="{StaticResource InputBg}" TextColor="White" />
                 </VerticalStackLayout>
             </DataTemplate>
 
             <DataTemplate x:Key="NumberParameterTemplate" x:DataType="models:NumberParameter">
-                <VerticalStackLayout Spacing="6">
+                <VerticalStackLayout Spacing="6" IsVisible="{Binding IsVisible}">
                     <Label Text="{Binding Name}" TextColor="{StaticResource TextMain}" FontSize="13" FontAttributes="Bold"/>
                     <Entry Text="{Binding Value}" Keyboard="Numeric" BackgroundColor="{StaticResource InputBg}" TextColor="{StaticResource Accent}" />
                 </VerticalStackLayout>
             </DataTemplate>
 
             <DataTemplate x:Key="BoolParameterTemplate" x:DataType="models:BoolParameter">
-                <VerticalStackLayout Spacing="6">
+                <VerticalStackLayout Spacing="6" IsVisible="{Binding IsVisible}">
                     <Label Text="{Binding Name}" TextColor="{StaticResource TextMain}" FontSize="13" FontAttributes="Bold"/>
                     <Switch IsToggled="{Binding Value}" OnColor="{StaticResource Accent}" HorizontalOptions="Start"/>
                 </VerticalStackLayout>
             </DataTemplate>
 
             <DataTemplate x:Key="ChoiceParameterTemplate" x:DataType="models:ChoiceParameter">
-                <VerticalStackLayout Spacing="6">
+                <VerticalStackLayout Spacing="6" IsVisible="{Binding IsVisible}">
                     <Label Text="{Binding Name}" TextColor="{StaticResource TextMain}" FontSize="13" FontAttributes="Bold"/>
                     <Border Stroke="#444" StrokeThickness="1" StrokeShape="RoundRectangle 4" BackgroundColor="{StaticResource InputBg}">
                         <Picker ItemsSource="{Binding Options}" SelectedItem="{Binding SelectedOption}" TextColor="White" TitleColor="Gray" FontSize="13"/>

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Maui.Views;
 using ElectricalImpedanceTomography.ViewModels;
 using Microsoft.Maui.Controls.Shapes;
 using SkiaSharp;
@@ -162,6 +163,10 @@ namespace ElectricalImpedanceTomography.Views
             tapGesture.Tapped += (s, e) => _viewModel.SelectBlockCommand.Execute(block);
             border.GestureRecognizers.Add(tapGesture);
 
+            var doubleTapGesture = new TapGestureRecognizer { NumberOfTapsRequired = 2 };
+            doubleTapGesture.Tapped += async (s, e) => await OnBlockDoubleTappedAsync(block);
+            border.GestureRecognizers.Add(doubleTapGesture);
+
             var connectGesture = new PanGestureRecognizer();
             connectGesture.PanUpdated += (s, e) => OnConnectionPanUpdated(block, e);
             outPort.GestureRecognizers.Add(connectGesture);
@@ -186,6 +191,33 @@ namespace ElectricalImpedanceTomography.Views
             border.Triggers.Add(trigger);
 
             return container;
+        }
+
+        private async Task OnBlockDoubleTappedAsync(ReconstructionConfigurationBlock block)
+        {
+            if (block.Type != BlockType.Initialization)
+                return;
+
+            var discretization = Workspace.GetDiscretization();
+            if (discretization == null)
+            {
+                await DisplayAlert("No Mesh", "You should create or load a mesh before editing the initial distribution!", "Ok");
+                return;
+            }
+
+            var initial = Workspace.GetInitialConductivityDistribution() ?? discretization.GetConductivityDistribution();
+            var original = Workspace.GetOriginalConductivityDistribution();
+            var parameters = Workspace.GetReconstructionParameters();
+
+            var popup = new InitialDistributionEditorPopup(discretization,
+                                                           initial,
+                                                           original,
+                                                           parameters.InitialDistributionType);
+
+            EventHandler handler = (_, _) => MeshPreviewCanvas?.InvalidateSurface();
+            popup.DistributionChanged += handler;
+            await this.ShowPopupAsync(popup);
+            popup.DistributionChanged -= handler;
         }
 
         private void OnBlockPanUpdated(ReconstructionConfigurationBlock block, View view, PanUpdatedEventArgs e)

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ConfigurationParameter.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ConfigurationParameter.cs
@@ -16,6 +16,17 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
         /// Gets or sets the unique key used for serialization and logic mapping.
         /// </summary>
         public string Key { get; set; } = string.Empty;
+
+        private bool _isVisible = true;
+
+        /// <summary>
+        /// Indicates whether the parameter should be rendered in the configuration UI.
+        /// </summary>
+        public bool IsVisible
+        {
+            get => _isVisible;
+            set => SetProperty(ref _isVisible, value);
+        }
     }
 
     /// <summary>

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using Utility.Classes.Application;
 using Utility.Classes.Discretizer;
+using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.Factories;
 using Utility.Classes.Measurement;
+using Utility.Classes.Reconstruction.VirtualElectrodes;
 using Utility.Classes.ReconstructionParameters;
 
 namespace Utility.Classes.Configurations.ReconstructionConfiguration
@@ -54,6 +57,21 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
 
         public static ReconstructionBlockDefinition GetDefinition(BlockType type) => Definitions[type];
 
+        private static bool HasFemMesh() => Workspace.GetDiscretization() is FEMMesh;
+
+        private static bool HasLbmGrid() => Workspace.GetDiscretization() is LBMGrid;
+
+        private static List<string> GetSolverOptions()
+        {
+            if (HasFemMesh())
+                return [FriendlyName(nameof(DifferentialEquationSolver.FEM))];
+
+            if (HasLbmGrid())
+                return [FriendlyName(nameof(DifferentialEquationSolver.LBM))];
+
+            return Enum.GetNames(typeof(DifferentialEquationSolver)).Select(FriendlyName).ToList();
+        }
+
         private static IEnumerable<ReconstructionBlockDefinition> CreateDefaultDefinitions()
         {
             yield return new ReconstructionBlockDefinition(
@@ -73,7 +91,10 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                         },
                         new NumberParameter { Name = "Random Max Conductivity", Key = "rand_max", Value = 1.0, Min = 0.0 },
                         new NumberParameter { Name = "Slight Scaling", Key = "slight_scale", Value = 0.95, Min = 0.0, Max = 1.0, Step = 0.05 },
-                        new NumberParameter { Name = "Random Differing Count", Key = "rand_diff_count", Value = 5, Min = 1, Step = 1 }
+                        new NumberParameter { Name = "Random Differing Count", Key = "rand_diff_count", Value = 5, Min = 1, Step = 1 },
+                        new BoolParameter { Name = "Presolve with CIM", Key = "use_cim", Value = false },
+                        new NumberParameter { Name = "Initialization Current Amplitude", Key = "init_current", Value = 1.0, Min = 0.0 },
+                        new BoolParameter { Name = "Solve in Complex Domain", Key = "init_complex", Value = false }
                     };
                 },
                 (block, target) =>
@@ -81,38 +102,100 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                     var selected = block.Parameters.OfType<ChoiceParameter>().FirstOrDefault(p => p.Key == "init_method");
                     if (selected != null)
                         target.InitialDistributionType = ParseEnum<InitialDistributionTypes>(selected.SelectedOption);
+
+                    target.UseCurtisImigranMorrowPresolve = block.Parameters
+                        .OfType<BoolParameter>().FirstOrDefault(p => p.Key == "use_cim")?.Value ?? target.UseCurtisImigranMorrowPresolve;
+
+                    target.InitializationCurrentAmplitude = block.Parameters
+                        .OfType<NumberParameter>().FirstOrDefault(p => p.Key == "init_current")?.Value
+                        ?? target.InitializationCurrentAmplitude;
+
+                    target.SolveInitializationInComplexDomain = block.Parameters
+                        .OfType<BoolParameter>().FirstOrDefault(p => p.Key == "init_complex")?.Value
+                        ?? target.SolveInitializationInComplexDomain;
                 });
 
             yield return new ReconstructionBlockDefinition(
                 BlockType.Measurement,
                 "Measurement",
                 "#4ECDC4",
-                () => new List<ConfigurationParameter>
+                () =>
                 {
-                    new ChoiceParameter
-                    {
-                        Name = "Measurement Source",
-                        Key = "measurement_source",
-                        Options = Enum.GetNames(typeof(MeasurementSourceOption)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(MeasurementSourceOption.Simulated))
-                    },
-                    new ChoiceParameter
-                    {
-                        Name = "Electrode Setup",
-                        Key = "electrode_setup",
-                        Options = Enum.GetNames(typeof(ElectrodeMeasurementSetup)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(ElectrodeMeasurementSetup.Active))
-                    },
-                    new BoolParameter { Name = "Use Potential Differences", Key = "use_potential_differences", Value = false },
-                    new BoolParameter { Name = "Apply Measurement Noise", Key = "apply_noise", Value = false },
-                    new ChoiceParameter
+                    var applyNoise = new BoolParameter { Name = "Apply Measurement Noise", Key = "apply_noise", Value = false };
+                    var noiseType = new ChoiceParameter
                     {
                         Name = "Noise Type",
                         Key = "noise_type",
                         Options = Enum.GetNames(typeof(MeasurementNoiseType)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(MeasurementNoiseType.None))
-                    },
-                    new NumberParameter { Name = "Noise Amplitude / dB", Key = "noise_amplitude", Value = 0.0, Min = 0.0, Step = 0.1 }
+                        SelectedOption = FriendlyName(nameof(MeasurementNoiseType.None)),
+                        IsVisible = applyNoise.Value
+                    };
+                    var noiseAmplitude = new NumberParameter
+                    {
+                        Name = "Noise Amplitude / dB",
+                        Key = "noise_amplitude",
+                        Value = 0.0,
+                        Min = 0.0,
+                        Step = 0.1,
+                        IsVisible = applyNoise.Value
+                    };
+
+                    applyNoise.PropertyChanged += (_, args) =>
+                    {
+                        if (args.PropertyName == nameof(BoolParameter.Value))
+                        {
+                            noiseType.IsVisible = applyNoise.Value;
+                            noiseAmplitude.IsVisible = applyNoise.Value;
+                        }
+                    };
+
+                    var useVirtualElectrodes = new BoolParameter
+                    {
+                        Name = "Use Virtual Electrodes",
+                        Key = "use_virtual_electrodes",
+                        Value = false
+                    };
+
+                    var virtualMethod = new ChoiceParameter
+                    {
+                        Name = "Virtual Electrode Method",
+                        Key = "virtual_method",
+                        Options = Enum.GetNames(typeof(VirtualElectrodeMethod)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(VirtualElectrodeMethod.None)),
+                        IsVisible = useVirtualElectrodes.Value
+                    };
+
+                    useVirtualElectrodes.PropertyChanged += (_, args) =>
+                    {
+                        if (args.PropertyName == nameof(BoolParameter.Value))
+                        {
+                            virtualMethod.IsVisible = useVirtualElectrodes.Value;
+                        }
+                    };
+
+                    return new List<ConfigurationParameter>
+                    {
+                        new ChoiceParameter
+                        {
+                            Name = "Measurement Source",
+                            Key = "measurement_source",
+                            Options = Enum.GetNames(typeof(MeasurementSourceOption)).Select(FriendlyName).ToList(),
+                            SelectedOption = FriendlyName(nameof(MeasurementSourceOption.Simulated))
+                        },
+                        new ChoiceParameter
+                        {
+                            Name = "Electrode Setup",
+                            Key = "electrode_setup",
+                            Options = Enum.GetNames(typeof(ElectrodeMeasurementSetup)).Select(FriendlyName).ToList(),
+                            SelectedOption = FriendlyName(nameof(ElectrodeMeasurementSetup.Active))
+                        },
+                        new BoolParameter { Name = "Use Potential Differences", Key = "use_potential_differences", Value = false },
+                        applyNoise,
+                        noiseType,
+                        noiseAmplitude,
+                        useVirtualElectrodes,
+                        virtualMethod
+                    };
                 },
                 (block, target) =>
                 {
@@ -129,30 +212,88 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                     var noiseAmplitude = block.Parameters.OfType<NumberParameter>().FirstOrDefault(p => p.Key == "noise_amplitude")?.Value ?? 0.0;
                     var applyNoise = block.Parameters.OfType<BoolParameter>().FirstOrDefault(p => p.Key == "apply_noise")?.Value ?? false;
                     target.MeasurementNoiseAmplitude = applyNoise ? noiseAmplitude : 0.0;
+
+                    var virtualElectrodeSettings = target.VirtualElectrodeSettings ?? new VirtualElectrodeSettings();
+                    var useVirtualElectrodes = block.Parameters.OfType<BoolParameter>().FirstOrDefault(p => p.Key == "use_virtual_electrodes")?.Value ?? false;
+                    var virtualMethod = block.Parameters.OfType<ChoiceParameter>().FirstOrDefault(p => p.Key == "virtual_method");
+
+                    virtualElectrodeSettings.UseVirtualElectrodes = useVirtualElectrodes;
+                    virtualElectrodeSettings.Method = useVirtualElectrodes
+                        ? ParseEnum<VirtualElectrodeMethod>(virtualMethod?.SelectedOption ?? FriendlyName(nameof(VirtualElectrodeMethod.None)))
+                        : VirtualElectrodeMethod.None;
+                    target.VirtualElectrodeSettings = virtualElectrodeSettings;
                 });
 
             yield return new ReconstructionBlockDefinition(
                 BlockType.Solver,
                 "Solver",
                 "#06D6A0",
-                () => new List<ConfigurationParameter>
+                () =>
                 {
-                    new ChoiceParameter
+                    var solverOptions = GetSolverOptions();
+                    var solverChoice = new ChoiceParameter
                     {
                         Name = "Differential Equation Solver",
                         Key = "solver_type",
-                        Options = Enum.GetNames(typeof(DifferentialEquationSolver)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(DifferentialEquationSolver.FEM))
-                    },
-                    new ChoiceParameter
+                        Options = solverOptions,
+                        SelectedOption = solverOptions.FirstOrDefault() ?? FriendlyName(nameof(DifferentialEquationSolver.FEM))
+                    };
+
+                    var femOrder = new NumberParameter
                     {
-                        Name = "Numeric Solver",
-                        Key = "numeric_solver",
-                        Options = Enum.GetNames(typeof(NumericSolver)).Select(FriendlyName).ToList(),
-                        SelectedOption = FriendlyName(nameof(NumericSolver.GMRES))
-                    },
-                    new NumberParameter { Name = "FEM Order", Key = "fem_order", Value = 1, Min = 1, Max = 2, Step = 1 },
-                    new NumberParameter { Name = "LBM Relaxation Time (tau)", Key = "lbm_tau", Value = 0.51, Min = 0.50001, Step = 0.01 }
+                        Name = "FEM Order",
+                        Key = "fem_order",
+                        Value = 1,
+                        Min = 1,
+                        Max = 2,
+                        Step = 1,
+                        IsVisible = solverChoice.SelectedOption == FriendlyName(nameof(DifferentialEquationSolver.FEM))
+                    };
+
+                    var lbmDomainSize = new NumberParameter
+                    {
+                        Name = "Physical Domain Size",
+                        Key = "lbm_domain_size",
+                        Value = 1.0,
+                        Min = 0.0001,
+                        Step = 0.1,
+                        IsVisible = solverChoice.SelectedOption == FriendlyName(nameof(DifferentialEquationSolver.LBM))
+                    };
+
+                    var lbmRelaxation = new ChoiceParameter
+                    {
+                        Name = "LBM Relaxation Model",
+                        Key = "lbm_relaxation",
+                        Options = Enum.GetNames(typeof(LatticeBoltzmannRelaxationModel)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(LatticeBoltzmannRelaxationModel.BGK)),
+                        IsVisible = solverChoice.SelectedOption == FriendlyName(nameof(DifferentialEquationSolver.LBM))
+                    };
+
+                    solverChoice.PropertyChanged += (_, args) =>
+                    {
+                        if (args.PropertyName == nameof(ChoiceParameter.SelectedOption))
+                        {
+                            var isFem = solverChoice.SelectedOption == FriendlyName(nameof(DifferentialEquationSolver.FEM));
+                            femOrder.IsVisible = isFem;
+                            lbmDomainSize.IsVisible = !isFem;
+                            lbmRelaxation.IsVisible = !isFem;
+                        }
+                    };
+
+                    return new List<ConfigurationParameter>
+                    {
+                        solverChoice,
+                        new ChoiceParameter
+                        {
+                            Name = "Numeric Solver",
+                            Key = "numeric_solver",
+                            Options = Enum.GetNames(typeof(NumericSolver)).Select(FriendlyName).ToList(),
+                            SelectedOption = FriendlyName(nameof(NumericSolver.GMRES))
+                        },
+                        femOrder,
+                        lbmDomainSize,
+                        lbmRelaxation
+                    };
                 },
                 (block, target) =>
                 {
@@ -161,6 +302,10 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                     target.Mesh = target.DifferentialEquationSolver == DifferentialEquationSolver.FEM
                         ? DiscretizationType.FEM
                         : DiscretizationType.LBM;
+
+                    target.LbmPhysicalDomainSize = block.Parameters.OfType<NumberParameter>().FirstOrDefault(p => p.Key == "lbm_domain_size")?.Value
+                        ?? target.LbmPhysicalDomainSize;
+                    target.LbmRelaxationModel = ParseEnumFromChoice<LatticeBoltzmannRelaxationModel>(block, "lbm_relaxation");
                 });
 
             yield return new ReconstructionBlockDefinition(

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/Rules/ReconstructionConfigurationRules.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/Rules/ReconstructionConfigurationRules.cs
@@ -1,5 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
+using Utility.Classes.Application;
+using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Classes.ReconstructionParameters;
 
 namespace Utility.Classes.Configurations.ReconstructionConfiguration.Rules
 {
@@ -30,6 +34,27 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration.Rules
                 ? constraint
                 : BlockConnectionConstraint.Unlimited;
 
+        public static bool IsConnectionAllowed(BlockType source, BlockType target, out string? reason)
+        {
+            reason = null;
+
+            if (source == BlockType.Measurement && target != BlockType.ErrorMetric)
+            {
+                reason = "Measurement outputs can only feed Error Metric blocks.";
+                return false;
+            }
+
+            if (target == BlockType.Optimizer && source != BlockType.ErrorMetric && source != BlockType.Regularizer)
+            {
+                reason = "Only Error Metric or Regularizer blocks can connect to an Optimizer.";
+                return false;
+            }
+
+            return true;
+        }
+
+        public static bool IsConnectionAllowed(BlockType source, BlockType target) => IsConnectionAllowed(source, target, out _);
+
         public static bool HasAvailableInput(ReconstructionConfigurationBlock block, IEnumerable<ReconstructionConnection> connections)
         {
             var constraint = GetConnectionConstraint(block.Type);
@@ -50,6 +75,14 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration.Rules
         public static IReadOnlyList<string> Validate(IEnumerable<ReconstructionConfigurationBlock> blocks, IEnumerable<ReconstructionConnection> connections)
         {
             var issues = new List<string>();
+
+            foreach (var connection in connections)
+            {
+                if (!IsConnectionAllowed(connection.Source.Type, connection.Target.Type, out var reason) && reason != null)
+                {
+                    issues.Add($"{connection.Source.Title} -> {connection.Target.Title}: {reason}");
+                }
+            }
 
             foreach (var block in blocks)
             {
@@ -75,9 +108,74 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration.Rules
                 {
                     issues.Add($"Error Metric '{errorMetric.Title}' must be connected to a Measurement block.");
                 }
+
+                var hasSolver = connections.Any(c => c.Target == errorMetric && c.Source.Type == BlockType.Solver);
+                if (!hasSolver)
+                {
+                    issues.Add($"Error Metric '{errorMetric.Title}' must be connected to a Solver block.");
+                }
+            }
+
+            foreach (var type in Enum.GetValues<BlockType>().Where(t => t != BlockType.PostProcessing))
+            {
+                if (!blocks.Any(b => b.Type == type))
+                {
+                    issues.Add($"Add at least one {type} block to the configuration.");
+                }
+            }
+
+            var discretization = Workspace.GetDiscretization();
+            if (discretization is FEMMesh)
+            {
+                foreach (var solver in blocks.Where(b => b.Type == BlockType.Solver))
+                {
+                    if (GetSelectedSolverType(solver) != DifferentialEquationSolver.FEM)
+                    {
+                        issues.Add("FEM mesh detected: choose FEM as the solver.");
+                    }
+                }
+            }
+            else if (discretization is LBMGrid)
+            {
+                foreach (var solver in blocks.Where(b => b.Type == BlockType.Solver))
+                {
+                    if (GetSelectedSolverType(solver) != DifferentialEquationSolver.LBM)
+                    {
+                        issues.Add("LBM grid detected: choose LBM as the solver.");
+                    }
+                }
             }
 
             return issues;
+        }
+
+        private static DifferentialEquationSolver GetSelectedSolverType(ReconstructionConfigurationBlock block)
+        {
+            var solverChoice = block.Parameters.OfType<ChoiceParameter>().FirstOrDefault(p => p.Key == "solver_type");
+            return solverChoice != null
+                ? ParseEnum<DifferentialEquationSolver>(solverChoice.SelectedOption)
+                : DifferentialEquationSolver.FEM;
+        }
+
+        private static T ParseEnum<T>(string friendly) where T : struct, Enum
+        {
+            if (string.IsNullOrWhiteSpace(friendly))
+                return default;
+
+            static string Normalize(string value) =>
+                new string(value.Where(char.IsLetterOrDigit).ToArray()).ToUpperInvariant();
+
+            var normalizedInput = Normalize(friendly);
+
+            foreach (var name in Enum.GetNames(typeof(T)))
+            {
+                if (Normalize(name) == normalizedInput)
+                    return Enum.Parse<T>(name, true);
+            }
+
+            return Enum.TryParse<T>(friendly, true, out var parsed)
+                ? parsed
+                : default;
         }
     }
 }

--- a/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
+++ b/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
@@ -54,6 +54,21 @@ namespace Utility.Classes.ReconstructionParameters
 
         public DiscretizationType Mesh = DiscretizationType.FEM;
 
+        [ObservableProperty]
+        private bool useCurtisImigranMorrowPresolve;
+
+        [ObservableProperty]
+        private double initializationCurrentAmplitude = 1.0;
+
+        [ObservableProperty]
+        private bool solveInitializationInComplexDomain;
+
+        [ObservableProperty]
+        private double lbmPhysicalDomainSize = 1.0;
+
+        [ObservableProperty]
+        private LatticeBoltzmannRelaxationModel lbmRelaxationModel = LatticeBoltzmannRelaxationModel.BGK;
+
         /// <summary>
         /// Creates a parameter set using the default reconstruction configuration.
         /// </summary>

--- a/Utility/Classes/ReconstructionParameters/LatticeBoltzmannRelaxationModel.cs
+++ b/Utility/Classes/ReconstructionParameters/LatticeBoltzmannRelaxationModel.cs
@@ -1,0 +1,9 @@
+namespace Utility.Classes.ReconstructionParameters
+{
+    public enum LatticeBoltzmannRelaxationModel
+    {
+        BGK = 0,
+        MRT = 1,
+        TRT = 2
+    }
+}


### PR DESCRIPTION
## Summary
- enforce new connection validation rules, including measurement-to-error metric and optimizer input restrictions with per-block requirements
- extend initialization, solver, and measurement blocks with CIM presolve, LBM relaxation/domain settings, and virtual electrode/noise visibility controls
- improve UI interactions by hiding conditional parameters and enabling double-click access to the initial distribution editor

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: `dotnet` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e6f61d4c8333a483be59a32f56fc)