### PR TITLE
Add Gaussian smoothing controls for LBM reconstruction potentials

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -135,11 +135,14 @@ namespace BusinessLayer
                 }
 
                 // Create differential equation solver according to discretization and requested backend
+                int lbmKernelSize = Math.Max(1, parameters.LbmGaussianFilterSize);
                 _differentialEquationSolver = DifferentialEquationSolverFactory.Create(discretization,
-                                                                                      parameters.DifferentialEquationSolver,
-                                                                                      _numericSolver,
-                                                                                      _useOmpParallelization,
-                                                                                      _useCudaParallelization);
+                                                                                       parameters.DifferentialEquationSolver,
+                                                                                       _numericSolver,
+                                                                                       _useOmpParallelization,
+                                                                                       _useCudaParallelization,
+                                                                                       parameters.UseLbmGaussianFilter,
+                                                                                       lbmKernelSize);
                 _regularizer = RegularizationFactory.Create(parameters.RegularizationTechnique, _discretization);
                 _errorMetricChoice = parameters.ErrorMetric;
                 _errorMetric = ErrorMetricFactory.Create(_errorMetricChoice);

--- a/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
@@ -38,11 +38,14 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public bool IsNoiseAmplitudeEnabled => ReconstructionParameters.MeasurementNoiseType != MeasurementNoiseType.None;
 
