### PR TITLE
Add model block and update reconstruction flow interactions

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -53,6 +53,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             else
             {
                 AddBlock(BlockType.Initialization, 50, 50);
+                AddBlock(BlockType.Model, 300, 50);
             }
 
             ApplyConfigurationToWorkspace();
@@ -109,6 +110,19 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
         }
 
+        [RelayCommand]
+        public void RotateBlock(ReconstructionConfigurationBlock? block)
+        {
+            if (block == null)
+            {
+                return;
+            }
+
+            block.Rotation = (block.Rotation + 15) % 360;
+            SelectBlock(block);
+            NotifyLayoutChanged();
+        }
+
         public void SelectConnection(ReconstructionConnection? connection)
         {
             ClearSelection();
@@ -131,14 +145,14 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             foreach (var block in Blocks)
             {
-                var blockRect = new Rect(block.X, block.Y, 200, 80);
+                var blockRect = new Rect(block.X, block.Y, block.Width, block.Height);
                 block.IsSelected = selectionRect.IntersectsWith(blockRect);
             }
 
             foreach (var conn in Connections)
             {
-                var midX = (conn.Source.X + 214 + conn.Target.X) / 2;
-                var midY = (conn.Source.Y + 30 + conn.Target.Y + 30) / 2;
+                var midX = (conn.Source.X + conn.Source.Width + conn.Target.X) / 2;
+                var midY = (conn.Source.Y + conn.Source.Height * 0.4 + conn.Target.Y + conn.Target.Height * 0.4) / 2;
                 conn.IsSelected = selectionRect.Contains(midX, midY);
             }
 
@@ -193,7 +207,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             if (!Connections.Any(c => c.Source == source && c.Target == target))
             {
-                Connections.Add(new ReconstructionConnection { Source = source, Target = target });
+                Connections.Add(new ReconstructionConnection { Source = source, Target = target, Weight = 1.0 });
                 ApplyConfigurationToWorkspace();
             }
         }
@@ -251,6 +265,9 @@ namespace ElectricalImpedanceTomography.ViewModels
                         Type = b.Type,
                         X = b.X,
                         Y = b.Y,
