### PR TITLE
Add conductivity smoothing options for LBM reconstructions

### DIFF
--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -56,6 +56,9 @@ namespace BusinessLayer
         private bool _useOmpParallelization = false;        // enable OMP for FEM assembly
         private bool _useCudaParallelization = false;       // enable CUDA in LBM routines
         private bool _usePotentialDifferences = false;      // represent data as sequential potential differences instead of absolute values
+        private bool _useLbmConductivityFilter = false;     // apply smoothing to conductivity updates on LBM grids
+        private int _lbmConductivityFilterInterval = 5;     // iteration cadence for conductivity smoothing
+        private int _lbmGaussianKernelSize = 3;             // shared kernel size for LBM Gaussian filters
         private NumericSolver _numericSolverChoice = NumericSolver.LU;
         private ErrorMetric _errorMetricChoice = ErrorMetric.L2;
 
@@ -135,18 +138,22 @@ namespace BusinessLayer
                 }
 
                 // Create differential equation solver according to discretization and requested backend
-                int lbmKernelSize = Math.Max(1, parameters.LbmGaussianFilterSize);
+                _lbmGaussianKernelSize = (int)Math.Max(1, parameters.LbmGaussianFilterSize);
+                if (_lbmGaussianKernelSize % 2 == 0)
+                    _lbmGaussianKernelSize += 1;
                 _differentialEquationSolver = DifferentialEquationSolverFactory.Create(discretization,
                                                                                        parameters.DifferentialEquationSolver,
                                                                                        _numericSolver,
                                                                                        _useOmpParallelization,
                                                                                        _useCudaParallelization,
                                                                                        parameters.UseLbmGaussianFilter,
-                                                                                       lbmKernelSize);
+                                                                                       _lbmGaussianKernelSize);
                 _regularizer = RegularizationFactory.Create(parameters.RegularizationTechnique, _discretization);
                 _errorMetricChoice = parameters.ErrorMetric;
                 _errorMetric = ErrorMetricFactory.Create(_errorMetricChoice);
                 _initialDistributionType = parameters.InitialDistributionType;
+                _useLbmConductivityFilter = parameters.UseLbmConductivityFilter;
+                _lbmConductivityFilterInterval = Math.Max(1, parameters.LbmConductivityFilterInterval);
 
                 // Initial conductivity distribution; may be provided externally
                 var initSigma = _initialSigma ?? ConductivityDistributionFactory.CreateInitialDistribution(discretization, _initialDistributionType);
@@ -815,6 +822,91 @@ namespace BusinessLayer
                                             frames);
         }
 
+        private ConductivityDistribution ApplyLbmConductivityGaussianFilter(LBMGrid mesh, ConductivityDistribution source)
+        {
+            int kernelSize = _lbmGaussianKernelSize;
+            if (kernelSize % 2 == 0)
+                kernelSize += 1;
+
+            var kernel1D = BuildBinomialKernel(kernelSize);
+            int half = kernelSize / 2;
+
+            var filtered = new Dictionary<int, double>(source.Conductivities.Count);
+
+            for (int y = 0; y < mesh.Ny; y++)
+            {
+                for (int x = 0; x < mesh.Nx; x++)
+                {
+                    var element = mesh.GetElementAt(x, y);
+                    double original = source.GetConductivity(element.Id);
+
+                    if (element.IsWall || element.GhostElement || element.IsElectrode)
+                    {
+                        filtered[element.Id] = original;
+                        continue;
+                    }
+
+                    double weightedSum = 0.0;
+                    double weightTotal = 0.0;
+
+                    for (int dy = -half; dy <= half; dy++)
+                    {
+                        int ny = y + dy;
+                        if (ny < 0 || ny >= mesh.Ny)
+                            continue;
+
+                        double wy = kernel1D[dy + half];
+
+                        for (int dx = -half; dx <= half; dx++)
+                        {
+                            int nx = x + dx;
+                            if (nx < 0 || nx >= mesh.Nx)
+                                continue;
+
+                            double wx = kernel1D[dx + half];
+                            double weight = wx * wy;
+
+                            var neighbor = mesh.GetElementAt(nx, ny);
+                            if (neighbor.IsWall || neighbor.GhostElement || neighbor.IsElectrode)
+                                continue;
+
+                            weightedSum += weight * source.GetConductivity(neighbor.Id);
+                            weightTotal += weight;
+                        }
+                    }
+
+                    filtered[element.Id] = weightTotal > 0 ? weightedSum / weightTotal : original;
+                }
+            }
+
+            return new ConductivityDistribution(filtered);
+        }
+
+        private static double[] BuildBinomialKernel(int size)
+        {
+            int n = size - 1;
+            double[] coeffs = new double[size];
+
+            for (int k = 0; k < size; k++)
+                coeffs[k] = BinomialCoefficient(n, k);
+
+            return coeffs;
+        }
+
+        private static double BinomialCoefficient(int n, int k)
+        {
+            k = Math.Min(k, n - k);
+            double result = 1.0;
+
+            for (int i = 1; i <= k; i++)
+            {
+                result *= n - (k - i);
+                result /= i;
+            }
+
+            return result;
+        }
+
         /// <summary>
         /// Background reconstruction routine for Lattice Boltzmann meshes.
         /// Mirrors the FEM routine: for each iteration cycles electrode pairs, accumulates data gradients,