+        public bool IsLbmSolverSelected => ReconstructionParameters.DifferentialEquationSolver == DifferentialEquationSolver.LBM;
+
         public BaseReconstructionPageViewModel()
         {
             _currentParameters = ReconstructionParameters;
             _currentParameters.PropertyChanged += OnReconstructionParametersPropertyChanged;
             OnPropertyChanged(nameof(IsNoiseAmplitudeEnabled));
+            OnPropertyChanged(nameof(IsLbmSolverSelected));
             Workspace.ConductivityMinimumBound = _currentParameters.ConductivityMinimumBound;
             Workspace.ConductivityMaximumBound = _currentParameters.ConductivityMaximumBound;
             ConductivityClipper.UpdateBounds(_currentParameters.ConductivityMinimumBound,
@@ -59,12 +62,16 @@ namespace ElectricalImpedanceTomography.ViewModels
             _currentParameters = value;
             _currentParameters.PropertyChanged += OnReconstructionParametersPropertyChanged;
             OnPropertyChanged(nameof(IsNoiseAmplitudeEnabled));
+            OnPropertyChanged(nameof(IsLbmSolverSelected));
         }
 
         private void OnReconstructionParametersPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             if (e.PropertyName == nameof(EITReconstructionParameters.MeasurementNoiseType))
                 OnPropertyChanged(nameof(IsNoiseAmplitudeEnabled));
+
+            if (e.PropertyName == nameof(EITReconstructionParameters.DifferentialEquationSolver))
+                OnPropertyChanged(nameof(IsLbmSolverSelected));
 
             if (e.PropertyName == nameof(EITReconstructionParameters.ConductivityMinimumBound)
                 || e.PropertyName == nameof(EITReconstructionParameters.ConductivityMaximumBound))

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -185,7 +185,7 @@
                         <Border Grid.Column="1"
                                 Style="{StaticResource PanelSectionBorderStyle}"
                                 BackgroundColor="{AppThemeBinding Light=#25324A, Dark=#25324A}">
-                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
+                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
                                 <Label Grid.Row="0" Text="Parameters" FontSize="Medium" FontAttributes="Bold" Margin="0,0,0,12"/>
                                 <Label Grid.Row="3" HorizontalOptions="Start" Text="Max Iteration Count" FontFamily="SF Pro Text" FontAttributes="None"/>
                                 <Entry Grid.Row="4" Text="{Binding MaxIterationCount}"/>
@@ -219,17 +219,38 @@
 
                                 <Label Grid.Row="15"
                                        HorizontalOptions="Start"
+                                       Text="LBM Potential Smoothing"
+                                       FontFamily="SF Pro Text"
+                                       FontAttributes="None"
+                                       IsVisible="{Binding IsLbmSolverSelected}"/>
+                                <Grid Grid.Row="16" ColumnDefinitions="*,Auto" ColumnSpacing="8"
+                                      IsVisible="{Binding IsLbmSolverSelected}">
+                                    <Label Text="Apply Gaussian filter (kernel size fixed on this page)"
+                                           VerticalOptions="Center"
+                                           FontFamily="SF Pro Text"/>
+                                    <Switch Grid.Column="1"
+                                            IsToggled="{Binding ReconstructionParameters.UseLbmGaussianFilter}"
+                                            HorizontalOptions="End"/>
+                                </Grid>
+                                <Label Grid.Row="17"
+                                       HorizontalOptions="Start"
+                                       Text="{Binding ReconstructionParameters.LbmGaussianFilterSize, StringFormat='Kernel size: {0}x{0}'}"
+                                       FontFamily="SF Pro Text"
+                                       IsVisible="{Binding IsLbmSolverSelected}"/>
+
+                                <Label Grid.Row="18"
+                                       HorizontalOptions="Start"
                                        Text="Virtual Electrode Method"
                                        FontFamily="SF Pro Text"
                                        FontAttributes="None"
                                        IsVisible="{Binding VirtualElectrodeSettings.UseVirtualElectrodes}"/>
-                                <Picker Grid.Row="16"
+                                <Picker Grid.Row="19"
                                         ItemsSource="{Binding VirtualElectrodeMethods}"
                                         SelectedItem="{Binding VirtualElectrodeSettings.Method}"
                                         IsVisible="{Binding VirtualElectrodeSettings.UseVirtualElectrodes}"
                                         MaximumWidthRequest="150"/>
 
-                                <Grid Grid.Row="17" ColumnDefinitions="Auto,*" ColumnSpacing="8"
+                                <Grid Grid.Row="19" ColumnDefinitions="Auto,*" ColumnSpacing="8"
                                       IsVisible="{Binding IsLinearCombinationMethod}">
                                     <Label Text="Alpha (0..1)"
                                            VerticalOptions="Center"
@@ -240,7 +261,7 @@
                                            HorizontalTextAlignment="End"/>
                                 </Grid>
 
-                                <Grid Grid.Row="17" ColumnDefinitions="Auto,*" ColumnSpacing="8"
+                                <Grid Grid.Row="19" ColumnDefinitions="Auto,*" ColumnSpacing="8"
                                       IsVisible="{Binding IsHarrachMethod}">
                                     <Label Text="Harrach λ"
                                            VerticalOptions="Center"
@@ -251,7 +272,7 @@
                                            HorizontalTextAlignment="End"/>
                                 </Grid>
 
-                                <Grid Grid.Row="17" ColumnDefinitions="Auto,*" ColumnSpacing="8"
+                                <Grid Grid.Row="19" ColumnDefinitions="Auto,*" ColumnSpacing="8"
                                       IsVisible="{Binding IsNdMethod}">
                                     <Label Text="ND Max Mode"
                                            VerticalOptions="Center"

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
@@ -339,6 +339,24 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                         IsVisible = solverChoice.SelectedOption == FriendlyName(nameof(DifferentialEquationSolver.LBM))
                     };
 
+                    var lbmGaussianFilter = new BoolParameter
+                    {
+                        Name = "Gaussian Filter Potential",
+                        Key = "lbm_gaussian_filter",
+                        Value = false,
+                        IsVisible = solverChoice.SelectedOption == FriendlyName(nameof(DifferentialEquationSolver.LBM))
+                    };
+
+                    var lbmGaussianKernel = new NumberParameter
+                    {
+                        Name = "Gaussian Kernel Size",
+                        Key = "lbm_gaussian_kernel",
+                        Value = 3,
+                        Min = 1,
+                        Step = 2,
+                        IsVisible = solverChoice.SelectedOption == FriendlyName(nameof(DifferentialEquationSolver.LBM))
+                    };
+
                     solverChoice.PropertyChanged += (_, args) =>
                     {
                         if (args.PropertyName == nameof(ChoiceParameter.SelectedOption))
@@ -347,6 +365,8 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                             femOrder.IsVisible = isFem;
                             lbmDomainSize.IsVisible = !isFem;
                             lbmRelaxation.IsVisible = !isFem;
+                            lbmGaussianFilter.IsVisible = !isFem;
+                            lbmGaussianKernel.IsVisible = !isFem;
                         }
                     };
 