+                        Width = b.Width,
+                        Height = b.Height,
+                        Rotation = b.Rotation,
                         Parameters = b.Parameters.Select(p => new ParameterDto
                         {
                             Key = p.Key,
@@ -260,7 +277,8 @@ namespace ElectricalImpedanceTomography.ViewModels
                     Connections = Connections.Select(c => new ConnectionDto
                     {
                         SourceId = c.Source.Id,
-                        TargetId = c.Target.Id
+                        TargetId = c.Target.Id,
+                        Weight = c.Weight
                     }).ToList()
                 };
 
@@ -309,7 +327,14 @@ namespace ElectricalImpedanceTomography.ViewModels
 
                 foreach (var bDto in dto.Blocks)
                 {
-                    var blk = ReconstructionBlockRegistry.CreateBlock(bDto.Type, bDto.X, bDto.Y, bDto.Id);
+                    var blk = ReconstructionBlockRegistry.CreateBlock(
+                        bDto.Type,
+                        bDto.X,
+                        bDto.Y,
+                        bDto.Id,
+                        bDto.Width <= 0 ? 214 : bDto.Width,
+                        bDto.Height <= 0 ? 80 : bDto.Height,
+                        bDto.Rotation);
 
                     foreach (var pDto in bDto.Parameters)
                     {
@@ -326,7 +351,12 @@ namespace ElectricalImpedanceTomography.ViewModels
                 {
                     if (idMap.TryGetValue(cDto.SourceId, out var src) && idMap.TryGetValue(cDto.TargetId, out var tgt))
                     {
-                        Connections.Add(new ReconstructionConnection { Source = src, Target = tgt });
+                        Connections.Add(new ReconstructionConnection
+                        {
+                            Source = src,
+                            Target = tgt,
+                            Weight = cDto.Weight <= 0 ? 1.0 : cDto.Weight
+                        });
                     }
                 }
 
@@ -373,8 +403,26 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public void NotifyLayoutChanged() => ApplyConfigurationToWorkspace();
 
+        private void UpdateConnectionWeightRequirements()
+        {
+            bool multiError = Blocks.Count(b => b.Type == BlockType.ErrorMetric) >= 2;
+            bool multiRegularizer = Blocks.Count(b => b.Type == BlockType.Regularizer) >= 2;
+            bool multiOptimizer = Blocks.Count(b => b.Type == BlockType.Optimizer) >= 2;
+
+            foreach (var connection in Connections)
+            {
+                bool requires =
+                    (multiError && (connection.Source.Type == BlockType.ErrorMetric || connection.Target.Type == BlockType.ErrorMetric)) ||
+                    (multiRegularizer && (connection.Source.Type == BlockType.Regularizer || connection.Target.Type == BlockType.Regularizer)) ||
+                    (multiOptimizer && (connection.Source.Type == BlockType.Optimizer || connection.Target.Type == BlockType.Optimizer));
+
+                connection.RequiresWeight = requires;
+            }
+        }
+
         private void UpdateDiagnostics()
         {
+            UpdateConnectionWeightRequirements();
             DebugLines.Clear();
             var blockSummary = string.Join(", ", Blocks
                 .GroupBy(b => b.Type)
@@ -426,6 +474,9 @@ namespace ElectricalImpedanceTomography.ViewModels
             public BlockType Type { get; set; }
             public double X { get; set; }
             public double Y { get; set; }
+            public double Width { get; set; }
+            public double Height { get; set; }
+            public double Rotation { get; set; }
             public List<ParameterDto> Parameters { get; set; }
         }
 
@@ -439,6 +490,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             public string SourceId { get; set; }
             public string TargetId { get; set; }
+            public double Weight { get; set; }
         }
     }
 }

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
@@ -196,6 +196,12 @@
                         <VerticalStackLayout IsVisible="{Binding SelectedConnection, Converter={StaticResource IsNotNullConverter}}">
                             <Label Text="Connection Selected" FontSize="18" TextColor="#DDD" HorizontalOptions="Center"/>
                             <Label Text="Press 'Delete Selected' to remove." FontSize="12" TextColor="#888" HorizontalOptions="Center"/>
+                            <VerticalStackLayout Spacing="6" Margin="0,8,0,0">
+                                <Label Text="Weight" FontSize="14" TextColor="{StaticResource TextMain}" HorizontalOptions="Center"/>
+                                <Slider Minimum="0" Maximum="10" Value="{Binding SelectedConnection.Weight}"/>
+                                <Label Text="{Binding SelectedConnection.Weight, StringFormat='{}{0:0.00}'}" FontSize="12" TextColor="{StaticResource TextMuted}" HorizontalOptions="Center"/>
+                                <Label Text="Weight required when combining similar blocks." FontSize="11" TextColor="#F0AD4E" HorizontalOptions="Center" IsVisible="{Binding SelectedConnection.RequiresWeight}"/>
+                            </VerticalStackLayout>
                         </VerticalStackLayout>
 
                         <!-- Empty State -->

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
@@ -34,11 +34,8 @@ namespace ElectricalImpedanceTomography.Views
         private ReconstructionConfigurationBlock? _draggedBlock;
         private Point _dragStartPoint;
 
-        private const double PortCenterY = 30;
-        private const double OutputPortXOffset = 214;
-        private const double InputPortXOffset = 0;
-        private const double BlockWidth = 214;
-        private const double BlockHeight = 80;
+        // Resizing state
+        private readonly Dictionary<ReconstructionConfigurationBlock, (double Width, double Height)> _resizeStartSizes = new();
 
         // Mesh preview drawing helpers
         private readonly SKPaint _lbmFill = new() { Style = SKPaintStyle.Fill, Color = SKColors.Black };
@@ -94,8 +91,12 @@ namespace ElectricalImpedanceTomography.Views
                 BackgroundColor = Color.FromArgb("#3A3A4E"),
                 StrokeShape = new RoundRectangle { CornerRadius = 8 },
                 WidthRequest = 200,
+                HeightRequest = 80,
                 Shadow = new Shadow { Brush = Brush.Black, Offset = new Point(0, 5), Opacity = 0.4f, Radius = 10 }
             };
+
+            border.SetBinding(WidthRequestProperty, new Binding(nameof(ReconstructionConfigurationBlock.Width), source: block));
+            border.SetBinding(HeightRequestProperty, new Binding(nameof(ReconstructionConfigurationBlock.Height), source: block));
 
             var headerColor = Color.FromArgb(block.IconColor);
 
