### PR TITLE
Enhance reconstruction configuration capture

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -419,6 +419,14 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
         }
 
+        [RelayCommand]
+        public void UseConfiguration()
+        {
+            var configuration = CompleteReconstructionConfigurationBuilder.Create(Blocks, Connections);
+            Workspace.SetCompleteReconstructionConfiguration(configuration);
+            ApplyConfigurationToWorkspace();
+        }
+
         private void ApplyConfigurationToWorkspace()
         {
             ReconstructionBlockRegistry.ApplyBlocksToWorkspace(Blocks);
@@ -521,8 +529,21 @@ namespace ElectricalImpedanceTomography.ViewModels
                     return;
                 }
 
-                NormalizeConnectionWeights();
-                ApplyConfigurationToWorkspace();
+                if (sender is ReconstructionConnection connection)
+                {
+                    try
+                    {
+                        _isNormalizingWeights = true;
+                        RebalanceWeightGroup(connection);
+                    }
+                    finally
+                    {
+                        _isNormalizingWeights = false;
+                    }
+
+                    NormalizeConnectionWeights(false);
+                    ApplyConfigurationToWorkspace();
+                }
             }
         }
 
@@ -568,10 +589,10 @@ namespace ElectricalImpedanceTomography.ViewModels
         }
 
         /// <summary>
-        /// Normalizes solver->error, error->regularizer, and optimizer->model weights so each compatible set sums to one.
+        /// Normalizes solver->error, error->regularizer, optimizer input, and optimizer->model weights so each compatible set sums to one.
         /// Connections that are not meant to be weighted (e.g., measurement->error) are forced back to unity and disabled in the UI.
         /// </summary>
-        private void NormalizeConnectionWeights()
+        private void NormalizeConnectionWeights(bool redistributeGroups = true)
         {
             if (_isNormalizingWeights)
             {
@@ -592,40 +613,17 @@ namespace ElectricalImpedanceTomography.ViewModels
                     connection.Weight = 1.0;
                 }
 
-                foreach (var group in Connections
-                    .Where(c => c.Source.Type == BlockType.Solver && c.Target.Type == BlockType.ErrorMetric)
-                    .GroupBy(c => c.Target))
+                foreach (var group in GetWeightedConnectionGroups())
                 {
                     foreach (var connection in group)
                     {
                         connection.RequiresWeight = true;
                     }
 
-                    NormalizeConnectionGroup(group);
-                }
-
-                foreach (var group in Connections
-                    .Where(c => c.Source.Type == BlockType.ErrorMetric && c.Target.Type == BlockType.Regularizer)
-                    .GroupBy(c => c.Source))
-                {
-                    foreach (var connection in group)
+                    if (redistributeGroups)
                     {
-                        connection.RequiresWeight = true;
+                        NormalizeConnectionGroup(group);
                     }
-
-                    NormalizeConnectionGroup(group);
-                }
-
-                foreach (var group in Connections
-                    .Where(c => c.Source.Type == BlockType.Optimizer && c.Target.Type == BlockType.Model)
-                    .GroupBy(c => c.Target))
-                {
-                    foreach (var connection in group)
-                    {
-                        connection.RequiresWeight = true;
-                    }
-
-                    NormalizeConnectionGroup(group);
                 }
             }
             finally
@@ -635,44 +633,138 @@ namespace ElectricalImpedanceTomography.ViewModels
         }
 
         /// <summary>
-        /// Rescales a specific connection group to sum to one while keeping larger weights proportionally closer to their requested values.
+        /// Equalizes weights inside a group so the sum equals one and every edge shares the remaining influence evenly.
         /// </summary>
