### PR TITLE
Enforce regularizer configuration constraints

### DIFF
--- a/BusinessLayer/ReconstructionConfigurationMaterializer.cs
+++ b/BusinessLayer/ReconstructionConfigurationMaterializer.cs
@@ -77,7 +77,7 @@ namespace BusinessLayer
                 .Where(b => b.Type == BlockType.Regularizer)
                 .Select(block =>
                 {
-                    double weight = configuration.ErrorMetricToRegularizerWeights
+                    double weight = configuration.ModelToRegularizerWeights
                         .Where(c => c.TargetId == block.Id)
                         .Sum(c => c.Weight);
                     weight = weight == 0 ? 1.0 : weight;

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -46,6 +46,9 @@ namespace ElectricalImpedanceTomography.ViewModels
         [ObservableProperty]
         private bool isConnectionMode;
 
+        [ObservableProperty]
+        private bool canUseConfiguration;
+
         public ObservableCollection<string> DebugLines { get; } = new();
 
         public ObservableCollection<string> ValidationIssues { get; } = new();
@@ -108,6 +111,12 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public void AddBlock(BlockType type, double x, double y)
         {
+            if (type == BlockType.Model && Blocks.Any(b => b.Type == BlockType.Model))
+            {
+                TrackIssue("Only one Model block can be added to the configuration.");
+                return;
+            }
+
             var newBlock = ReconstructionBlockRegistry.CreateBlock(type, x, y);
             RegisterBlock(newBlock);
             Blocks.Add(newBlock);
@@ -420,6 +429,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         }
 
         [RelayCommand]
+        [RelayCommand(CanExecute = nameof(CanUseConfiguration))]
         public void UseConfiguration()
         {
             var configuration = CompleteReconstructionConfigurationBuilder.Create(Blocks, Connections);
@@ -461,6 +471,11 @@ namespace ElectricalImpedanceTomography.ViewModels
         }
 
         public void NotifyLayoutChanged() => ApplyConfigurationToWorkspace();
+
+        partial void OnCanUseConfigurationChanged(bool value)
+        {
+            UseConfigurationCommand.NotifyCanExecuteChanged();
+        }
 
         /// <summary>
         /// Keeps connection subscriptions and normalized weights in sync when the graph changes.
@@ -578,6 +593,8 @@ namespace ElectricalImpedanceTomography.ViewModels
             {
                 ValidationIssues.Add(issue);
             }
+
+            CanUseConfiguration = !ValidationIssues.Any();
         }
 
         private void TrackIssue(string message)
@@ -712,7 +729,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                     .ToList();
             }
 
-            if (connection.Source.Type == BlockType.ErrorMetric && connection.Target.Type == BlockType.Regularizer)
+            if (connection.Source.Type == BlockType.Model && connection.Target.Type == BlockType.Regularizer)
             {
                 return Connections
                     .Where(c => c.Source == connection.Source && c.Target.Type == BlockType.Regularizer)
@@ -745,8 +762,8 @@ namespace ElectricalImpedanceTomography.ViewModels
                 .GroupBy(c => c.Target)
                 .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
 
-            var errorToRegularizer = Connections
-                .Where(c => c.Source.Type == BlockType.ErrorMetric && c.Target.Type == BlockType.Regularizer)
+            var modelToRegularizer = Connections
+                .Where(c => c.Source.Type == BlockType.Model && c.Target.Type == BlockType.Regularizer)
                 .GroupBy(c => c.Source)
                 .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
 
@@ -762,7 +779,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                 .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
 
             return solverToError
-                .Concat(errorToRegularizer)
+                .Concat(modelToRegularizer)
                 .Concat(optimizerInputs)
                 .Concat(optimizerToModel);
         }

--- a/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionConfigurationPage.xaml
@@ -118,7 +118,8 @@
                                 BackgroundColor="{StaticResource Accent}"
                                 TextColor="Black"
                                 FontAttributes="Bold"
-                                Command="{Binding UseConfigurationCommand}" />
+                                Command="{Binding UseConfigurationCommand}"
+                                IsEnabled="{Binding CanUseConfiguration}" />
                         <Button Text="Delete Selected" BackgroundColor="#FF4757" TextColor="White" HeightRequest="40" CornerRadius="6" Command="{Binding DeleteSelectedCommand}"/>
                     <Grid ColumnDefinitions="*,*">
                         <Button Grid.Column="0" Text="Save" BackgroundColor="#2E8B57" TextColor="White" HeightRequest="40" CornerRadius="6" Margin="0,0,5,0" Command="{Binding SaveConfigurationCommand}"/>

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/CompleteReconstructionConfiguration.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/CompleteReconstructionConfiguration.cs
@@ -15,14 +15,14 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
             IReadOnlyList<ConfiguredBlockSnapshot> blocks,
             IReadOnlyList<WeightedConnectionSnapshot> allConnections,
             IReadOnlyList<WeightedConnectionSnapshot> solverToErrorMetricWeights,