@@ -935,6 +1027,13 @@ namespace BusinessLayer
                 mesh.SetConductivityDistribution(updated);
                 // Ghost conductivities are derived quantities; refresh them immediately after interior updates.
                 mesh.UpdateGhostConductivityFromNeighbors();
+
+                if (_useLbmConductivityFilter && (iter + 1) % _lbmConductivityFilterInterval == 0)
+                {
+                    var smoothed = ApplyLbmConductivityGaussianFilter(mesh, mesh.GetConductivityDistribution());
+                    mesh.SetConductivityDistribution(smoothed);
+                    mesh.UpdateGhostConductivityFromNeighbors();
+                }
             }
 
             ConductivityDistribution reconstructed = mesh.GetConductivityDistribution();

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -186,7 +186,7 @@
                                 MaximumWidthRequest="180"
                                 Style="{StaticResource PanelSectionBorderStyle}"
                                 BackgroundColor="{AppThemeBinding Light=#25324A, Dark=#25324A}">
-                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
+                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
                                 <Label Grid.Row="0" Text="Parameters" FontSize="Medium" FontAttributes="Bold" Margin="0,0,0,12"/>
                                 <Label Grid.Row="3" HorizontalOptions="Start" Text="Max Iteration Count" FontFamily="SF Pro Text" FontAttributes="None"/>
                                 <Entry Grid.Row="4" Text="{Binding MaxIterationCount}" MaximumWidthRequest="130" HorizontalOptions="Start"/>
@@ -239,19 +239,35 @@
                                             HorizontalOptions="End"/>
                                 </Grid>
 
-                                <Label Grid.Row="18"
+                                <Label Grid.Row="17"
+                                       HorizontalOptions="Start"
+                                       Text="LBM Conductivity Smoothing"
+                                       FontFamily="SF Pro Text"
+                                       FontAttributes="None"
+                                       IsVisible="{Binding IsLbmSolverSelected}"/>
+                                <Grid Grid.Row="18" ColumnDefinitions="*,Auto" ColumnSpacing="8"
+                                      IsVisible="{Binding IsLbmSolverSelected}">
+                                    <Label Text="Filter"
+                                           VerticalOptions="Center"
+                                           FontFamily="SF Pro Text"/>
+                                    <Switch Grid.Column="1"
+                                            IsToggled="{Binding ReconstructionParameters.UseLbmConductivityFilter}"
+                                            HorizontalOptions="End"/>
+                                </Grid>
+
+                                <Label Grid.Row="19"
                                        HorizontalOptions="Start"
                                        Text="Virtual Electrode Method"
                                        FontFamily="SF Pro Text"
                                        FontAttributes="None"
                                        IsVisible="{Binding VirtualElectrodeSettings.UseVirtualElectrodes}"/>
-                                <Picker Grid.Row="19"
+                                <Picker Grid.Row="20"
                                         ItemsSource="{Binding VirtualElectrodeMethods}"
                                         SelectedItem="{Binding VirtualElectrodeSettings.Method}"
                                         IsVisible="{Binding VirtualElectrodeSettings.UseVirtualElectrodes}"
                                         MaximumWidthRequest="150"/>
 
-                                <Grid Grid.Row="19" ColumnDefinitions="Auto,*" ColumnSpacing="8"
+                                <Grid Grid.Row="21" ColumnDefinitions="Auto,*" ColumnSpacing="8"
                                       IsVisible="{Binding IsLinearCombinationMethod}">
                                     <Label Text="Alpha (0..1)"
                                            VerticalOptions="Center"
@@ -262,7 +278,7 @@
                                            HorizontalTextAlignment="End"/>
                                 </Grid>
 
-                                <Grid Grid.Row="19" ColumnDefinitions="Auto,*" ColumnSpacing="8"
+                                <Grid Grid.Row="22" ColumnDefinitions="Auto,*" ColumnSpacing="8"
                                       IsVisible="{Binding IsHarrachMethod}">
                                     <Label Text="Harrach λ"
                                            VerticalOptions="Center"
@@ -273,7 +289,7 @@
                                            HorizontalTextAlignment="End"/>
                                 </Grid>
 