@@ -160,7 +161,11 @@ namespace ElectricalImpedanceTomography.Views
             border.GestureRecognizers.Add(panGesture);
 
             var tapGesture = new TapGestureRecognizer();
-            tapGesture.Tapped += (s, e) => _viewModel.SelectBlockCommand.Execute(block);
+            tapGesture.Tapped += (s, e) =>
+            {
+                _viewModel.SelectBlockCommand.Execute(block);
+                _viewModel.RotateBlockCommand.Execute(block);
+            };
             border.GestureRecognizers.Add(tapGesture);
 
             var doubleTapGesture = new TapGestureRecognizer { NumberOfTapsRequired = 2 };
@@ -171,14 +176,35 @@ namespace ElectricalImpedanceTomography.Views
             connectGesture.PanUpdated += (s, e) => OnConnectionPanUpdated(block, e);
             outPort.GestureRecognizers.Add(connectGesture);
 
-            var container = new Grid { WidthRequest = 214, BindingContext = block };
+            var resizeHandle = new Border
+            {
+                WidthRequest = 16,
+                HeightRequest = 16,
+                BackgroundColor = Color.FromArgb("#55FFFFFF"),
+                Stroke = Color.FromArgb("#444"),
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle { CornerRadius = 4 },
+                HorizontalOptions = LayoutOptions.End,
+                VerticalOptions = LayoutOptions.End,
+                Margin = new Thickness(0, 0, -6, -6)
+            };
+
+            var resizePan = new PanGestureRecognizer();
+            resizePan.PanUpdated += (s, e) => OnResizePanUpdated(block, e);
+            resizeHandle.GestureRecognizers.Add(resizePan);
+
+            var container = new Grid { WidthRequest = 214, HeightRequest = 80, BindingContext = block };
+            container.SetBinding(WidthRequestProperty, new Binding(nameof(ReconstructionConfigurationBlock.Width), source: block));
+            container.SetBinding(HeightRequestProperty, new Binding(nameof(ReconstructionConfigurationBlock.Height), source: block));
+            container.SetBinding(RotationProperty, new Binding(nameof(ReconstructionConfigurationBlock.Rotation), source: block));
             // Ensure individual blocks remain hit-testable even though the parent layout is transparent.
             container.InputTransparent = false;
             container.Add(border);
             container.Add(inPort);
             container.Add(outPort);
+            container.Add(resizeHandle);
 
-            AbsoluteLayout.SetLayoutBounds(container, new Rect(block.X, block.Y, AbsoluteLayout.AutoSize, AbsoluteLayout.AutoSize));
+            AbsoluteLayout.SetLayoutBounds(container, new Rect(block.X, block.Y, block.Width, block.Height));
 
             // Bind IsSelected to trigger visual changes on block
             var trigger = new DataTrigger(typeof(Border))
@@ -269,8 +295,28 @@ namespace ElectricalImpedanceTomography.Views
                 .FirstOrDefault(c => ReferenceEquals(c.BindingContext, block));
             if (view != null)
             {
-                AbsoluteLayout.SetLayoutBounds(view, new Rect(newX, newY, AbsoluteLayout.AutoSize, AbsoluteLayout.AutoSize));
+                AbsoluteLayout.SetLayoutBounds(view, new Rect(newX, newY, block.Width, block.Height));
             }
+        }
+
+        private void UpdateBlockSize(ReconstructionConfigurationBlock block, double newWidth, double newHeight)
+        {
+            var clampedWidth = Math.Max(140, newWidth);
+            var clampedHeight = Math.Max(60, newHeight);
+
+            block.Width = clampedWidth;
+            block.Height = clampedHeight;
+
+            var view = NodeContainer.Children
+                .OfType<View>()
+                .FirstOrDefault(c => ReferenceEquals(c.BindingContext, block));
+
+            if (view != null)
+            {
+                AbsoluteLayout.SetLayoutBounds(view, new Rect(block.X, block.Y, clampedWidth, clampedHeight));
+            }
+
+            ConnectionsCanvas.InvalidateSurface();
         }
 
         private void OnConnectionPanUpdated(ReconstructionConfigurationBlock sourceBlock, PanUpdatedEventArgs e)
@@ -282,11 +328,10 @@ namespace ElectricalImpedanceTomography.Views
                     {
                         return;
                     }
-                    double startX = sourceBlock.X + OutputPortXOffset;
-                    double startY = sourceBlock.Y + PortCenterY;
+                    var anchor = GetOutputPortAnchor(sourceBlock);
                     _tempConnectionSource = sourceBlock;