-            IReadOnlyList<WeightedConnectionSnapshot> errorMetricToRegularizerWeights,
+            IReadOnlyList<WeightedConnectionSnapshot> modelToRegularizerWeights,
             IReadOnlyList<WeightedConnectionSnapshot> optimizerInputWeights,
             IReadOnlyList<WeightedConnectionSnapshot> optimizerToModelWeights)
         {
             Blocks = blocks;
             AllConnections = allConnections;
             SolverToErrorMetricWeights = solverToErrorMetricWeights;
-            ErrorMetricToRegularizerWeights = errorMetricToRegularizerWeights;
+            ModelToRegularizerWeights = modelToRegularizerWeights;
             OptimizerInputWeights = optimizerInputWeights;
             OptimizerToModelWeights = optimizerToModelWeights;
             CapturedAtUtc = DateTime.UtcNow;
@@ -44,9 +44,9 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
         public IReadOnlyList<WeightedConnectionSnapshot> SolverToErrorMetricWeights { get; }
 
         /// <summary>
-        /// Weights mapping an error metric into its regularizers.
+        /// Weights mapping the Model block into its regularizers.
         /// </summary>
-        public IReadOnlyList<WeightedConnectionSnapshot> ErrorMetricToRegularizerWeights { get; }
+        public IReadOnlyList<WeightedConnectionSnapshot> ModelToRegularizerWeights { get; }
 
         /// <summary>
         /// Combined weights feeding each optimizer (from error metrics and regularizers).
@@ -133,8 +133,8 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                 .Where(c => c.SourceType == BlockType.Solver && c.TargetType == BlockType.ErrorMetric)
                 .ToList();
 
-            var errorToRegularizerWeights = connectionSnapshots
-                .Where(c => c.SourceType == BlockType.ErrorMetric && c.TargetType == BlockType.Regularizer)
+            var modelToRegularizerWeights = connectionSnapshots
+                .Where(c => c.SourceType == BlockType.Model && c.TargetType == BlockType.Regularizer)
                 .ToList();
 
             var optimizerInputWeights = connectionSnapshots
@@ -150,7 +150,7 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                 blockSnapshots,
                 connectionSnapshots,
                 solverToErrorWeights,
-                errorToRegularizerWeights,
+                modelToRegularizerWeights,
                 optimizerInputWeights,
                 optimizerToModelWeights);
         }

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/Rules/ReconstructionConfigurationRules.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/Rules/ReconstructionConfigurationRules.cs
@@ -57,15 +57,21 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration.Rules
                 return false;
             }
 
-            if (target == BlockType.Regularizer && source != BlockType.ErrorMetric)
+            if (target == BlockType.Regularizer && source != BlockType.Model)
             {
-                reason = "Regularizer inputs must come from an Error Metric block.";
+                reason = "Regularizer inputs must come from the Model block.";
                 return false;
             }
 
             if (source == BlockType.Optimizer && target != BlockType.Model)
             {
                 reason = "Optimizer outputs must connect into the Model block.";
+                return false;
+            }
+
+            if (source == BlockType.Regularizer && target != BlockType.Optimizer)
+            {
+                reason = "Regularizer outputs must connect into an Optimizer block.";
                 return false;
             }
 
@@ -149,12 +155,33 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration.Rules
                 }
             }
 
+            foreach (var regularizer in blocks.Where(b => b.Type == BlockType.Regularizer))
+            {
+                var hasModelInput = connections.Any(c => c.Target == regularizer && c.Source.Type == BlockType.Model);
+                if (!hasModelInput)
+                {
+                    issues.Add($"Regularizer '{regularizer.Title}' must be connected to the Model block.");
+                }
+
+                var hasOptimizerOutput = connections.Any(c => c.Source == regularizer && c.Target.Type == BlockType.Optimizer);
+                if (!hasOptimizerOutput)
+                {
+                    issues.Add($"Regularizer '{regularizer.Title}' must feed into an Optimizer block.");
+                }
+            }
+
             foreach (var type in Enum.GetValues<BlockType>().Where(t => t != BlockType.PostProcessing && t != BlockType.Regularizer))
             {
                 if (!blocks.Any(b => b.Type == type))
                 {
                     issues.Add($"Add at least one {type} block to the configuration.");
                 }
+            }
+
+            var modelCount = blocks.Count(b => b.Type == BlockType.Model);
+            if (modelCount > 1)
+            {
+                issues.Add("Only one Model block is allowed in the configuration.");
             }
 
             var discretization = Workspace.GetDiscretization();


### PR DESCRIPTION
## Summary
- enforce model-to-regularizer-to-optimizer connection constraints and single model limitation in reconstruction rules
- update configuration materialization, builder, and UI to honor the new regularizer flow and disable configuration usage until valid
- normalize connection weighting groups to reflect the updated block relationships

## Testing
- ⚠️ `dotnet build ElectricalImpedanceTomography.sln` *(unavailable: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925e7a30f948333bc15703608e04bb5)