### PR TITLE
Improve weight handling in reconstruction configuration

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -1,8 +1,12 @@
+/// \file ReconstructionConfigurationPageViewModel.cs
+/// \brief ViewModel responsible for orchestrating the reconstruction configuration canvas state.
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
+using System.Collections.Specialized;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Text.Json;
 using Utility.Classes.Application;
@@ -54,6 +58,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         public const double MinGridSpacing = 12;
         public const double MaxGridSpacing = 96;
         private const double DefaultGridSpacing = 32;
+        private bool _isNormalizingWeights;
 
         public ReconstructionConfigurationPageViewModel()
         {
@@ -74,7 +79,15 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             ApplyConfigurationToWorkspace();
             Blocks.CollectionChanged += (_, __) => UpdateDiagnostics();
-            Connections.CollectionChanged += (_, __) => UpdateDiagnostics();
+            Connections.CollectionChanged += OnConnectionsCollectionChanged;
+
+            foreach (var connection in Connections)
+            {
+                RegisterConnection(connection);
+            }
+
+            NormalizeConnectionWeights();
+            UpdateDiagnostics();
         }
 
         /// <summary>
@@ -441,26 +454,80 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public void NotifyLayoutChanged() => ApplyConfigurationToWorkspace();
 
-        private void UpdateConnectionWeightRequirements()
+        /// <summary>
+        /// Keeps connection subscriptions and normalized weights in sync when the graph changes.
+        /// </summary>
+        private void OnConnectionsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            bool multiError = Blocks.Count(b => b.Type == BlockType.ErrorMetric) >= 2;
-            bool multiRegularizer = Blocks.Count(b => b.Type == BlockType.Regularizer) >= 2;
-            bool multiOptimizer = Blocks.Count(b => b.Type == BlockType.Optimizer) >= 2;
-
-            foreach (var connection in Connections)
+            if (e.OldItems != null)
             {
-                bool requires =
-                    (multiError && (connection.Source.Type == BlockType.ErrorMetric || connection.Target.Type == BlockType.ErrorMetric)) ||
-                    (multiRegularizer && (connection.Source.Type == BlockType.Regularizer || connection.Target.Type == BlockType.Regularizer)) ||
-                    (multiOptimizer && (connection.Source.Type == BlockType.Optimizer || connection.Target.Type == BlockType.Optimizer));
+                foreach (var old in e.OldItems.OfType<ReconstructionConnection>())
+                {
+                    UnregisterConnection(old);
+                }
+            }
 
