### PR TITLE
Adjust reconstruction UI controls and block appearance settings

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -290,6 +290,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                         Type = b.Type,
                         X = b.X,
                         Y = b.Y,
+                        FontSize = b.FontSize,
                         Width = b.Width,
                         Height = b.Height,
                         Rotation = b.Rotation,
@@ -357,6 +358,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                         bDto.X,
                         bDto.Y,
                         bDto.Id,
+                        bDto.FontSize <= 0 ? 13 : bDto.FontSize,
                         bDto.Width <= 0 ? 214 : bDto.Width,
                         bDto.Height <= 0 ? 80 : bDto.Height,
                         bDto.Rotation);
@@ -505,6 +507,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             public BlockType Type { get; set; }
             public double X { get; set; }
             public double Y { get; set; }
+            public double FontSize { get; set; }
             public double Width { get; set; }
             public double Height { get; set; }
             public double Rotation { get; set; }

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
@@ -110,16 +110,6 @@
 
                 <!-- ACTIONS (Updated) -->
                 <VerticalStackLayout Grid.Row="2" VerticalOptions="End" Spacing="10">
-                    <Label Text="GRID" FontSize="11" FontAttributes="Bold" TextColor="{StaticResource TextMuted}" />
-                    <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="6">
-                        <Button Text="-" BackgroundColor="#444" TextColor="#CCC" HeightRequest="36" CornerRadius="6" WidthRequest="40" Command="{Binding DecreaseGridSpacingCommand}"/>
-                        <Label Grid.Column="1" Text="{Binding GridSpacing, StringFormat='{}Grid: {0:0} px'}" VerticalTextAlignment="Center" TextColor="{StaticResource TextMain}" FontSize="13" HorizontalOptions="Center" />
-                        <Button Grid.Column="2" Text="+" BackgroundColor="#444" TextColor="#CCC" HeightRequest="36" CornerRadius="6" WidthRequest="40" Command="{Binding IncreaseGridSpacingCommand}"/>
-                    </Grid>
-                    <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
-                        <Button Text="Zoom -" BackgroundColor="#353543" TextColor="#DDD" HeightRequest="36" CornerRadius="6" Clicked="OnZoomOutClicked"/>
-                        <Button Grid.Column="1" Text="Zoom +" BackgroundColor="#353543" TextColor="#DDD" HeightRequest="36" CornerRadius="6" Clicked="OnZoomInClicked"/>
-                    </Grid>
                     <Button Text="Delete Selected" BackgroundColor="#FF4757" TextColor="White" HeightRequest="40" CornerRadius="6" Command="{Binding DeleteSelectedCommand}"/>
                     <Grid ColumnDefinitions="*,*">
                         <Button Grid.Column="0" Text="Save" BackgroundColor="#2E8B57" TextColor="White" HeightRequest="40" CornerRadius="6" Margin="0,0,5,0" Command="{Binding SaveConfigurationCommand}"/>
@@ -131,52 +121,77 @@
         </Border>
 
         <!-- CENTER: CANVAS -->
-        <ScrollView Grid.Column="1"
-                    x:Name="CanvasScrollView"
-                    Orientation="Both"
-                    HorizontalScrollBarVisibility="Always"
-                    VerticalScrollBarVisibility="Always"
-                    BackgroundColor="#1E1E2E">
-            <Grid x:Name="CanvasWrapper"
-                  WidthRequest="{Binding CanvasWidth}"
-                  HeightRequest="{Binding CanvasHeight}"
-                  BackgroundColor="#1E1E2E">
-                <BoxView Color="#232330" Opacity="0.5"/>
+        <Grid Grid.Column="1">
+            <ScrollView
+                x:Name="CanvasScrollView"
+                Orientation="Both"
+                HorizontalScrollBarVisibility="Always"
+                VerticalScrollBarVisibility="Always"
+                BackgroundColor="#1E1E2E">
+                <Grid x:Name="CanvasWrapper"
+                      WidthRequest="{Binding CanvasWidth}"
+                      HeightRequest="{Binding CanvasHeight}"
+                      BackgroundColor="#1E1E2E">
+                    <BoxView Color="#232330" Opacity="0.5"/>
 