-                    _tempConnectionStart = new Point(startX, startY);
-                    _tempConnectionEnd = _tempConnectionStart;
+                    _tempConnectionStart = anchor;
+                    _tempConnectionEnd = anchor;
                     ConnectionsCanvas.InvalidateSurface();
                     break;
                 case GestureStatus.Running:
@@ -314,6 +359,27 @@ namespace ElectricalImpedanceTomography.Views
             }
         }
 
+        private void OnResizePanUpdated(ReconstructionConfigurationBlock block, PanUpdatedEventArgs e)
+        {
+            switch (e.StatusType)
+            {
+                case GestureStatus.Started:
+                    _resizeStartSizes[block] = (block.Width, block.Height);
+                    break;
+                case GestureStatus.Running:
+                    if (_resizeStartSizes.TryGetValue(block, out var start))
+                    {
+                        UpdateBlockSize(block, start.Width + e.TotalX, start.Height + e.TotalY);
+                    }
+                    break;
+                case GestureStatus.Completed:
+                case GestureStatus.Canceled:
+                    _resizeStartSizes.Remove(block);
+                    _viewModel.NotifyLayoutChanged();
+                    break;
+            }
+        }
+
         private ReconstructionConfigurationBlock FindTargetBlock(Point location)
         {
             foreach (var block in _viewModel.Blocks)
@@ -323,9 +389,8 @@ namespace ElectricalImpedanceTomography.Views
                     continue;
                 }
 
-                double targetX = block.X + InputPortXOffset;
-                double targetY = block.Y + PortCenterY;
-                if (Math.Abs(location.X - targetX) < 40 && Math.Abs(location.Y - targetY) < 40)
+                var anchor = GetInputPortAnchor(block);
+                if (Math.Abs(location.X - anchor.X) < 40 && Math.Abs(location.Y - anchor.Y) < 40)
                 {
                     return block;
                 }
@@ -390,7 +455,7 @@ namespace ElectricalImpedanceTomography.Views
                 return false;
             }
 
-            var portCenter = new Point(block.X + OutputPortXOffset, block.Y + PortCenterY);
+            var portCenter = GetOutputPortAnchor(block);
             if (Distance(viewPoint, portCenter) <= 16)
             {
                 _tempConnectionSource = block;
@@ -524,8 +589,8 @@ namespace ElectricalImpedanceTomography.Views
         private ReconstructionConfigurationBlock? FindBlockAtPoint(Point point)
         {
             return _viewModel.Blocks.FirstOrDefault(block =>
-                point.X >= block.X && point.X <= block.X + BlockWidth &&
-                point.Y >= block.Y && point.Y <= block.Y + BlockHeight);
+                point.X >= block.X && point.X <= block.X + block.Width &&
+                point.Y >= block.Y && point.Y <= block.Y + block.Height);
         }
 
         private static double Distance(Point a, Point b)
@@ -534,6 +599,14 @@ namespace ElectricalImpedanceTomography.Views
             var dy = a.Y - b.Y;
             return Math.Sqrt(dx * dx + dy * dy);
         }