-        private void NormalizeConnectionGroup(IEnumerable<ReconstructionConnection> connections)
+        private void NormalizeConnectionGroup(IReadOnlyCollection<ReconstructionConnection> connections)
         {
-            var groupList = connections.ToList();
-
-            if (!groupList.Any())
+            if (connections.Count == 0)
             {
                 return;
             }
 
-            var total = groupList.Sum(c => c.Weight);
-
-            if (total <= 0)
-            {
-                var even = Math.Round(1.0 / groupList.Count, 4);
-                foreach (var connection in groupList)
-                {
-                    connection.Weight = even;
-                }
-                return;
-            }
-
-            var ordered = groupList.OrderByDescending(c => c.Weight).ToList();
+            var evenWeight = Math.Round(1.0 / connections.Count, 4);
             var remaining = 1.0;
 
-            foreach (var connection in ordered)
+            foreach (var connection in connections.Take(connections.Count - 1))
             {
-                var portion = connection.Weight / total;
-                var adjusted = Math.Min(remaining, portion);
-                connection.Weight = adjusted;
-                remaining -= connection.Weight;
+                connection.Weight = evenWeight;
+                remaining -= evenWeight;
             }
 
-            if (remaining > 0 && ordered.Any())
+            var last = connections.Last();
+            last.Weight = Math.Max(0, Math.Round(remaining, 4));
+        }
+
+        /// <summary>
+        /// Adjusts all other weights in the affected group after the user edits one value so the sum remains one.
+        /// </summary>
+        private void RebalanceWeightGroup(ReconstructionConnection changed)
+        {
+            var group = FindWeightedGroupForConnection(changed);
+
+            if (group.Count == 0)
             {
-                ordered.First().Weight = ordered.First().Weight + remaining;
+                return;
             }
+
+            if (group.Count == 1)
+            {
+                changed.Weight = 1.0;
+                return;
+            }
+
+            var others = group.Where(c => c != changed).ToList();
+            var remainingWeight = Math.Max(0.0, 1.0 - changed.Weight);
+
+            if (!others.Any())
+            {
+                changed.Weight = 1.0;
+                return;
+            }
+
+            var evenShare = Math.Round(remainingWeight / others.Count, 4);
+            double allocated = 0.0;
+
+            for (int i = 0; i < others.Count; i++)
+            {
+                var targetWeight = i == others.Count - 1
+                    ? Math.Max(0, Math.Round(remainingWeight - allocated, 4))
+                    : evenShare;
+                others[i].Weight = targetWeight;
+                allocated += targetWeight;
+            }
+
+            // Fix rounding drift to guarantee a clean sum of one.
+            var sum = changed.Weight + others.Sum(c => c.Weight);
+            if (others.Any() && Math.Abs(1.0 - sum) > 0.0001)
+            {
+                var correction = Math.Round(1.0 - sum, 4);
+                others.Last().Weight = Math.Max(0, Math.Round(others.Last().Weight + correction, 4));
+            }
+        }
+
+        private List<ReconstructionConnection> FindWeightedGroupForConnection(ReconstructionConnection connection)
+        {
+            if (connection.Source.Type == BlockType.Solver && connection.Target.Type == BlockType.ErrorMetric)
+            {
+                return Connections
+                    .Where(c => c.Source.Type == BlockType.Solver && c.Target == connection.Target)
+                    .ToList();
+            }
+
+            if (connection.Source.Type == BlockType.ErrorMetric && connection.Target.Type == BlockType.Regularizer)
+            {
+                return Connections
+                    .Where(c => c.Source == connection.Source && c.Target.Type == BlockType.Regularizer)
+                    .ToList();
+            }
+
+            if (connection.Target.Type == BlockType.Optimizer &&
+                (connection.Source.Type == BlockType.ErrorMetric || connection.Source.Type == BlockType.Regularizer))
+            {
+                return Connections
+                    .Where(c => c.Target == connection.Target &&
+                                (c.Source.Type == BlockType.ErrorMetric || c.Source.Type == BlockType.Regularizer))
+                    .ToList();
+            }
+
+            if (connection.Source.Type == BlockType.Optimizer && connection.Target.Type == BlockType.Model)
+            {
+                return Connections
+                    .Where(c => c.Target == connection.Target && c.Source.Type == BlockType.Optimizer)
+                    .ToList();
+            }
+
+            return new List<ReconstructionConnection>();
+        }
+
+        private IEnumerable<IReadOnlyCollection<ReconstructionConnection>> GetWeightedConnectionGroups()
+        {
+            var solverToError = Connections
+                .Where(c => c.Source.Type == BlockType.Solver && c.Target.Type == BlockType.ErrorMetric)
+                .GroupBy(c => c.Target)
+                .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
+
+            var errorToRegularizer = Connections
+                .Where(c => c.Source.Type == BlockType.ErrorMetric && c.Target.Type == BlockType.Regularizer)
+                .GroupBy(c => c.Source)
+                .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
+
+            var optimizerInputs = Connections
+                .Where(c => c.Target.Type == BlockType.Optimizer &&
+                            (c.Source.Type == BlockType.ErrorMetric || c.Source.Type == BlockType.Regularizer))
+                .GroupBy(c => c.Target)
+                .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
+
+            var optimizerToModel = Connections
+                .Where(c => c.Source.Type == BlockType.Optimizer && c.Target.Type == BlockType.Model)
+                .GroupBy(c => c.Target)
+                .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
+
+            return solverToError
+                .Concat(errorToRegularizer)
+                .Concat(optimizerInputs)
+                .Concat(optimizerToModel);
         }
 
         partial void OnGridSpacingChanged(double value)

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
@@ -122,6 +122,15 @@
 
         <!-- CENTER: CANVAS -->
         <Grid Grid.Column="1">