-                <!-- Dotted background grid -->
-                <skia:SKCanvasView x:Name="GridCanvas"
-                                   PaintSurface="OnGridPaintSurface"
-                                   InputTransparent="True"
-                                   IgnorePixelScaling="True" />
+                    <!-- Dotted background grid -->
+                    <skia:SKCanvasView x:Name="GridCanvas"
+                                       PaintSurface="OnGridPaintSurface"
+                                       InputTransparent="True"
+                                       IgnorePixelScaling="True" />
 
-                <!-- SkiaSharp Layer: Touch Enabled -->
-                <skia:SKCanvasView x:Name="ConnectionsCanvas"
-                                   PaintSurface="OnCanvasPaintSurface"
-                                   EnableTouchEvents="True"
-                                   Touch="OnCanvasTouch"
-                                   IgnorePixelScaling="True"
-                                   InputTransparent="False" />
+                    <!-- SkiaSharp Layer: Touch Enabled -->
+                    <skia:SKCanvasView x:Name="ConnectionsCanvas"
+                                       PaintSurface="OnCanvasPaintSurface"
+                                       EnableTouchEvents="True"
+                                       Touch="OnCanvasTouch"
+                                       IgnorePixelScaling="True"
+                                       InputTransparent="False" />
 
-                <!-- Container for blocks -->
-                <!-- Allow the canvas below to receive touches for box selection while keeping blocks interactive. -->
-                <AbsoluteLayout x:Name="NodeContainer"
-                                BackgroundColor="Transparent"
-                                InputTransparent="True"
-                                WidthRequest="{Binding CanvasWidth}"
-                                HeightRequest="{Binding CanvasHeight}">
-                </AbsoluteLayout>
+                    <!-- Container for blocks -->
+                    <!-- Allow the canvas below to receive touches for box selection while keeping blocks interactive. -->
+                    <AbsoluteLayout x:Name="NodeContainer"
+                                    BackgroundColor="Transparent"
+                                    InputTransparent="True"
+                                    WidthRequest="{Binding CanvasWidth}"
+                                    HeightRequest="{Binding CanvasHeight}">
+                    </AbsoluteLayout>
 
-                <!-- Selection Rectangle Overlay (New) -->
-                <BoxView x:Name="SelectionBox"
-                         Color="#4CC9F0"
-                         Opacity="0.2"
-                         InputTransparent="True"
-                         IsVisible="False"
-                         HorizontalOptions="Start"
-                         VerticalOptions="Start"/>
+                    <!-- Selection Rectangle Overlay (New) -->
+                    <BoxView x:Name="SelectionBox"
+                             Color="#4CC9F0"
+                             Opacity="0.2"
+                             InputTransparent="True"
+                             IsVisible="False"
+                             HorizontalOptions="Start"
+                             VerticalOptions="Start"/>
 
-            </Grid>
-        </ScrollView>
+                </Grid>
+            </ScrollView>
+
+            <!-- Floating grid + zoom controls -->
+            <Border HorizontalOptions="End"
+                    VerticalOptions="Start"
+                    Margin="0,12,12,0"
+                    Padding="10"
+                    BackgroundColor="#2A2A3A"
+                    Stroke="#444"
+                    StrokeShape="RoundRectangle 8"
+                    Opacity="0.95"
+                    WidthRequest="220">
+                <VerticalStackLayout Spacing="8">
+                    <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="6">
+                        <Button Text="-" BackgroundColor="#444" TextColor="#CCC" HeightRequest="36" CornerRadius="6" WidthRequest="40" Command="{Binding DecreaseGridSpacingCommand}"/>
+                        <Label Grid.Column="1" Text="{Binding GridSpacing, StringFormat='{}Grid: {0:0} px'}" VerticalTextAlignment="Center" TextColor="{StaticResource TextMain}" FontSize="13" HorizontalOptions="Center" />
+                        <Button Grid.Column="2" Text="+" BackgroundColor="#444" TextColor="#CCC" HeightRequest="36" CornerRadius="6" WidthRequest="40" Command="{Binding IncreaseGridSpacingCommand}"/>
+                    </Grid>
+                    <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                        <Button Text="Zoom -" BackgroundColor="#353543" TextColor="#DDD" HeightRequest="36" CornerRadius="6" Clicked="OnZoomOutClicked"/>
+                        <Button Grid.Column="1" Text="Zoom +" BackgroundColor="#353543" TextColor="#DDD" HeightRequest="36" CornerRadius="6" Clicked="OnZoomInClicked"/>
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+        </Grid>
 
         <!-- RIGHT SIDE: PROPERTIES -->
         <Border Grid.Column="2" BackgroundColor="{StaticResource BgPanel}" StrokeThickness="0" Padding="20">