+
+        private static double GetPortOffsetY(ReconstructionConfigurationBlock block) => block.Height * 0.4;
+
+        private static Point GetInputPortAnchor(ReconstructionConfigurationBlock block)
+            => new(block.X, block.Y + GetPortOffsetY(block));
+
+        private static Point GetOutputPortAnchor(ReconstructionConfigurationBlock block)
+            => new(block.X + block.Width, block.Y + GetPortOffsetY(block));
 
         private bool TrySelectConnection(SKPoint clickPoint)
         {
@@ -544,10 +617,13 @@ namespace ElectricalImpedanceTomography.Views
             {
                 if (conn.Source == null || conn.Target == null) continue;
 
-                float x1 = (float)(conn.Source.X + OutputPortXOffset);
-                float y1 = (float)(conn.Source.Y + PortCenterY);
-                float x2 = (float)(conn.Target.X + InputPortXOffset);
-                float y2 = (float)(conn.Target.Y + PortCenterY);
+                var sourceAnchor = GetOutputPortAnchor(conn.Source);
+                var targetAnchor = GetInputPortAnchor(conn.Target);
+
+                float x1 = (float)sourceAnchor.X;
+                float y1 = (float)sourceAnchor.Y;
+                float x2 = (float)targetAnchor.X;
+                float y2 = (float)targetAnchor.Y;
 
                 float midX = (x1 + x2) / 2;
                 float midY = (y1 + y2) / 2;
@@ -614,16 +690,69 @@ namespace ElectricalImpedanceTomography.Views
                 StrokeCap = SKStrokeCap.Round
             };
 
+            using var weightPaint = new SKPaint
+            {
+                Style = SKPaintStyle.Stroke,
+                Color = SKColors.Yellow,
+                StrokeWidth = 4,
+                IsAntialias = true,
+                StrokeCap = SKStrokeCap.Round
+            };
+
             foreach (var conn in _viewModel.Connections)
             {
                 if (conn.Source == null || conn.Target == null) continue;
 
-                float x1 = (float)(conn.Source.X + OutputPortXOffset);
-                float y1 = (float)(conn.Source.Y + PortCenterY);
-                float x2 = (float)(conn.Target.X + InputPortXOffset);
-                float y2 = (float)(conn.Target.Y + PortCenterY);
+                var sourceAnchor = GetOutputPortAnchor(conn.Source);
+                var targetAnchor = GetInputPortAnchor(conn.Target);
 
-                DrawConnectionCurve(canvas, conn.IsSelected ? paintSelected : paintNormal, x1, y1, x2, y2);
+                float x1 = (float)sourceAnchor.X;
+                float y1 = (float)sourceAnchor.Y;
+                float x2 = (float)targetAnchor.X;
+                float y2 = (float)targetAnchor.Y;
+
+                var paintToUse = conn.IsSelected
+                    ? paintSelected
+                    : conn.RequiresWeight
+                        ? weightPaint
+                        : paintNormal;
+
+                using var styledPaint = new SKPaint(paintToUse)
+                {
+                    PathEffect = (conn.Source.Type == BlockType.Optimizer && conn.Target.Type == BlockType.Model)
+                        ? SKPathEffect.CreateDash(new float[] { 6, 6 }, 0)
+                        : paintToUse.PathEffect
+                };
+
+                DrawConnectionCurve(canvas, styledPaint, x1, y1, x2, y2);
+
+                if (conn.RequiresWeight)
+                {
+                    var label = $"{conn.Weight:0.##}";
+                    using var textPaint = new SKPaint
+                    {
+                        Color = SKColors.White,
+                        IsAntialias = true,
+                        TextSize = 16,
+                        Typeface = SKTypeface.FromFamilyName("Arial", SKFontStyle.Bold)
+                    };
+
+                    float labelX = (x1 + x2) / 2f;
+                    float labelY = (y1 + y2) / 2f - 6;
+                    var textBounds = new SKRect();
+                    textPaint.MeasureText(label, ref textBounds);
+                    var padding = 6f;
+
+                    using var bgPaint = new SKPaint
+                    {
+                        Color = SKColor.Parse("#66000000"),
+                        IsAntialias = true
+                    };
+                    var rect = SKRect.Create(labelX - textBounds.MidX - padding, labelY + textBounds.Top - padding,
+                        textBounds.Width + 2 * padding, textBounds.Height + 2 * padding);
+                    canvas.DrawRoundRect(rect, 6, 6, bgPaint);
+                    canvas.DrawText(label, labelX - textBounds.MidX, labelY, textPaint);
+                }
             }
 
             if (_tempConnectionStart.HasValue && _tempConnectionEnd.HasValue)

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/BlockType.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/BlockType.cs
@@ -12,6 +12,12 @@
         Initialization,
 
         /// <summary>
+        /// Physical model description for the domain, e.g., electrode contact
+        /// impedances and conductivity bounds.
+        /// </summary>
+        Model,
+
+        /// <summary>
         /// Block describing the incoming measurements and their preprocessing.
         /// </summary>
         Measurement,

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
@@ -23,7 +23,14 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
 
         public static IReadOnlyCollection<BlockType> BlockTypes => Definitions.Keys;
 
-        public static ReconstructionConfigurationBlock CreateBlock(BlockType type, double x, double y, string? id = null)
+        public static ReconstructionConfigurationBlock CreateBlock(
+            BlockType type,
+            double x,
+            double y,
+            string? id = null,
+            double width = 214,
+            double height = 80,
+            double rotation = 0)
         {
             if (!Definitions.TryGetValue(type, out var definition))
                 throw new ArgumentException($"No block definition found for type {type}.", nameof(type));
@@ -36,7 +43,10 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                 definition.IconColor,
                 x,
                 y,
-                parameters);
+                parameters,
+                width,
+                height,
+                rotation);
         }
 
         public static void ApplyBlocksToWorkspace(IEnumerable<ReconstructionConfigurationBlock> blocks)