+            <Button Text="Use this configuration"
+                    HorizontalOptions="Start"
+                    VerticalOptions="Start"
+                    Margin="12"
+                    Padding="14,8"
+                    BackgroundColor="{StaticResource Accent}"
+                    TextColor="Black"
+                    FontAttributes="Bold"
+                    Command="{Binding UseConfigurationCommand}" />
             <ScrollView
                 x:Name="CanvasScrollView"
                 Orientation="Both"

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -32,6 +32,7 @@ namespace Utility.Classes.Application
         private static List<ReconstructionResult> _reconstructionResults = [];
         private static List<ReconstructionFrame> _reconstructionFrames = [];
         private static List<ReconstructionConfigurationBlock> _reconstructionBlocks = [];
+        private static CompleteReconstructionConfiguration? _completeReconstructionConfiguration;
         private static List<WorkspaceMessage> _messages = [];
         private static ConductivityDistribution? _originalConductivityDistribution = null;
         private static ConductivityDistribution? _initialConductivityDistribution = null;
@@ -86,6 +87,8 @@ namespace Utility.Classes.Application
         public static void SetReconstructionResults(List<ReconstructionResult> results) => _reconstructionResults = results;
         public static void SetReconstructionFrames(List<ReconstructionFrame> frames) => _reconstructionFrames = frames;
         public static void SetReconstructionBlocks(List<ReconstructionConfigurationBlock> blocks) => _reconstructionBlocks = blocks;
+        public static void SetCompleteReconstructionConfiguration(CompleteReconstructionConfiguration? configuration)
+            => _completeReconstructionConfiguration = configuration;
         public static void SetOriginalConductivityDistribution(ConductivityDistribution? sigma) => _originalConductivityDistribution = sigma;
         public static void SetInitialConductivityDistribution(ConductivityDistribution? sigma) => _initialConductivityDistribution = sigma;
 
@@ -97,6 +100,7 @@ namespace Utility.Classes.Application
         public static List<ReconstructionResult> GetReconstructionResults() => _reconstructionResults;
         public static List<ReconstructionFrame> GetReconstructionFrames() => _reconstructionFrames;
         public static IReadOnlyList<ReconstructionConfigurationBlock> GetReconstructionBlocks() => _reconstructionBlocks;