@@ -194,6 +209,25 @@
             <StackLayout BindableLayout.ItemsSource="{Binding SelectedBlock.Parameters}"
                          BindableLayout.ItemTemplateSelector="{StaticResource ParameterTemplateSelector}" Spacing="18" />
         </VerticalStackLayout>
+
+                        <VerticalStackLayout IsVisible="{Binding SelectedBlock, Converter={StaticResource IsNotNullConverter}}" Spacing="10">
+                            <BoxView HeightRequest="1" Color="#444" />
+                            <Label Text="Appearance" FontSize="12" TextColor="{StaticResource TextMuted}" FontAttributes="Bold" />
+                            <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="8">
+                                <VerticalStackLayout Grid.Row="0" Grid.Column="0" Spacing="4">
+                                    <Label Text="Width" FontSize="12" TextColor="{StaticResource TextMain}" />
+                                    <Entry Text="{Binding SelectedBlock.Width, Mode=TwoWay}" Keyboard="Numeric" BackgroundColor="{StaticResource InputBg}" TextColor="White" />
+                                </VerticalStackLayout>
+                                <VerticalStackLayout Grid.Row="0" Grid.Column="1" Spacing="4">
+                                    <Label Text="Height" FontSize="12" TextColor="{StaticResource TextMain}" />
+                                    <Entry Text="{Binding SelectedBlock.Height, Mode=TwoWay}" Keyboard="Numeric" BackgroundColor="{StaticResource InputBg}" TextColor="White" />
+                                </VerticalStackLayout>
+                                <VerticalStackLayout Grid.Row="1" Grid.ColumnSpan="2" Spacing="4">
+                                    <Label Text="Font Size" FontSize="12" TextColor="{StaticResource TextMain}" />
+                                    <Entry Text="{Binding SelectedBlock.FontSize, Mode=TwoWay}" Keyboard="Numeric" BackgroundColor="{StaticResource InputBg}" TextColor="White" />
+                                </VerticalStackLayout>
+                            </Grid>
+                        </VerticalStackLayout>
 
                         <!-- Connection Selection (Keep) -->
                         <VerticalStackLayout IsVisible="{Binding SelectedConnection, Converter={StaticResource IsNotNullConverter}}">

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
@@ -36,10 +36,6 @@ namespace ElectricalImpedanceTomography.Views
         private ReconstructionConfigurationBlock? _draggedBlock;
         private Point _dragStartPoint;
 
-        // Resizing state for blocks
-        private readonly Dictionary<ReconstructionConfigurationBlock, (double Width, double Height)> _resizeStartSizes = new();
-        private ReconstructionConfigurationBlock? _resizeArmedBlock;
-
         // Canvas panning state for right-click drag
         private bool _isCanvasPanning;
         private Point _canvasPanStart;
@@ -60,11 +56,15 @@ namespace ElectricalImpedanceTomography.Views
         // Enlarged hit-targets for connection interactions to make drawing easier
         private const double OutputPortHitRadius = 40;   // was 16
         private const double TargetPortHitHalfSize = 70; // was 40
-        private const double ResizeHotZone = 36;
         private const double MinBlockWidth = 140;
         private const double MinBlockHeight = 60;
         private const double MaxBlockWidth = 520;
         private const double MaxBlockHeight = 360;
+
+        private const double PortMarginTop = 22;
+        private const double PortSize = 22;
+
+        private readonly HashSet<ReconstructionConfigurationBlock> _subscribedBlocks = new();
 
         private double _canvasScale = 1.0;
         private const double MinCanvasScale = 0.5;
@@ -101,6 +101,17 @@ namespace ElectricalImpedanceTomography.Views
 
         private void OnBlocksChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