@@ -362,7 +382,9 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                         },
                         femOrder,
                         lbmDomainSize,
-                        lbmRelaxation
+                        lbmRelaxation,
+                        lbmGaussianFilter,
+                        lbmGaussianKernel
                     };
                 },
                 (block, target) =>
@@ -376,6 +398,15 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                     target.LbmPhysicalDomainSize = block.Parameters.OfType<NumberParameter>().FirstOrDefault(p => p.Key == "lbm_domain_size")?.Value
                         ?? target.LbmPhysicalDomainSize;
                     target.LbmRelaxationModel = ParseEnumFromChoice<LatticeBoltzmannRelaxationModel>(block, "lbm_relaxation");
+
+                    var gaussianToggle = block.Parameters.OfType<BoolParameter>().FirstOrDefault(p => p.Key == "lbm_gaussian_filter")?.Value ?? target.UseLbmGaussianFilter;
+                    var gaussianSizeRaw = block.Parameters.OfType<NumberParameter>().FirstOrDefault(p => p.Key == "lbm_gaussian_kernel")?.Value ?? target.LbmGaussianFilterSize;
+                    int gaussianSize = (int)Math.Max(1, gaussianSizeRaw);
+                    if (gaussianSize % 2 == 0)
+                        gaussianSize += 1;
+
+                    target.UseLbmGaussianFilter = gaussianToggle;
+                    target.LbmGaussianFilterSize = gaussianSize;
                 });
 
             yield return new ReconstructionBlockDefinition(

--- a/Utility/Classes/Factories/DifferentialEquationSolverFactory.cs
+++ b/Utility/Classes/Factories/DifferentialEquationSolverFactory.cs
@@ -16,10 +16,12 @@ namespace Utility.Classes.Factories
                                                          DifferentialEquationSolver des,
                                                          INumericSolver numericSolver,
                                                          bool useOmpParallelization = false,
-                                                         bool useCudaAcceleration = false) => des switch
+                                                         bool useCudaAcceleration = false,
+                                                         bool useLbmPotentialFilter = false,
+                                                         int lbmGaussianKernelSize = 3) => des switch
         {
             DifferentialEquationSolver.FEM => CreateFiniteElementSolver((FEMMesh)discretization, numericSolver, useOmpParallelization),
-            DifferentialEquationSolver.LBM => CreateLatticeBoltzmannSolver(useCudaAcceleration),
+            DifferentialEquationSolver.LBM => CreateLatticeBoltzmannSolver(useCudaAcceleration, useLbmPotentialFilter, lbmGaussianKernelSize),
             DifferentialEquationSolver.Graph => CreateGraphBasedSolver((FEMMesh)discretization, numericSolver),
             _ => throw new NotSupportedException()
         };
@@ -33,9 +35,11 @@ namespace Utility.Classes.Factories
             return deSolver;
         }
 