-                connection.RequiresWeight = requires;
+            if (e.NewItems != null)
+            {
+                foreach (var added in e.NewItems.OfType<ReconstructionConnection>())
+                {
+                    RegisterConnection(added);
+                }
+            }
+
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                foreach (var connection in Connections)
+                {
+                    UnregisterConnection(connection);
+                }
+
+                foreach (var connection in Connections)
+                {
+                    RegisterConnection(connection);
+                }
+            }
+
+            NormalizeConnectionWeights();
+            UpdateDiagnostics();
+        }
+
+        /// <summary>
+        /// Hooks property change notifications for a connection to react to weight edits.
+        /// </summary>
+        private void RegisterConnection(ReconstructionConnection connection)
+        {
+            connection.PropertyChanged -= OnConnectionPropertyChanged;
+            connection.PropertyChanged += OnConnectionPropertyChanged;
+        }
+
+        /// <summary>
+        /// Removes property change subscriptions when a connection is removed from the canvas.
+        /// </summary>
+        private void UnregisterConnection(ReconstructionConnection connection)
+        {
+            connection.PropertyChanged -= OnConnectionPropertyChanged;
+        }
+
+        /// <summary>
+        /// Rebalances connection weights when a weight edit occurs from the UI.
+        /// </summary>
+        private void OnConnectionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(ReconstructionConnection.Weight))
+            {
+                if (_isNormalizingWeights)
+                {
+                    return;
+                }
+
+                NormalizeConnectionWeights();
+                ApplyConfigurationToWorkspace();
             }
         }
 
         private void UpdateDiagnostics()
         {
-            UpdateConnectionWeightRequirements();
             DebugLines.Clear();
             var blockSummary = string.Join(", ", Blocks
                 .GroupBy(b => b.Type)
@@ -497,6 +564,114 @@ namespace ElectricalImpedanceTomography.ViewModels
             if (!ValidationIssues.Contains(message))
             {
                 ValidationIssues.Add(message);
+            }
+        }
+
+        /// <summary>
+        /// Normalizes solver->error, error->regularizer, and optimizer->model weights so each compatible set sums to one.
+        /// Connections that are not meant to be weighted (e.g., measurement->error) are forced back to unity and disabled in the UI.
+        /// </summary>
+        private void NormalizeConnectionWeights()
+        {
+            if (_isNormalizingWeights)
+            {
+                return;
+            }
+
+            try
+            {
+                _isNormalizingWeights = true;
+
+                foreach (var connection in Connections)
+                {
+                    connection.RequiresWeight = false;
+                }
+
+                foreach (var connection in Connections.Where(c => c.Source.Type == BlockType.Measurement && c.Target.Type == BlockType.ErrorMetric))
+                {
+                    connection.Weight = 1.0;
+                }
+
+                foreach (var group in Connections
+                    .Where(c => c.Source.Type == BlockType.Solver && c.Target.Type == BlockType.ErrorMetric)
+                    .GroupBy(c => c.Target))
+                {
+                    foreach (var connection in group)
+                    {
+                        connection.RequiresWeight = true;
+                    }
+
+                    NormalizeConnectionGroup(group);
+                }
+
+                foreach (var group in Connections
+                    .Where(c => c.Source.Type == BlockType.ErrorMetric && c.Target.Type == BlockType.Regularizer)
+                    .GroupBy(c => c.Source))
+                {
+                    foreach (var connection in group)
+                    {
+                        connection.RequiresWeight = true;
+                    }
+
+                    NormalizeConnectionGroup(group);
+                }
+
+                foreach (var group in Connections
+                    .Where(c => c.Source.Type == BlockType.Optimizer && c.Target.Type == BlockType.Model)
+                    .GroupBy(c => c.Target))
+                {
+                    foreach (var connection in group)
+                    {
+                        connection.RequiresWeight = true;
+                    }
+
+                    NormalizeConnectionGroup(group);
+                }
+            }
+            finally
+            {
+                _isNormalizingWeights = false;
+            }
+        }
+
+        /// <summary>
+        /// Rescales a specific connection group to sum to one while keeping larger weights proportionally closer to their requested values.
+        /// </summary>
+        private void NormalizeConnectionGroup(IEnumerable<ReconstructionConnection> connections)
+        {
+            var groupList = connections.ToList();
+
+            if (!groupList.Any())
+            {
+                return;
+            }
+
+            var total = groupList.Sum(c => c.Weight);
+
+            if (total <= 0)
+            {
+                var even = Math.Round(1.0 / groupList.Count, 4);
+                foreach (var connection in groupList)
+                {
+                    connection.Weight = even;
+                }
+                return;
+            }
+
+            var ordered = groupList.OrderByDescending(c => c.Weight).ToList();
+            var remaining = 1.0;
+
+            foreach (var connection in ordered)
+            {
+                var portion = connection.Weight / total;
+                var adjusted = Math.Min(remaining, portion);
+                connection.Weight = adjusted;
+                remaining -= connection.Weight;
+            }
+
+            if (remaining > 0 && ordered.Any())
+            {
+                ordered.First().Weight = ordered.First().Weight + remaining;
             }
         }
 

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
@@ -225,8 +225,18 @@
                             <Label Text="Press 'Delete Selected' to remove." FontSize="12" TextColor="#888" HorizontalOptions="Center"/>
                             <VerticalStackLayout Spacing="6" Margin="0,8,0,0">
                                 <Label Text="Weight" FontSize="14" TextColor="{StaticResource TextMain}" HorizontalOptions="Center"/>
-                                <Slider Minimum="0" Maximum="1" Value="{Binding SelectedConnection.Weight, Mode=TwoWay}" ThumbColor="{StaticResource Accent}" MinimumTrackColor="{StaticResource Accent}" StepFrequency="0.0001"/>
-                                <Label Text="{Binding SelectedConnection.Weight, StringFormat='{}{0:0.0000}'}" FontSize="12" TextColor="{StaticResource TextMuted}" HorizontalOptions="Center"/>
+                                <Slider Minimum="0" Maximum="1" Value="{Binding SelectedConnection.Weight, Mode=TwoWay}" ThumbColor="{StaticResource Accent}" MinimumTrackColor="{StaticResource Accent}" StepFrequency="0.0001" IsEnabled="{Binding SelectedConnection.RequiresWeight}"/>
+                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                                    <Label Grid.Column="0" Text="{Binding SelectedConnection.Weight, StringFormat='{}{0:0.0000}'}" FontSize="12" TextColor="{StaticResource TextMuted}" HorizontalOptions="Start"/>
+                                    <Entry Grid.Column="1"
+                                           WidthRequest="120"
+                                           HorizontalTextAlignment="Center"
+                                           TextColor="{StaticResource TextMain}"
+                                           BackgroundColor="{StaticResource InputBg}"
+                                           Keyboard="Numeric"
+                                           IsEnabled="{Binding SelectedConnection.RequiresWeight}"
+                                           Text="{Binding SelectedConnection.Weight, Mode=TwoWay}" />
+                                </Grid>
                                 <Label Text="Weight required when combining similar blocks." FontSize="11" TextColor="#F0AD4E" HorizontalOptions="Center" IsVisible="{Binding SelectedConnection.RequiresWeight}"/>
                             </VerticalStackLayout>
                         </VerticalStackLayout>

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml.cs
@@ -1,3 +1,5 @@
+/// \file ReconstructionConfigurationPage.xaml.cs
+/// \brief Interactive canvas and control logic for the reconstruction configuration editor UI.
 using CommunityToolkit.Maui.Views;
 using ElectricalImpedanceTomography.ViewModels;
 using Microsoft.Maui.Controls.Shapes;
@@ -1170,7 +1172,7 @@ namespace ElectricalImpedanceTomography.Views
 
         /// <summary>
         /// Paints all committed connections and any temporary connection being dragged.
-        /// Adds style variations for selection and weight requirements.
+        /// Adds style variations for selection and weight requirements and positions weight labels beside the path for clarity.
         /// </summary>
         private void OnCanvasPaintSurface(object sender, SKPaintSurfaceEventArgs e)
         {
@@ -1201,7 +1203,7 @@ namespace ElectricalImpedanceTomography.Views
             using var weightPaint = new SKPaint
             {
                 Style = SKPaintStyle.Stroke,
-                Color = SKColors.Yellow,
+                Color = SKColor.Parse("#4CC9F0"),
                 StrokeWidth = 4,
                 IsAntialias = true,
                 StrokeCap = SKStrokeCap.Round
@@ -1234,7 +1236,7 @@ namespace ElectricalImpedanceTomography.Views
                     var label = $"{conn.Weight:0.####}";
                     using var textPaint = new SKPaint
                     {
-                        Color = SKColors.White,
+                        Color = SKColor.Parse("#A6E3FA"),
                         IsAntialias = true,
                         TextSize = 16,
                         Typeface = SKTypeface.FromFamilyName("Arial", SKFontStyle.Bold)
@@ -1243,7 +1245,14 @@ namespace ElectricalImpedanceTomography.Views
                     var midPoint = EvaluateCubic(curve, 0.5);
                     var textBounds = new SKRect();
                     textPaint.MeasureText(label, ref textBounds);
-                    canvas.DrawText(label, midPoint.X - textBounds.MidX, midPoint.Y - textBounds.MidY, textPaint);
+
+                    var isHorizontal = Math.Abs(curve.p3.X - curve.p0.X) >= Math.Abs(curve.p3.Y - curve.p0.Y);
+                    var offset = isHorizontal
+                        ? new SKPoint(0, -Math.Max(10, textBounds.Height))
+                        : new SKPoint(Math.Max(10, textBounds.Width * 0.6f), 0);
+
+                    var labelPosition = new SKPoint(midPoint.X + offset.X - textBounds.MidX, midPoint.Y + offset.Y - textBounds.MidY);
+                    canvas.DrawText(label, labelPosition.X, labelPosition.Y, textPaint);
                 }
             }
 

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/Rules/ReconstructionConfigurationRules.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/Rules/ReconstructionConfigurationRules.cs
@@ -134,14 +134,6 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration.Rules
                 }
             }
 
-            foreach (var connection in connections.Where(c => c.RequiresWeight))
-            {
-                if (connection.Weight <= 0)
-                {
-                    issues.Add($"Set a positive weight for connection {connection.Source.Title} -> {connection.Target.Title}.");
-                }
-            }
-
             foreach (var errorMetric in blocks.Where(b => b.Type == BlockType.ErrorMetric))
             {
                 var hasMeasurement = connections.Any(c => c.Target == errorMetric && c.Source.Type == BlockType.Measurement);


### PR DESCRIPTION
## Summary
- add numeric weight entry and disable weight controls when a connection is not weighted
- normalize solver-to-error, error-to-regularizer, and optimizer-to-model weights so each group sums to 1 without validation errors
- refresh weight label styling/placement and extend documentation for the reconstruction configuration page and view model

## Testing
- `dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj` *(fails: dotnet SDK not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a9456e00833394a206834c619830)