+            if (e.OldItems != null)
+            {
+                foreach (var old in e.OldItems.OfType<ReconstructionConfigurationBlock>())
+                {
+                    if (_subscribedBlocks.Remove(old))
+                    {
+                        old.PropertyChanged -= OnBlockPropertyChanged;
+                    }
+                }
+            }
+
             // Re-create visual containers for blocks after any add/remove
             RefreshNodeContainer();
             SnapBlocksToGrid();
@@ -129,9 +140,22 @@ namespace ElectricalImpedanceTomography.Views
             NodeContainer.Children.Clear();
             foreach (var block in _viewModel.Blocks)
             {
+                EnsureBlockSubscription(block);
                 var view = CreateBlockView(block);
                 NodeContainer.Children.Add(view);
             }
+        }
+
+        private void EnsureBlockSubscription(ReconstructionConfigurationBlock block)
+        {
+            if (_subscribedBlocks.Contains(block))
+            {
+                return;
+            }
+
+            _subscribedBlocks.Add(block);
+            block.PropertyChanged += OnBlockPropertyChanged;
+            EnforceBlockSize(block);
         }
 
         private View CreateBlockView(ReconstructionConfigurationBlock block)
@@ -160,7 +184,7 @@ namespace ElectricalImpedanceTomography.Views
             headerGrid.Add(new BoxView { Color = headerColor, WidthRequest = 4, HorizontalOptions = LayoutOptions.Start, VerticalOptions = LayoutOptions.Fill });
             var titleLabel = new Label
             {
-                FontSize = 13,
+                FontSize = block.FontSize,
                 FontAttributes = FontAttributes.Bold,
                 TextColor = Color.FromArgb("#F0F0F0"),
                 VerticalOptions = LayoutOptions.Center,
@@ -168,17 +192,19 @@ namespace ElectricalImpedanceTomography.Views
                 BindingContext = block
             };
             titleLabel.SetBinding(Label.TextProperty, nameof(ReconstructionConfigurationBlock.Title));
+            titleLabel.SetBinding(Label.FontSizeProperty, new Binding(nameof(ReconstructionConfigurationBlock.FontSize), source: block));
             headerGrid.Add(titleLabel);
 
             // Secondary info text (e.g., highlighted option)
             var contentLabel = new Label
             {
-                FontSize = 11,
+                FontSize = block.FontSize,
                 TextColor = Color.FromArgb("#999"),
                 Margin = 10,
                 BindingContext = block
             };
             contentLabel.SetBinding(Label.TextProperty, nameof(ReconstructionConfigurationBlock.HighlightedOption));
+            contentLabel.SetBinding(Label.FontSizeProperty, new Binding(nameof(ReconstructionConfigurationBlock.FontSize), source: block));
 
             mainStack.Add(headerGrid);
             mainStack.Add(contentLabel);
@@ -281,6 +307,29 @@ namespace ElectricalImpedanceTomography.Views
             return container;
         }
 
+        private void OnBlockPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (sender is not ReconstructionConfigurationBlock block)
+            {
+                return;
+            }
+
+            if (e.PropertyName == nameof(ReconstructionConfigurationBlock.Width) ||
+                e.PropertyName == nameof(ReconstructionConfigurationBlock.Height))
+            {
+                EnforceBlockSize(block);
+                UpdateBlockViewLayout(block);
+                ConnectionsCanvas.InvalidateSurface();
+                _viewModel.NotifyLayoutChanged();
+            }
+            else if (e.PropertyName == nameof(ReconstructionConfigurationBlock.X) ||
+                     e.PropertyName == nameof(ReconstructionConfigurationBlock.Y))
+            {
+                UpdateBlockViewLayout(block);
+                ConnectionsCanvas.InvalidateSurface();
+            }
+        }
+
         /// <summary>
         /// Handles double-tap on a block card. If the block is the Initialization block,
         /// opens a popup to edit the initial conductivity distribution.