+        public static CompleteReconstructionConfiguration? GetCompleteReconstructionConfiguration() => _completeReconstructionConfiguration;
         public static ConductivityDistribution? GetOriginalConductivityDistribution() => _originalConductivityDistribution;
         public static ConductivityDistribution? GetInitialConductivityDistribution() => _initialConductivityDistribution;
 

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/CompleteReconstructionConfiguration.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/CompleteReconstructionConfiguration.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Utility.Classes.Configurations.ReconstructionConfiguration
+{
+    /// <summary>
+    /// Immutable snapshot of the entire reconstruction canvas configuration.
+    /// Captures blocks, their parameters, and all relevant weighted links so the
+    /// description can be passed to the runtime reconstruction pipeline.
+    /// </summary>
+    public class CompleteReconstructionConfiguration
+    {
+        public CompleteReconstructionConfiguration(
+            IReadOnlyList<ConfiguredBlockSnapshot> blocks,
+            IReadOnlyList<WeightedConnectionSnapshot> allConnections,
+            IReadOnlyList<WeightedConnectionSnapshot> solverToErrorMetricWeights,
+            IReadOnlyList<WeightedConnectionSnapshot> errorMetricToRegularizerWeights,
+            IReadOnlyList<WeightedConnectionSnapshot> optimizerInputWeights,
+            IReadOnlyList<WeightedConnectionSnapshot> optimizerToModelWeights)
+        {
+            Blocks = blocks;
+            AllConnections = allConnections;
+            SolverToErrorMetricWeights = solverToErrorMetricWeights;
+            ErrorMetricToRegularizerWeights = errorMetricToRegularizerWeights;
+            OptimizerInputWeights = optimizerInputWeights;
+            OptimizerToModelWeights = optimizerToModelWeights;
+            CapturedAtUtc = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Complete set of configured blocks, including their parameters and layout metadata.
+        /// </summary>
+        public IReadOnlyList<ConfiguredBlockSnapshot> Blocks { get; }
+
+        /// <summary>
+        /// Every connection on the canvas with its persisted weight for auditing/debugging.
+        /// </summary>
+        public IReadOnlyList<WeightedConnectionSnapshot> AllConnections { get; }
+
+        /// <summary>
+        /// Weights applied from solver blocks into error metrics.
+        /// </summary>
+        public IReadOnlyList<WeightedConnectionSnapshot> SolverToErrorMetricWeights { get; }
+
+        /// <summary>
+        /// Weights mapping an error metric into its regularizers.
+        /// </summary>
+        public IReadOnlyList<WeightedConnectionSnapshot> ErrorMetricToRegularizerWeights { get; }
+
+        /// <summary>
+        /// Combined weights feeding each optimizer (from error metrics and regularizers).
+        /// </summary>
+        public IReadOnlyList<WeightedConnectionSnapshot> OptimizerInputWeights { get; }
+
+        /// <summary>
+        /// Weights applied from optimizers into the model block.
+        /// </summary>
+        public IReadOnlyList<WeightedConnectionSnapshot> OptimizerToModelWeights { get; }
+
+        /// <summary>
+        /// Timestamp describing when this snapshot was produced.
+        /// </summary>
+        public DateTime CapturedAtUtc { get; }
+    }
+
+    /// <summary>
+    /// Lightweight DTO capturing a single block configuration and its parameters.
+    /// </summary>
+    public record ConfiguredBlockSnapshot(
+        string Id,
+        BlockType Type,
+        string Title,
+        double X,
+        double Y,
+        double Width,
+        double Height,
+        double Rotation,
+        IReadOnlyList<BlockParameterSnapshot> Parameters);
+
+    /// <summary>
+    /// Serialized representation of a parameter for later reconstruction.
+    /// </summary>
+    public record BlockParameterSnapshot(string Key, string Name, string Value);
+
+    /// <summary>
+    /// Captures the directional and weighted characteristics of a connection.
+    /// </summary>
+    public record WeightedConnectionSnapshot(
+        string SourceId,
+        string TargetId,
+        BlockType SourceType,
+        BlockType TargetType,
+        double Weight);
+
+    /// <summary>
+    /// Utility class that translates the live canvas graph into a portable configuration snapshot.
+    /// </summary>
+    public static class CompleteReconstructionConfigurationBuilder
+    {
+        /// <summary>
+        /// Creates a full reconstruction description from the current blocks and connections.
+        /// </summary>
+        public static CompleteReconstructionConfiguration Create(
+            IEnumerable<ReconstructionConfigurationBlock> blocks,
+            IEnumerable<ReconstructionConnection> connections)
+        {
+            var blockSnapshots = blocks
+                .Select(b => new ConfiguredBlockSnapshot(
+                    b.Id,
+                    b.Type,
+                    b.Title,
+                    b.X,
+                    b.Y,
+                    b.Width,
+                    b.Height,
+                    b.Rotation,
+                    b.Parameters
+                        .Select(p => new BlockParameterSnapshot(p.Key, p.Name, GetParameterValue(p)))
+                        .ToList()))
+                .ToList();
+
+            var connectionSnapshots = connections
+                .Select(c => new WeightedConnectionSnapshot(
+                    c.Source.Id,
+                    c.Target.Id,
+                    c.Source.Type,
+                    c.Target.Type,
+                    c.Weight))
+                .ToList();
+
+            var solverToErrorWeights = connectionSnapshots
+                .Where(c => c.SourceType == BlockType.Solver && c.TargetType == BlockType.ErrorMetric)
+                .ToList();
+
+            var errorToRegularizerWeights = connectionSnapshots
+                .Where(c => c.SourceType == BlockType.ErrorMetric && c.TargetType == BlockType.Regularizer)
+                .ToList();
+
+            var optimizerInputWeights = connectionSnapshots
+                .Where(c => c.TargetType == BlockType.Optimizer &&
+                            (c.SourceType == BlockType.ErrorMetric || c.SourceType == BlockType.Regularizer))
+                .ToList();
+
+            var optimizerToModelWeights = connectionSnapshots
+                .Where(c => c.SourceType == BlockType.Optimizer && c.TargetType == BlockType.Model)
+                .ToList();
+
+            return new CompleteReconstructionConfiguration(
+                blockSnapshots,
+                connectionSnapshots,
+                solverToErrorWeights,
+                errorToRegularizerWeights,
+                optimizerInputWeights,
+                optimizerToModelWeights);
+        }
+
+        private static string GetParameterValue(ConfigurationParameter parameter) => parameter switch
+        {
+            TextParameter text => text.Value,
+            NumberParameter number => number.Value.ToString(),
+            BoolParameter toggle => toggle.Value.ToString(),
+            ChoiceParameter choice => choice.SelectedOption,
+            _ => string.Empty
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add a complete reconstruction configuration snapshot builder and persist it in the workspace
- expose a "Use this configuration" action in the canvas to capture configured blocks and weights
- rebalance connection weights for optimizers, error metrics, and regularizers while keeping sums normalized and editable

## Testing
- dotnet build (fails: dotnet CLI is unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b53185b0833391613f612e06413a)