@@ -113,6 +123,64 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                     target.SolveInitializationInComplexDomain = block.Parameters
                         .OfType<BoolParameter>().FirstOrDefault(p => p.Key == "init_complex")?.Value
                         ?? target.SolveInitializationInComplexDomain;
+                });
+
+            yield return new ReconstructionBlockDefinition(
+                BlockType.Model,
+                "Model",
+                "#8BC34A",
+                () => new List<ConfigurationParameter>
+                {
+                    new NumberParameter
+                    {
+                        Name = "Contact Impedance (Ω)",
+                        Key = "contact_impedance",
+                        Value = 0.1,
+                        Min = 0.0,
+                        Step = 0.01
+                    },
+                    new NumberParameter
+                    {
+                        Name = "Contact Impedance Variation (Ω)",
+                        Key = "contact_impedance_var",
+                        Value = 0.0,
+                        Min = 0.0,
+                        Step = 0.01
+                    },
+                    new NumberParameter
+                    {
+                        Name = "Conductivity Lower Bound",
+                        Key = "sigma_min",
+                        Value = 0.1,
+                        Min = 0.0,
+                        Step = 0.05
+                    },
+                    new NumberParameter
+                    {
+                        Name = "Conductivity Upper Bound",
+                        Key = "sigma_max",
+                        Value = 10.0,
+                        Min = 0.1,
+                        Step = 0.1
+                    }
+                },
+                (block, target) =>
+                {
+                    target.ConductivityMinimumBound = block.Parameters
+                        .OfType<NumberParameter>()
+                        .FirstOrDefault(p => p.Key == "sigma_min")?.Value ?? target.ConductivityMinimumBound;
+
+                    target.ConductivityMaximumBound = block.Parameters
+                        .OfType<NumberParameter>()
+                        .FirstOrDefault(p => p.Key == "sigma_max")?.Value ?? target.ConductivityMaximumBound;
+
+                    target.ContactImpedanceOhms = block.Parameters
+                        .OfType<NumberParameter>()
+                        .FirstOrDefault(p => p.Key == "contact_impedance")?.Value ?? target.ContactImpedanceOhms;
+
+                    target.ContactImpedanceVariation = block.Parameters
+                        .OfType<NumberParameter>()
+                        .FirstOrDefault(p => p.Key == "contact_impedance_var")?.Value ?? target.ContactImpedanceVariation;
                 });
 
             yield return new ReconstructionBlockDefinition(

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
@@ -22,7 +22,10 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
             string iconColor,
             double x,
             double y,
-            IEnumerable<ConfigurationParameter> parameters)
+            IEnumerable<ConfigurationParameter> parameters,
+            double width = 214,
+            double height = 80,
+            double rotation = 0)
         {
             Id = id;
             Title = title;
@@ -30,6 +33,9 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
             IconColor = iconColor;
             X = x;
             Y = y;
+            Width = width;
+            Height = height;
+            Rotation = rotation;
             Parameters = new ObservableCollection<ConfigurationParameter>(parameters);
             HookParameterChanges();
             UpdateHighlightedOption();
@@ -83,6 +89,24 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
         /// Collection of configurable parameters associated with this block.
         /// </summary>
         public ObservableCollection<ConfigurationParameter> Parameters { get; set; } = new();
+
+        private double _width = 214;
+        /// <summary>
+        /// Visual width of the block on the canvas.
+        /// </summary>
+        public double Width { get => _width; set => SetProperty(ref _width, value); }
+
+        private double _height = 80;
+        /// <summary>
+        /// Visual height of the block on the canvas.
+        /// </summary>
+        public double Height { get => _height; set => SetProperty(ref _height, value); }
+
+        private double _rotation;
+        /// <summary>
+        /// Rotation angle in degrees applied to the block container.
+        /// </summary>
+        public double Rotation { get => _rotation; set => SetProperty(ref _rotation, value % 360); }
 
         public event Action<ReconstructionConfigurationBlock>? ParametersChanged;
 

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConnection.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConnection.cs
@@ -12,6 +12,28 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
         public ReconstructionConfigurationBlock Source { get; set; }
         public ReconstructionConfigurationBlock Target { get; set; }
 
+        private double _weight = 1.0;
+        /// <summary>
+        /// Relative influence of this connection when multiple blocks of the
+        /// same category are present.
+        /// </summary>
+        public double Weight
+        {
+            get => _weight;
+            set => SetProperty(ref _weight, value);
+        }
+
+        private bool _requiresWeight;
+        /// <summary>
+        /// Indicates whether the connection should display and enforce a
+        /// weight (e.g., when multiple regularizers are active).
+        /// </summary>
+        public bool RequiresWeight
+        {
+            get => _requiresWeight;
+            set => SetProperty(ref _requiresWeight, value);
+        }
+
         private bool _isSelected;
         public bool IsSelected
         {

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/Rules/ReconstructionConfigurationRules.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/Rules/ReconstructionConfigurationRules.cs
@@ -21,6 +21,7 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration.Rules
         private static readonly Dictionary<BlockType, BlockConnectionConstraint> ConnectionConstraints = new()
         {
             { BlockType.Initialization, new BlockConnectionConstraint(0, int.MaxValue) },
+            { BlockType.Model, BlockConnectionConstraint.Unlimited },
             { BlockType.Measurement, new BlockConnectionConstraint(0, int.MaxValue) },
             { BlockType.ErrorMetric, BlockConnectionConstraint.Unlimited },
             { BlockType.Optimizer, BlockConnectionConstraint.Unlimited },
@@ -38,9 +39,33 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration.Rules
         {
             reason = null;
 
+            if (source == BlockType.Initialization && target != BlockType.Model)
+            {
+                reason = "Initializer output must feed the Model block.";
+                return false;
+            }
+
             if (source == BlockType.Measurement && target != BlockType.ErrorMetric)
             {
                 reason = "Measurement outputs can only feed Error Metric blocks.";
+                return false;
+            }
+
+            if (target == BlockType.ErrorMetric && source != BlockType.Solver && source != BlockType.Measurement)
+            {
+                reason = "Error Metric inputs must originate from a Solver or Measurement block.";
+                return false;
+            }
+
+            if (target == BlockType.Regularizer && source != BlockType.Model)
+            {
+                reason = "Regularizer inputs must come from the Model block.";
+                return false;
+            }
+
+            if (source == BlockType.Optimizer && target != BlockType.Model)
+            {
+                reason = "Optimizer outputs must connect into the Model block.";
                 return false;
             }
 
@@ -98,6 +123,22 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration.Rules
                 if (constraint.MaxOutputs < int.MaxValue && outgoing > constraint.MaxOutputs)
                 {
                     issues.Add($"{block.Title} exceeds its allowed number of outputs ({constraint.MaxOutputs}).");
+                }
+            }
+
+            foreach (var optimizer in blocks.Where(b => b.Type == BlockType.Optimizer))
+            {
+                if (!connections.Any(c => c.Source == optimizer && c.Target.Type == BlockType.Model))
+                {
+                    issues.Add($"Optimizer '{optimizer.Title}' must feed the Model block.");
+                }
+            }
+
+            foreach (var connection in connections.Where(c => c.RequiresWeight))
+            {
+                if (connection.Weight <= 0)
+                {
+                    issues.Add($"Set a positive weight for connection {connection.Source.Title} -> {connection.Target.Title}.");
                 }
             }
 

--- a/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
+++ b/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
@@ -32,6 +32,12 @@ namespace Utility.Classes.ReconstructionParameters
         private double measurementNoiseAmplitude = 0.0;
 
         [ObservableProperty]
+        private double contactImpedanceOhms = 0.1;
+
+        [ObservableProperty]
+        private double contactImpedanceVariation = 0.0;
+
+        [ObservableProperty]
         private DrivePattern drivePattern = DrivePattern.Adjecent;
 
         [ObservableProperty]


### PR DESCRIPTION
## Summary
- add a model block with contact impedance and bound parameters plus persistence support
- enforce updated connection rules, dotted optimizer-to-model links, and weightable highlighted connections when combining similar blocks
- allow blocks to be resized and rotated directly on the canvas while exposing connection weight controls in the inspector

## Testing
- Not run (dotnet SDK not available in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925628725648333897a83e92d408df1)