@@ -288,14 +337,6 @@ namespace ElectricalImpedanceTomography.Views
         private async Task OnBlockDoubleTappedAsync(ReconstructionConfigurationBlock block, TappedEventArgs tapArgs, View? sourceView)
         {
             var position = sourceView != null ? tapArgs.GetPosition(sourceView) : null;
-            if (position.HasValue && IsInResizeHotZone(block, position.Value))
-            {
-                ArmResize(block);
-                return;
-            }
-
-            _resizeArmedBlock = null;
-
             // Only Initialization blocks support this editor
             if (block.Type != BlockType.Initialization)
                 return;
@@ -333,26 +374,10 @@ namespace ElectricalImpedanceTomography.Views
             switch (e.StatusType)
             {
                 case GestureStatus.Started:
-                    if (_resizeArmedBlock == block)
-                    {
-                        _resizeStartSizes[block] = (block.Width, block.Height);
-                        break;
-                    }
-                    _resizeArmedBlock = null;
                     // Capture starting positions for selected blocks
                     PrepareDragPositions(block);
                     break;
                 case GestureStatus.Running:
-                    if (_resizeArmedBlock == block)
-                    {
-                        if (_resizeStartSizes.TryGetValue(block, out var startSize))
-                        {
-                            UpdateBlockSize(block,
-                                startSize.Width + e.TotalX / _canvasScale,
-                                startSize.Height + e.TotalY / _canvasScale);
-                        }
-                        break;
-                    }
                     // Apply delta to every moved block
                     foreach (var kvp in _dragStartPositions)
                     {
@@ -366,13 +391,6 @@ namespace ElectricalImpedanceTomography.Views
                     break;
                 case GestureStatus.Completed:
                 case GestureStatus.Canceled:
-                    if (_resizeArmedBlock == block)
-                    {
-                        _resizeArmedBlock = null;
-                        _resizeStartSizes.Remove(block);
-                        _viewModel.NotifyLayoutChanged();
-                        break;
-                    }
                     // Clear temp state and notify ViewModel so it can update workspace/state
                     _dragStartPositions.Clear();
                     _viewModel.NotifyLayoutChanged();
@@ -418,29 +436,6 @@ namespace ElectricalImpedanceTomography.Views
             }
         }
 
-        /// <summary>
-        /// Resizes a block while enforcing minimum size. Updates visual bounds and redraws connections.
-        /// </summary>
-        private void UpdateBlockSize(ReconstructionConfigurationBlock block, double newWidth, double newHeight)
-        {
-            var clampedWidth = Math.Clamp(SnapToGrid(newWidth), MinBlockWidth, MaxBlockWidth);
-            var clampedHeight = Math.Clamp(SnapToGrid(newHeight), MinBlockHeight, MaxBlockHeight);
-
-            block.Width = clampedWidth;
-            block.Height = clampedHeight;
-
-            var view = NodeContainer.Children
-                .OfType<View>()
-                .FirstOrDefault(c => ReferenceEquals(c.BindingContext, block));
-
-            if (view != null)
-            {
-                ApplyBlockLayout(block, view);
-            }
-
-            ConnectionsCanvas.InvalidateSurface();
-        }
-
         private double SnapToGrid(double value)
         {
             var spacing = _viewModel.GridSpacing;
@@ -458,22 +453,32 @@ namespace ElectricalImpedanceTomography.Views
             {
                 block.X = SnapToGrid(block.X);
                 block.Y = SnapToGrid(block.Y);
-                block.Width = Math.Clamp(SnapToGrid(block.Width), MinBlockWidth, MaxBlockWidth);
-                block.Height = Math.Clamp(SnapToGrid(block.Height), MinBlockHeight, MaxBlockHeight);
+                EnforceBlockSize(block);
 
-                var view = NodeContainer.Children
-                    .OfType<View>()
-                    .FirstOrDefault(c => ReferenceEquals(c.BindingContext, block));
-
-                if (view != null)
-                {
-                    ApplyBlockLayout(block, view);
-                }
+                UpdateBlockViewLayout(block);
             }
 
             ConnectionsCanvas.InvalidateSurface();
             GridCanvas.InvalidateSurface();
             _viewModel.NotifyLayoutChanged();
+        }
+
+        private void EnforceBlockSize(ReconstructionConfigurationBlock block)
+        {
+            block.Width = Math.Clamp(block.Width, MinBlockWidth, MaxBlockWidth);
+            block.Height = Math.Clamp(block.Height, MinBlockHeight, MaxBlockHeight);
+        }
+
+        private void UpdateBlockViewLayout(ReconstructionConfigurationBlock block)
+        {
+            var view = NodeContainer.Children
+                .OfType<View>()
+                .FirstOrDefault(c => ReferenceEquals(c.BindingContext, block));
+
+            if (view != null)
+            {
+                ApplyBlockLayout(block, view);
+            }
         }
 
         private void ApplyBlockLayout(ReconstructionConfigurationBlock block, View view)
@@ -867,36 +872,23 @@ namespace ElectricalImpedanceTomography.Views
             return Math.Sqrt(dx * dx + dy * dy);
         }
 
