### PR TITLE
Fix solver-error weights and preserve export color mode

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -724,7 +724,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             if (connection.Source.Type == BlockType.Solver && connection.Target.Type == BlockType.ErrorMetric)
             {
                 return Connections
-                    .Where(c => c.Source.Type == BlockType.Solver && c.Target == connection.Target)
+                    .Where(c => c.Source == connection.Source && c.Target.Type == BlockType.ErrorMetric)
                     .ToList();
             }
 
@@ -758,7 +758,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             var solverToError = Connections
                 .Where(c => c.Source.Type == BlockType.Solver && c.Target.Type == BlockType.ErrorMetric)
-                .GroupBy(c => c.Target)
+                .GroupBy(c => c.Source)
                 .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
 
             var modelToRegularizer = Connections

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -48,6 +48,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         private bool _updatingDrivePatternSelection;
         private EITReconstructionParameters? _trackedParameters;
         private MeasurementSourceOption _selectedMeasurementSource = Workspace.GetMeasurementSource();
+        private PotentialDisplayMode _selectedDisplayMode = PotentialDisplayMode.Default;
 
         public VirtualElectrodeSettings VirtualElectrodeSettings => ReconstructionParameters.VirtualElectrodeSettings;
 
@@ -1614,7 +1615,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             ResetVideoExportState();
 
-            _ = mode;
+            _selectedDisplayMode = mode;
 
             _videoExportDistributionSize = ReconstructionVideoRenderer.NormalizeSize(distributionCanvasSize, 250, 250);
             _videoExportColorbarSize = ReconstructionVideoRenderer.NormalizeSize(colorbarCanvasSize, 250, 20);
@@ -1648,6 +1649,8 @@ namespace ElectricalImpedanceTomography.ViewModels
                                                                             IProgress<VideoExportProgressReport>? progress = null,
                                                                             CancellationToken cancellationToken = default)
         {
+            _selectedDisplayMode = mode;
+
             var frames = Workspace.GetReconstructionFrames().ToList();
             if (frames.Count == 0)
                 return VideoExportResult.CreateFailure("No Frames", "There are no reconstruction frames to export.");
@@ -1717,14 +1720,14 @@ namespace ElectricalImpedanceTomography.ViewModels
                                 : residualHistory.Count;
 
                             using var image = ReconstructionVideoRenderer.RenderFrameSnapshot(frames[i],
-                                                                                               context,
-                                                                                               fallbackDiscretization,
-                                                                                               residualHistory,
-                                                                                               residualCount,
-                                                                                               distributionSize,
-                                                                                               colorbarSize,
-                                                                                               residualSize,
-                                                                                               mode);
+                                                                                                 context,
+                                                                                                 fallbackDiscretization,
+                                                                                                 residualHistory,
+                                                                                                 residualCount,
+                                                                                                 distributionSize,
+                                                                                                 colorbarSize,
+                                                                                                 residualSize,
+                                                                                                 _selectedDisplayMode);
 
                             if (videoWidth == 0 || videoHeight == 0)
                             {
@@ -1885,7 +1888,8 @@ namespace ElectricalImpedanceTomography.ViewModels
         public Task<DataExportResult> ExportReconstructionDataAsync(PotentialDisplayMode mode)
         {
             string rootDirectory = FileSystem.Current.AppDataDirectory;
-            return _exportService.ExportAsync(rootDirectory, mode);
+            _selectedDisplayMode = mode;
+            return _exportService.ExportAsync(rootDirectory, _selectedDisplayMode);
         }
 
         private static DistributionMetrics? ComputeInitialDistributionMetrics(ReconstructionResult snapshot)


### PR DESCRIPTION
## Summary
- rebalance solver-to-error metric connection weights per solver so they normalize correctly
- track the selected potential display mode for exports to ensure video and data outputs use the user’s coloring

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925ec89197c8333b3860ad0f52ef72e)