-        private static LatticeBoltzmannDESolver CreateLatticeBoltzmannSolver(bool useCudaAcceleration)
+        private static LatticeBoltzmannDESolver CreateLatticeBoltzmannSolver(bool useCudaAcceleration, bool useLbmPotentialFilter, int lbmGaussianKernelSize)
         {
-            var deSolver = new LatticeBoltzmannDESolver(useCudaAcceleration: useCudaAcceleration);
+            var deSolver = new LatticeBoltzmannDESolver(useCudaAcceleration: useCudaAcceleration,
+                                                        applyGaussianFilter: useLbmPotentialFilter,
+                                                        gaussianFilterSize: lbmGaussianKernelSize);
 
             Workspace.AddLogMessage("DifferentialEquationSolverFactory", "Created Lattice Boltzmann solver object.");
 

--- a/Utility/Classes/Reconstruction/DESolvers/LatticeBoltzmannDESolver.cs
+++ b/Utility/Classes/Reconstruction/DESolvers/LatticeBoltzmannDESolver.cs
@@ -17,14 +17,21 @@ namespace Utility.Classes.Reconstruction.DESolvers
         public LatticeBoltzmannDESolver(int maxIterations = 2000,
                                         double convergenceThreshold = 1e-7,
                                         int checkInterval = 200,
-                                        bool useCudaAcceleration = false)
+                                        bool useCudaAcceleration = false,
+                                        bool applyGaussianFilter = false,
+                                        int gaussianFilterSize = 3)
         {
             _maxIterations = maxIterations;
             _convergenceThreshold = convergenceThreshold;
             _checkInterval = checkInterval;
             _useCuda = useCudaAcceleration;
 
-            _solver = new LatticeBoltzmannSolver(_maxIterations, _convergenceThreshold, _checkInterval, _useCuda);
+            _solver = new LatticeBoltzmannSolver(_maxIterations,
+                                                 _convergenceThreshold,
+                                                 _checkInterval,
+                                                 _useCuda,
+                                                 applyGaussianFilter,
+                                                 gaussianFilterSize);
         }
 
         public PotentialDistribution Solve(IDiscretization discretization, BoundaryCondition bc, Complex[]? adjointSource)

--- a/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
+++ b/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
@@ -50,6 +50,12 @@ namespace Utility.Classes.ReconstructionParameters
         private bool useCudaAcceleration = false;
 
         [ObservableProperty]
+        private bool useLbmGaussianFilter = false;
+
+        [ObservableProperty]
+        private int lbmGaussianFilterSize = 3;
+
+        [ObservableProperty]
         private double conductivityMinimumBound = 0.1;
 
         [ObservableProperty]

--- a/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
+++ b/Utility/Classes/Solvers/LatticeBoltzmannSolver/LatticeBoltzmannSolver.cs
@@ -24,6 +24,8 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
         private double SolutionTolerance = 1e-8;               // Convergence tolerance for steady-state detection
         private int ConvergenceCheckFrequency = 100;           // How often to check convergence (computational cost)
         private readonly bool _useCuda;                        // Whether to use GPU acceleration
+        private readonly bool _applyGaussianFilter;            // Smooth potential maps with Gaussian kernel
+        private readonly int _gaussianKernelSize;              // Kernel size (odd) for Gaussian smoothing
 
         // LBM stability constants
         private const double TauSafetyEpsilon = 0.02;          // Keep τ safely away from 0.5 to limit anisotropy
@@ -136,12 +138,19 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
         /// <param name="solutionTolerance">Relative change threshold for convergence</param>
         /// <param name="convergenceCheckFrequency">Iteration interval for convergence testing</param>
         /// <param name="useCuda">Enable GPU acceleration if available</param>
-        public LatticeBoltzmannSolver(int maxIterationCount, double solutionTolerance, int convergenceCheckFrequency, bool useCuda = false)
+        public LatticeBoltzmannSolver(int maxIterationCount,
+                                      double solutionTolerance,
+                                      int convergenceCheckFrequency,
+                                      bool useCuda = false,
+                                      bool applyGaussianFilter = false,
+                                      int gaussianFilterSize = 3)
         {
             MaxIterationCount = maxIterationCount;
             SolutionTolerance = solutionTolerance;
             ConvergenceCheckFrequency = convergenceCheckFrequency;
             _useCuda = useCuda;
+            _applyGaussianFilter = applyGaussianFilter;
+            _gaussianKernelSize = EnsureOddKernel(Math.Max(1, gaussianFilterSize));
         }
 
         /// <summary>
@@ -158,6 +167,33 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             return Math.Max(0.0, conductivity);
         }
 