-        private bool IsInResizeHotZone(ReconstructionConfigurationBlock block, Point tapPosition)
+        private double GetPortCenterY(ReconstructionConfigurationBlock block)
         {
-            var logicalX = tapPosition.X / _canvasScale;
-            var logicalY = tapPosition.Y / _canvasScale;
-
-            return logicalX >= block.Width - ResizeHotZone && logicalY >= block.Height - ResizeHotZone;
+            var desiredCenter = PortMarginTop + (PortSize * 0.5);
+            return Math.Min(block.Height - PortSize * 0.5, desiredCenter);
         }
-
-        private void ArmResize(ReconstructionConfigurationBlock block)
-        {
-            _resizeArmedBlock = block;
-            _resizeStartSizes[block] = (block.Width, block.Height);
-        }
-
-        /// <summary>
-        /// Vertical offset of port location (40% down from top edge).
-        /// </summary>
-        private static double GetPortOffsetY(ReconstructionConfigurationBlock block) => block.Height * 0.4;
 
         /// <summary>
         /// Left-side input port center in view coordinates.
         /// </summary>
-        private static Point GetInputPortAnchor(ReconstructionConfigurationBlock block)
-            => new(block.X, block.Y + GetPortOffsetY(block));
+        private Point GetInputPortAnchor(ReconstructionConfigurationBlock block)
+            => new(block.X, block.Y + GetPortCenterY(block));
 
         /// <summary>
         /// Right-side output port center in view coordinates.
         /// </summary>
-        private static Point GetOutputPortAnchor(ReconstructionConfigurationBlock block)
-            => new(block.X + block.Width, block.Y + GetPortOffsetY(block));
+        private Point GetOutputPortAnchor(ReconstructionConfigurationBlock block)
+            => new(block.X + block.Width, block.Y + GetPortCenterY(block));
 
         /// <summary>
         /// Attempts to select a connection by clicking near the geometric midpoint of its curve.

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
@@ -28,6 +28,7 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
             double x,
             double y,
             string? id = null,
+            double fontSize = 13,
             double width = 214,
             double height = 80,
             double rotation = 0)
@@ -44,6 +45,7 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                 x,
                 y,
                 parameters,
+                fontSize,
                 width,
                 height,
                 rotation);

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionConfigurationBlock.cs
@@ -23,6 +23,7 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
             double x,
             double y,
             IEnumerable<ConfigurationParameter> parameters,
+            double fontSize = 13,
             double width = 214,
             double height = 80,
             double rotation = 0)
@@ -33,6 +34,7 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
             IconColor = iconColor;
             X = x;
             Y = y;
+            FontSize = fontSize;
             Width = width;
             Height = height;
             Rotation = rotation;
@@ -101,6 +103,12 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
         /// Visual height of the block on the canvas.
         /// </summary>
         public double Height { get => _height; set => SetProperty(ref _height, value); }
+
+        private double _fontSize = 13;
+        /// <summary>
+        /// Font size used for block labels.
+        /// </summary>
+        public double FontSize { get => _fontSize; set => SetProperty(ref _fontSize, value); }
 
         private double _rotation;
         /// <summary>


### PR DESCRIPTION
## Summary
- move grid spacing and zoom controls into a floating overlay on the reconstruction canvas
- add appearance controls for block size and font, persisting them through save/load
- clamp block sizing independently from grid spacing and anchor connection drawing to port centers

## Testing
- dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj -clp:Summary *(fails: dotnet CLI unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257f072cfc8333943553489ec80047)