-                                <Grid Grid.Row="19" ColumnDefinitions="Auto,*" ColumnSpacing="8"
+                                <Grid Grid.Row="23" ColumnDefinitions="Auto,*" ColumnSpacing="8"
                                       IsVisible="{Binding IsNdMethod}">
                                     <Label Text="ND Max Mode"
                                            VerticalOptions="Center"

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockRegistry.cs
@@ -363,28 +363,54 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                         {
                             var isFem = solverChoice.SelectedOption == FriendlyName(nameof(DifferentialEquationSolver.FEM));
                             femOrder.IsVisible = isFem;
+                            numericSolverChoice.IsVisible = isFem;
                             lbmDomainSize.IsVisible = !isFem;
                             lbmRelaxation.IsVisible = !isFem;
                             lbmGaussianFilter.IsVisible = !isFem;
                             lbmGaussianKernel.IsVisible = !isFem;
+                            lbmConductivityFilter.IsVisible = !isFem;
+                            lbmConductivityFilterInterval.IsVisible = !isFem;
                         }
+                    };
+
+                    var numericSolverChoice = new ChoiceParameter
+                    {
+                        Name = "Numeric Solver",
+                        Key = "numeric_solver",
+                        Options = Enum.GetNames(typeof(NumericSolver)).Select(FriendlyName).ToList(),
+                        SelectedOption = FriendlyName(nameof(NumericSolver.GMRES)),
+                        IsVisible = solverChoice.SelectedOption == FriendlyName(nameof(DifferentialEquationSolver.FEM))
+                    };
+
+                    var lbmConductivityFilter = new BoolParameter
+                    {
+                        Name = "Gaussian Filter Conductivity",
+                        Key = "lbm_conductivity_filter",
+                        Value = false,
+                        IsVisible = solverChoice.SelectedOption == FriendlyName(nameof(DifferentialEquationSolver.LBM))
+                    };
+
+                    var lbmConductivityFilterInterval = new NumberParameter
+                    {
+                        Name = "Conductivity Filter Interval",
+                        Key = "lbm_conductivity_filter_interval",
+                        Value = 5,
+                        Min = 1,
+                        Step = 1,
+                        IsVisible = solverChoice.SelectedOption == FriendlyName(nameof(DifferentialEquationSolver.LBM))
                     };
 
                     return new List<ConfigurationParameter>
                     {
                         solverChoice,
-                        new ChoiceParameter
-                        {
-                            Name = "Numeric Solver",
-                            Key = "numeric_solver",
-                            Options = Enum.GetNames(typeof(NumericSolver)).Select(FriendlyName).ToList(),
-                            SelectedOption = FriendlyName(nameof(NumericSolver.GMRES))
-                        },
+                        numericSolverChoice,
                         femOrder,
                         lbmDomainSize,
                         lbmRelaxation,
                         lbmGaussianFilter,
-                        lbmGaussianKernel
+                        lbmGaussianKernel,
+                        lbmConductivityFilter,
+                        lbmConductivityFilterInterval
                     };
                 },
                 (block, target) =>
@@ -405,8 +431,17 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
                     if (gaussianSize % 2 == 0)
                         gaussianSize += 1;
 
+                    var conductivityFilterToggle = block.Parameters.OfType<BoolParameter>().FirstOrDefault(p => p.Key == "lbm_conductivity_filter")?.Value
+                        ?? target.UseLbmConductivityFilter;
+                    var conductivityFilterIntervalRaw = block.Parameters.OfType<NumberParameter>()
+                        .FirstOrDefault(p => p.Key == "lbm_conductivity_filter_interval")?.Value
+                        ?? target.LbmConductivityFilterInterval;
+                    int conductivityFilterInterval = (int)Math.Max(1, conductivityFilterIntervalRaw);
+
                     target.UseLbmGaussianFilter = gaussianToggle;
                     target.LbmGaussianFilterSize = gaussianSize;
+                    target.UseLbmConductivityFilter = conductivityFilterToggle;
+                    target.LbmConductivityFilterInterval = conductivityFilterInterval;
                 });
 
             yield return new ReconstructionBlockDefinition(

--- a/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
+++ b/Utility/Classes/ReconstructionParameters/EITReconstructionParameters.cs
@@ -53,7 +53,13 @@ namespace Utility.Classes.ReconstructionParameters
         private bool useLbmGaussianFilter = false;
 
         [ObservableProperty]
+        private bool useLbmConductivityFilter = false;
+
+        [ObservableProperty]
         private int lbmGaussianFilterSize = 3;
+
+        [ObservableProperty]
+        private int lbmConductivityFilterInterval = 5;
 
         [ObservableProperty]
         private double conductivityMinimumBound = 0.1;


### PR DESCRIPTION
## Summary
- add a reconstruction-page toggle to apply periodic Gaussian smoothing to LBM conductivity maps
- expose conductivity smoothing controls and defaults in the LBM solver block of the configuration canvas
- hide numeric solver selection when LBM is chosen and apply the smoothing interval during LBM reconstruction runs

## Testing
- Not run (dotnet CLI not available in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273f9e9b508333990bf5e23f36b717)