+        private static int EnsureOddKernel(int size) => size % 2 == 0 ? size + 1 : size;
+
+        private static double[] BuildBinomialKernel(int size)
+        {
+            int n = size - 1;
+            double[] coeffs = new double[size];
+
+            for (int k = 0; k < size; k++)
+                coeffs[k] = BinomialCoefficient(n, k);
+
+            return coeffs;
+        }
+
+        private static double BinomialCoefficient(int n, int k)
+        {
+            k = Math.Min(k, n - k);
+            double result = 1.0;
+
+            for (int i = 1; i <= k; i++)
+            {
+                result *= n - (k - i);
+                result /= i;
+            }
+
+            return result;
+        }
+
         /// <summary>
         /// Computes BGK relaxation time from material conductivity and clamps it for stability.
         /// </summary>
@@ -170,6 +206,68 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
             // Enforce minimum relaxation time to prevent numerical instability
             // Values below 0.5 can cause negative distribution functions
             return tau < MinTau ? MinTau : tau;
+        }
+
+        private Dictionary<int, double> ApplyPotentialFilter(LBMGrid lbmGrid, Dictionary<int, double> potentials)
+        {
+            if (!_applyGaussianFilter)
+                return potentials;
+
+            return ApplyGaussianFilter(lbmGrid, potentials);
+        }
+
+        private Dictionary<int, double> ApplyGaussianFilter(LBMGrid lbmGrid, IReadOnlyDictionary<int, double> potentials)
+        {
+            var kernel1D = BuildBinomialKernel(_gaussianKernelSize);
+            int half = _gaussianKernelSize / 2;
+            var filtered = new Dictionary<int, double>(potentials.Count);
+
+            for (int y = 0; y < lbmGrid.Ny; y++)
+            {
+                for (int x = 0; x < lbmGrid.Nx; x++)
+                {
+                    var element = lbmGrid.GetElementAt(x, y);
+                    double original = potentials.TryGetValue(element.Id, out double value) ? value : 0.0;
+
+                    if (element.IsWall || element.GhostElement)
+                    {
+                        filtered[element.Id] = original;
+                        continue;
+                    }
+
+                    double weightedSum = 0.0;
+                    double weightTotal = 0.0;
+
+                    for (int ky = -half; ky <= half; ky++)
+                    {
+                        int ny = y + ky;
+                        if (ny < 0 || ny >= lbmGrid.Ny)
+                            continue;
+
+                        for (int kx = -half; kx <= half; kx++)
+                        {
+                            int nx = x + kx;
+                            if (nx < 0 || nx >= lbmGrid.Nx)
+                                continue;
+
+                            var neighbor = lbmGrid.GetElementAt(nx, ny);
+                            if (neighbor.IsWall || neighbor.GhostElement)
+                                continue;
+
+                            if (!potentials.TryGetValue(neighbor.Id, out double neighborValue))
+                                continue;
+
+                            double weight = kernel1D[kx + half] * kernel1D[ky + half];
+                            weightedSum += weight * neighborValue;
+                            weightTotal += weight;
+                        }
+                    }
+
+                    filtered[element.Id] = weightTotal > 0.0 ? weightedSum / weightTotal : original;
+                }
+            }
+
+            return filtered;
         }
 
         /// <summary>
@@ -597,7 +695,8 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 result[elements[idx].Id] = value;
             }
 
-            var pd = new PotentialDistribution(result);
+            var filtered = ApplyPotentialFilter(lbmGrid, result);
+            var pd = new PotentialDistribution(filtered);
             lbmGrid.SetPotentialDistribution(pd);
             return pd;
         }
@@ -973,7 +1072,8 @@ namespace Utility.Classes.Solvers.LatticeBoltzmannSolver
                 result[elementIds[idx]] = phiValue - gauge;
             }
 
-            var pd = new PotentialDistribution(result);
+            var filtered = ApplyPotentialFilter(lbmGrid, result);
+            var pd = new PotentialDistribution(filtered);
             lbmGrid.SetPotentialDistribution(pd);
             return pd;
         }


### PR DESCRIPTION
## Summary
- add Gaussian smoothing parameters for LBM solvers, including configuration block options for enabling the filter and choosing kernel size
- apply Gaussian filtering to CPU and CUDA LBM potential outputs based on the new setting
- surface the LBM smoothing toggle and kernel size display on the reconstruction page when the LBM solver is selected

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet CLI not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69270a6914a48333aa728050b1f283d4)