### PR TITLE
Add block FEM reconstruction path and configuration wiring

### DIFF
--- a/BusinessLayer/BlockFemReconstructionPersistence.cs
+++ b/BusinessLayer/BlockFemReconstructionPersistence.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.Collections.Generic;
+using System.Numerics;
 using Utility.Classes;
 using Utility.Classes.Configurations.ReconstructionConfiguration;
 using Utility.Classes.Discretizer;
@@ -23,6 +24,12 @@ namespace BusinessLayer
 
         private CompleteReconstructionConfiguration? _completeReconstructionConfiguration = null;
 
+        /// <summary>
+        /// Materialized runtime context derived from the block configuration. Contains
+        /// the mesh, solver instances and weighted reconstruction components.
+        /// </summary>
+        public ReconstructionRuntimeContext? RuntimeContext { get; private set; }
+
         private InitialDistributionTypes _initialDistributionType = InitialDistributionTypes.Homogeneous;
         private ConductivityDistribution _originalDistribution;
         private ConductivityDistribution _initialDistribution;
@@ -30,25 +37,48 @@ namespace BusinessLayer
         private ElectrodeMeasurementSetup _measurementSetup = ElectrodeMeasurementSetup.Active;
         private bool _usePotentialDifferences = false;
 
+        /// <summary>
+        /// Exposes the active differential equation solver so services can share it with
+        /// measurement preparation pipelines.
+        /// </summary>
+        public IDifferentialEquationSolver? DifferentialEquationSolver => _differentialEquationSolver;
+
         public void Initialize(CompleteReconstructionConfiguration configuration)
         {
             _completeReconstructionConfiguration = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
-            var runtimeContext = ReconstructionConfigurationMaterializer.Materialize(configuration);
+            RuntimeContext = ReconstructionConfigurationMaterializer.Materialize(configuration);
 
-            _mesh = runtimeContext.Mesh;
-            _differentialEquationSolver = runtimeContext.DifferentialEquationSolver;
-            _numericSolver = runtimeContext.NumericSolver;
-            _regularizers = runtimeContext.Regularizers;
-            _errorMetrics = runtimeContext.ErrorMetrics;
-            _numericOptimizers = runtimeContext.NumericOptimizers;
-            _initialDistributionType = runtimeContext.InitialDistributionType;
-            _originalDistribution = runtimeContext.OriginalDistribution;
-            _initialDistribution = runtimeContext.InitialDistribution;
-            _measurementSetup = runtimeContext.MeasurementSetup;
-            _usePotentialDifferences = runtimeContext.UsePotentialDifferences;
+            _mesh = RuntimeContext.Mesh;
+            _differentialEquationSolver = RuntimeContext.DifferentialEquationSolver;
+            _numericSolver = RuntimeContext.NumericSolver;
+            _regularizers = RuntimeContext.Regularizers;
+            _errorMetrics = RuntimeContext.ErrorMetrics;
+            _numericOptimizers = RuntimeContext.NumericOptimizers;
+            _initialDistributionType = RuntimeContext.InitialDistributionType;
+            _originalDistribution = RuntimeContext.OriginalDistribution;
+            _initialDistribution = RuntimeContext.InitialDistribution;
+            _measurementSetup = RuntimeContext.MeasurementSetup;
+            _usePotentialDifferences = RuntimeContext.UsePotentialDifferences;
         }
 
+        /// <summary>
+        /// Updates the internally tracked conductivity distribution to keep regularization
+        /// and gradient calculations aligned with the latest optimization step.
+        /// </summary>
+        /// <param name="updated">Most recent conductivity estimate.</param>
+        public void UpdateCurrentDistribution(ConductivityDistribution updated)
+        {
+            _initialDistribution = updated ?? throw new ArgumentNullException(nameof(updated));
+            _mesh?.SetConductivityDistribution(updated);
+        }
+
+        /// <summary>
+        /// Executes a block-based FEM reconstruction step across the provided measurement frames,
+        /// producing per-frame gradients, potentials and adjoint solutions.
+        /// </summary>
+        /// <param name="measurement">Measurement frames mapped to the solver ordering.</param>
+        /// <returns>Collection of reconstruction frames, one entry per measurement frame.</returns>
         public List<ReconstructionFrame> Step(EITMeasurement measurement)
         {
             // Basic error checking
@@ -337,12 +367,14 @@ namespace BusinessLayer
         /// <returns></returns>
         private ConductivityDistribution CalculateCombinedRegularization()
         {
+            var currentDistribution = _mesh?.GetConductivityDistribution() ?? _initialDistribution
+                                       ?? throw new InvalidOperationException("No conductivity distribution available for regularization evaluation.");
             List<ConductivityDistribution> regularizations = new List<ConductivityDistribution>();
 
             Parallel.ForEach(_regularizers, regulizerEntry =>
             {
                 var (weight, regulizer) = regulizerEntry;
-                var regularization = regulizer.EvaluateGradient(_mesh, _initialDistribution);
+                var regularization = regulizer.EvaluateGradient(_mesh, currentDistribution);
 
                 // Scale regularization with its weight
                 foreach (var elementId in regularization.IdValuePairs.Keys.ToList())

--- a/BusinessLayer/Settings.cs
+++ b/BusinessLayer/Settings.cs
@@ -9,7 +9,8 @@ namespace BusinessLayer
             return DataAccessLayer.Settings.ApplyContainerRegistration()
                 .RegisterType<IDAQPersistence, DAQPersistence>()
                 .RegisterType<IMeasurementPersistence, MeasurementPersistence>()
-                .RegisterType<IReconstructionPersistence, ReconstructionPersistence>();
+                .RegisterType<IReconstructionPersistence, ReconstructionPersistence>()
+                .RegisterType<BlockFemReconstructionPersistence, BlockFemReconstructionPersistence>();
         }
     }
 }

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -431,12 +431,14 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             var configuration = CompleteReconstructionConfigurationBuilder.Create(Blocks, Connections);
             Workspace.SetCompleteReconstructionConfiguration(configuration);
+            Workspace.SetUseBlockConfiguration(true);
             ApplyConfigurationToWorkspace();
         }
 
         private void ApplyConfigurationToWorkspace()
         {
             ReconstructionBlockRegistry.ApplyBlocksToWorkspace(Blocks);
+            Workspace.SetUseBlockConfiguration(true);
             UpdateDiagnostics();
         }
 

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -20,6 +20,7 @@ using Utility.Classes;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Classes.Configurations.ReconstructionConfiguration;
 using Utility.Classes.Factories;
 using Utility.Classes.Measurement;
 using Utility.Classes.ReconstructionParameters;
@@ -36,10 +37,14 @@ namespace ElectricalImpedanceTomography.ViewModels
     public partial class ReconstructionPageViewModel : BaseReconstructionPageViewModel
     {
         private readonly IReconstructionService _reconstructionService;
+        private readonly IBlockFemReconstructionService _blockReconstructionService;
         private readonly IReconstructionExportService _exportService;
 
         private readonly Stopwatch _reconstructionStopwatch = new();
         private readonly Timer _elapsedTimer;
+
+        private bool _blockInitialized;
+        private CompleteReconstructionConfiguration? _lastBlockConfiguration;
 
         private IDiscretization? _discretization = Workspace.GetDiscretization();
         private IDiscretization? _initializedDiscretization;
@@ -57,6 +62,69 @@ namespace ElectricalImpedanceTomography.ViewModels
         public bool IsLinearCombinationMethod => VirtualElectrodeSettings.UseVirtualElectrodes && VirtualElectrodeSettings.Method == VirtualElectrodeMethod.LinearCombination;
         public bool IsHarrachMethod => VirtualElectrodeSettings.UseVirtualElectrodes && VirtualElectrodeSettings.Method == VirtualElectrodeMethod.HarrachSensitivityInterpolation;
         public bool IsNdMethod => VirtualElectrodeSettings.UseVirtualElectrodes && VirtualElectrodeSettings.Method == VirtualElectrodeMethod.NdMapSpectralInterpolation;
+
+        private const string MixedPickerLabel = "Mixed";
+
+        [ObservableProperty]
+        private bool useBlockConfiguration = Workspace.GetUseBlockConfiguration();
+
+        public ObservableCollection<string> ErrorMetricPickerOptions { get; } = new();
+        public ObservableCollection<string> RegularizationPickerOptions { get; } = new();
+        public ObservableCollection<string> OptimizerPickerOptions { get; } = new();
+
+        [ObservableProperty]
+        private string? selectedErrorMetricDisplay;
+
+        [ObservableProperty]
+        private string? selectedRegularizationDisplay;
+
+        [ObservableProperty]
+        private string? selectedOptimizerDisplay;
+
+        [ObservableProperty]
+        private bool isErrorMetricPickerEnabled = true;
+
+        [ObservableProperty]
+        private bool isRegularizationPickerEnabled = true;
+
+        [ObservableProperty]
+        private bool isOptimizerPickerEnabled = true;
+
+        private bool ShouldUseBlockConfiguration => UseBlockConfiguration && Workspace.GetCompleteReconstructionConfiguration() != null;
+
+        partial void OnUseBlockConfigurationChanged(bool value)
+        {
+            Workspace.SetUseBlockConfiguration(value);
+            _blockInitialized = false;
+            RefreshMethodPickerOptions();
+        }
+
+        partial void OnSelectedErrorMetricDisplayChanged(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value) || value == MixedPickerLabel)
+                return;
+
+            if (Enum.TryParse<ErrorMetric>(value, out var parsed))
+                ReconstructionParameters.ErrorMetric = parsed;
+        }
+
+        partial void OnSelectedRegularizationDisplayChanged(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value) || value == MixedPickerLabel)
+                return;
+
+            if (Enum.TryParse<RegularizationTechnique>(value, out var parsed))
+                ReconstructionParameters.RegularizationTechnique = parsed;
+        }
+
+        partial void OnSelectedOptimizerDisplayChanged(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value) || value == MixedPickerLabel)
+                return;
+
+            if (Enum.TryParse<NumericOptimizer>(value, out var parsed))
+                ReconstructionParameters.NumericOptimizer = parsed;
+        }
 
         [ObservableProperty]
         private int iterationCount = 0;
@@ -329,9 +397,11 @@ namespace ElectricalImpedanceTomography.ViewModels
         }
 
         public ReconstructionPageViewModel(IReconstructionService reconstructionService,
+                                           IBlockFemReconstructionService blockReconstructionService,
                                            IReconstructionExportService exportService)
         {
             _reconstructionService = reconstructionService;
+            _blockReconstructionService = blockReconstructionService;
             _exportService = exportService;
 
             _elapsedTimer = new Timer(200)
@@ -371,12 +441,26 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             _reconstructionService.ReconstructionUpdated += OnServiceReconstructionUpdated;
             _reconstructionService.ReconstructionFrameUpdated += OnServiceFrameUpdated;
+            _blockReconstructionService.ReconstructionUpdated += OnServiceReconstructionUpdated;
+            _blockReconstructionService.ReconstructionFrameUpdated += OnServiceFrameUpdated;
+            RefreshMethodPickerOptions();
         }
 
         public void PrepareForNewReconstruction()
         {
             UpdateMesh();
             UpdateReconstructionParameters();
+
+            if (ShouldUseBlockConfiguration)
+            {
+                _blockReconstructionService.Initialize();
+                _initializedDiscretization = Workspace.GetDiscretization();
+                IterationCount = 0;
+                _resetMetricsOnStart = true;
+                _lastBlockConfiguration = Workspace.GetCompleteReconstructionConfiguration();
+                _blockInitialized = true;
+                return;
+            }
 
             var mesh = _discretization ?? throw new NullReferenceException("Mesh was null during reconstruction initialization, check calling code!");
 
@@ -440,6 +524,76 @@ namespace ElectricalImpedanceTomography.ViewModels
                 : "Use OMP Parallelization";
 
             OnPropertyChanged(nameof(UseParallelizationToggle));
+        }
+
+        /// <summary>
+        /// Synchronizes the method picker options with the current reconstruction mode.
+        /// Displays a non-editable "Mixed" option when multiple blocks are configured
+        /// for a given category.
+        /// </summary>
+        public void RefreshMethodPickerOptions()
+        {
+            var parameters = ReconstructionParameters;
+            if (parameters == null)
+                return;
+
+            var configuration = Workspace.GetCompleteReconstructionConfiguration();
+            var workspaceFlag = Workspace.GetUseBlockConfiguration();
+            if (UseBlockConfiguration != workspaceFlag)
+                UseBlockConfiguration = workspaceFlag;
+            if (UseBlockConfiguration && configuration == null)
+                UseBlockConfiguration = false;
+            bool mixedErrorMetric = ShouldUseBlockConfiguration && configuration != null && configuration.Blocks.Count(b => b.Type == BlockType.ErrorMetric) > 1;
+            bool mixedRegularizer = ShouldUseBlockConfiguration && configuration != null && configuration.Blocks.Count(b => b.Type == BlockType.Regularizer) > 1;
+            bool mixedOptimizer = ShouldUseBlockConfiguration && configuration != null && configuration.Blocks.Count(b => b.Type == BlockType.Optimizer) > 1;
+
+            UpdateMethodPicker(ErrorMetricPickerOptions,
+                               ErrorMetricOptions.Select(option => option.ToString()),
+                               mixedErrorMetric,
+                               parameters.ErrorMetric.ToString(),
+                               value => SelectedErrorMetricDisplay = value,
+                               enabled => IsErrorMetricPickerEnabled = enabled);
+
+            UpdateMethodPicker(RegularizationPickerOptions,
+                               RegularizationTechniqueOptions.Select(option => option.ToString()),
+                               mixedRegularizer,
+                               parameters.RegularizationTechnique.ToString(),
+                               value => SelectedRegularizationDisplay = value,
+                               enabled => IsRegularizationPickerEnabled = enabled);
+
+            UpdateMethodPicker(OptimizerPickerOptions,
+                               NumericOptimizerOptions.Select(option => option.ToString()),
+                               mixedOptimizer,
+                               parameters.NumericOptimizer.ToString(),
+                               value => SelectedOptimizerDisplay = value,
+                               enabled => IsOptimizerPickerEnabled = enabled);
+        }
+
+        /// <summary>
+        /// Populates a method picker with either the available options or a locked "Mixed" placeholder.
+        /// </summary>
+        private void UpdateMethodPicker(ObservableCollection<string> target,
+                                        IEnumerable<string> options,
+                                        bool isMixed,
+                                        string currentValue,
+                                        Action<string?> setSelected,
+                                        Action<bool> setEnabled)
+        {
+            target.Clear();
+
+            if (isMixed)
+            {
+                target.Add(MixedPickerLabel);
+                setSelected(MixedPickerLabel);
+                setEnabled(false);
+                return;
+            }
+
+            foreach (var option in options)
+                target.Add(option);
+
+            setSelected(target.FirstOrDefault(o => o == currentValue) ?? target.FirstOrDefault());
+            setEnabled(true);
         }
 
         public void SetDrivePattern(DrivePattern pattern)
@@ -740,6 +894,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                 TrackReconstructionParameters(ReconstructionParameters);
                 SyncDrivePatternSelection();
                 UpdateParallelizationToggleState();
+                RefreshMethodPickerOptions();
             }
         }
 
@@ -821,12 +976,36 @@ namespace ElectricalImpedanceTomography.ViewModels
             _discretization = Workspace.GetDiscretization();
             RefreshMeasurementSourceSelection();
         }
-        private void UpdateReconstructionParameters() => ReconstructionParameters = Workspace.GetReconstructionParameters();
+        private void UpdateReconstructionParameters()
+        {
+            ReconstructionParameters = Workspace.GetReconstructionParameters();
+            RefreshMethodPickerOptions();
+        }
 
         private void InitializeReconstruction(bool force = false)
         {
             UpdateMesh();
             UpdateReconstructionParameters();
+
+            if (ShouldUseBlockConfiguration)
+            {
+                var config = Workspace.GetCompleteReconstructionConfiguration();
+                if (_lastBlockConfiguration != config)
+                {
+                    _blockInitialized = false;
+                    _lastBlockConfiguration = config;
+                }
+
+                if (force || !_blockInitialized)
+                {
+                    _blockReconstructionService.Initialize();
+                    _blockInitialized = true;
+                    IterationCount = 0;
+                    _initializedDiscretization = Workspace.GetDiscretization();
+                }
+
+                return;
+            }
 
             var mesh = _discretization;
             var reconstructionParameters = ReconstructionParameters;
@@ -1499,23 +1678,53 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             PrepareForNewReconstruction();
             BeginReconstructionMetrics();
+
+            if (ShouldUseBlockConfiguration)
+            {
+                _ = _blockReconstructionService.RunFullReconstructionCycleAsync(StepSize,
+                                                                                 RegularizationWeight,
+                                                                                 ExcitationCurrentAmplitude);
+                return;
+            }
+
             _reconstructionService.StartBackgroundReconstruction(MaxIterationCount, StepSize, RegularizationWeight, ExcitationCurrentAmplitude);
         }
 
         public void PauseReconstruction()
         {
+            if (ShouldUseBlockConfiguration)
+            {
+                PauseReconstructionMetrics();
+                return;
+            }
+
             _reconstructionService.PauseBackgroundReconstruction();
             PauseReconstructionMetrics();
         }
 
         public void ResumeReconstruction()
         {
+            if (ShouldUseBlockConfiguration)
+            {
+                BeginReconstructionMetrics();
+                return;
+            }
+
             _reconstructionService.ResumeBackgroundReconstruction();
             BeginReconstructionMetrics();
         }
 
         public void StopReconstruction()
         {
+            if (ShouldUseBlockConfiguration)
+            {
+                StopReconstructionMetrics();
+                _blockInitialized = false;
+                _initializedDiscretization = null;
+                _lastRunSignature = null;
+                return;
+            }
+
             _reconstructionService.StopBackgroundReconstruction();
             StopReconstructionMetrics();
             _initializedDiscretization = null;
@@ -1532,6 +1741,8 @@ namespace ElectricalImpedanceTomography.ViewModels
             // Reset view model state and clear workspace frames/results
             Workspace.ClearReconstructionFrames();
             Workspace.SetReconstructionResults(new List<ReconstructionResult>());
+
+            _blockInitialized = false;
 
             IterationCount = 0;
             Residual = 1.0;
@@ -1557,9 +1768,19 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             InitializeReconstruction();
             BeginReconstructionMetrics();
+
+            if (ShouldUseBlockConfiguration)
+            {
+                var blockResult = _blockReconstructionService.RunFullReconstructionCycleAsync(StepSize,
+                                                                                               RegularizationWeight,
+                                                                                               ExcitationCurrentAmplitude);
+                StopElapsedTimer();
+                return blockResult;
+            }
+
             var result = _reconstructionService.RunFullReconstructionCycleAsync(StepSize,
-                                                                         RegularizationWeight,
-                                                                         ExcitationCurrentAmplitude);
+                                                                             RegularizationWeight,
+                                                                             ExcitationCurrentAmplitude);
             StopElapsedTimer();
 
             return result;
@@ -1569,6 +1790,17 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             InitializeReconstruction();
             BeginReconstructionMetrics();
+
+            if (ShouldUseBlockConfiguration)
+            {
+                await _blockReconstructionService.StepReconstructionAsync(StepSize,
+                                                                          RegularizationWeight,
+                                                                          ExcitationCurrentAmplitude);
+                StopElapsedTimer();
+                FlushPendingTrendUpdates();
+                return;
+            }
+
             await _reconstructionService.StepReconstructionAsync();
             StopElapsedTimer();
             FlushPendingTrendUpdates();

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -170,11 +170,11 @@
                                 <Label Grid.Row="3" HorizontalOptions="Start" Text="DE Solver" FontFamily="SF Pro Text" FontAttributes="None"/>
                                 <Picker Grid.Row="4" ItemsSource="{Binding DifferentialEquationSolverOptions}" SelectedItem="{Binding ReconstructionParameters.DifferentialEquationSolver}" WidthRequest="150"/>
                                 <Label Grid.Row="5" HorizontalOptions="Start" Text="Error Metric" FontFamily="SF Pro Text" FontAttributes="None"/>
-                                <Picker Grid.Row="6" HorizontalOptions="Start" ItemsSource="{Binding ErrorMetricOptions}" SelectedItem="{Binding ReconstructionParameters.ErrorMetric}" WidthRequest="150"/>
+                                <Picker Grid.Row="6" HorizontalOptions="Start" ItemsSource="{Binding ErrorMetricPickerOptions}" SelectedItem="{Binding SelectedErrorMetricDisplay}" WidthRequest="150" IsEnabled="{Binding IsErrorMetricPickerEnabled}"/>
                                 <Label Grid.Row="7" HorizontalOptions="Start" Text="Regularization" FontFamily="SF Pro Text" FontAttributes="None"/>
-                                <Picker Grid.Row="8" ItemsSource="{Binding RegularizationTechniqueOptions}" SelectedItem="{Binding ReconstructionParameters.RegularizationTechnique}" WidthRequest="150"/>
+                                <Picker Grid.Row="8" ItemsSource="{Binding RegularizationPickerOptions}" SelectedItem="{Binding SelectedRegularizationDisplay}" WidthRequest="150" IsEnabled="{Binding IsRegularizationPickerEnabled}"/>
                                 <Label Grid.Row="9" HorizontalOptions="Start" Text="Optimizer" FontFamily="SF Pro Text" FontAttributes="None"/>
-                                <Picker Grid.Row="10" ItemsSource="{Binding NumericOptimizerOptions}" SelectedItem="{Binding ReconstructionParameters.NumericOptimizer}"/>
+                                <Picker Grid.Row="10" ItemsSource="{Binding OptimizerPickerOptions}" SelectedItem="{Binding SelectedOptimizerDisplay}" IsEnabled="{Binding IsOptimizerPickerEnabled}"/>
                                 <Label Grid.Row="11" HorizontalOptions="Start" Text="Linear Solver" FontFamily="SF Pro Text" FontAttributes="None"/>
                                 <Picker Grid.Row="12" ItemsSource="{Binding NumericSolverOptions}" SelectedItem="{Binding ReconstructionParameters.NumericSolver}" WidthRequest="150"/>
                                 <Label Grid.Row="13" HorizontalOptions="Start" Text="{Binding ParallelizationToggleLabel}" FontFamily="SF Pro Text" FontAttributes="None"/>

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -160,6 +160,7 @@ public partial class ReconstructionPage : ContentPage
             this.StartBackgroundPulse(startColor, endColor);
             _viewModel.RefreshMeasurementSourceOptions();
             _viewModel.LoadAvailableReconstructions();
+            _viewModel.RefreshMethodPickerOptions();
         }
 
     protected override void OnDisappearing()

--- a/ServiceLayer/BlockFemReconstructionService.cs
+++ b/ServiceLayer/BlockFemReconstructionService.cs
@@ -1,0 +1,223 @@
+using BusinessLayer;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Utility.Classes;
+using Utility.Classes.Application;
+using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Measurement;
+using Utility.Logger;
+
+namespace ServiceLayer
+{
+    /// <summary>
+    /// Wires the block-based FEM reconstruction persistence into the application layer.
+    /// Responsible for preparing measurements, executing the block persistence step and
+    /// emitting intermediate frames and aggregated results for UI consumption.
+    /// </summary>
+    public class BlockFemReconstructionService : IBlockFemReconstructionService
+    {
+        private readonly BlockFemReconstructionPersistence _persistence;
+        private readonly IMeasurementService _measurementService;
+        private readonly ILogger _logger;
+
+        private ReconstructionRuntimeContext? _runtimeContext;
+        private bool _initialized;
+
+        /// <inheritdoc />
+        public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
+
+        /// <inheritdoc />
+        public event EventHandler<ReconstructionFrame>? ReconstructionFrameUpdated;
+
+        public BlockFemReconstructionService(BlockFemReconstructionPersistence persistence,
+                                             IMeasurementService measurementService,
+                                             ILogger logger)
+        {
+            _persistence = persistence;
+            _measurementService = measurementService;
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public void Initialize()
+        {
+            var configuration = Workspace.GetCompleteReconstructionConfiguration()
+                                ?? throw new InvalidOperationException("Block reconstruction requires a configured reconstruction canvas.");
+
+            _persistence.Initialize(configuration);
+            _runtimeContext = _persistence.RuntimeContext
+                              ?? throw new InvalidOperationException("Failed to materialize reconstruction runtime context.");
+
+            Workspace.SetDiscretization(_runtimeContext.Mesh);
+            Workspace.SetOriginalConductivityDistribution(_runtimeContext.OriginalDistribution);
+            Workspace.SetInitialConductivityDistribution(_runtimeContext.InitialDistribution);
+            Workspace.SetElectrodeMeasurementSetup(_runtimeContext.MeasurementSetup);
+
+            var parameters = Workspace.GetReconstructionParameters();
+            _measurementService.Initialize(_runtimeContext.Mesh,
+                                           parameters,
+                                           parameters.DrivePattern,
+                                           () => _persistence.DifferentialEquationSolver,
+                                           _runtimeContext.OriginalDistribution);
+            _measurementService.SyncMeasurementSource();
+
+            Workspace.SetReconstructionFrames(new List<ReconstructionFrame>());
+            Workspace.SetReconstructionResults(new List<ReconstructionResult>());
+            _initialized = true;
+        }
+
+        /// <inheritdoc />
+        public Task<ReconstructionResult?> RunFullReconstructionCycleAsync(double stepSize,
+                                                                           double regularizationWeight,
+                                                                           double excitationAmplitude)
+            => Task.Run(() => ExecuteReconstructionCycle(stepSize, regularizationWeight, excitationAmplitude));
+
+        /// <inheritdoc />
+        public Task<ReconstructionResult?> StepReconstructionAsync(double stepSize,
+                                                                    double regularizationWeight,
+                                                                    double excitationAmplitude)
+            => Task.Run(() => ExecuteReconstructionCycle(stepSize, regularizationWeight, excitationAmplitude));
+
+        private ReconstructionResult? ExecuteReconstructionCycle(double stepSize,
+                                                                  double regularizationWeight,
+                                                                  double excitationAmplitude)
+        {
+            if (!_initialized)
+                Initialize();
+            if (_runtimeContext == null)
+                throw new InvalidOperationException("Reconstruction runtime context is not available.");
+
+            try
+            {
+                var measurement = PrepareMeasurement(excitationAmplitude);
+                var frames = _persistence.Step(measurement);
+
+                foreach (var frame in frames)
+                {
+                    Workspace.AddReconstructionFrameToWorkspace(frame);
+                    ReconstructionFrameUpdated?.Invoke(this, frame);
+                }
+
+                var mesh = _runtimeContext.Mesh;
+                var previous = mesh.GetConductivityDistribution();
+                var updated = ApplyGradientUpdate(frames, previous, stepSize, regularizationWeight);
+                if (updated == null)
+                    return null;
+
+                var result = new ReconstructionResult(mesh.GetDiscretization(),
+                                                      _runtimeContext.OriginalDistribution,
+                                                      previous,
+                                                      updated,
+                                                      frames);
+
+                Workspace.AddReconstructionResultToWorkspace(result);
+                ReconstructionUpdated?.Invoke(this, result);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                throw;
+            }
+        }
+
+        private EITMeasurement PrepareMeasurement(double excitationAmplitude)
+        {
+            if (_runtimeContext == null)
+                throw new InvalidOperationException("Reconstruction runtime context is not available.");
+
+            _measurementService.EnsureMeasurements(excitationAmplitude);
+
+            var electrodes = _runtimeContext.Mesh.GetElectrodes().Cast<Electrode>().ToList();
+            var preparedFrames = new List<double[]>();
+
+            foreach (var frame in _measurementService.GetAllMeasurements())
+            {
+                var prepared = _measurementService.PrepareMeasurementFrame(frame, electrodes);
+                preparedFrames.Add(prepared);
+            }
+
+            var measurement = new EITMeasurement(preparedFrames, _measurementService.CurrentPattern)
+            {
+                CurrentAmplitude = _measurementService.RealMeasurementAmplitude ?? excitationAmplitude
+            };
+
+            return measurement;
+        }
+
+        private ConductivityDistribution? ApplyGradientUpdate(IReadOnlyList<ReconstructionFrame> frames,
+                                                              ConductivityDistribution currentSigma,
+                                                              double stepSize,
+                                                              double regularizationWeight)
+        {
+            if (_runtimeContext == null)
+                return null;
+            if (frames.Count == 0)
+                return null;
+
+            var aggregated = AggregateGradient(frames, regularizationWeight);
+            var updated = ApplyOptimizers(currentSigma, aggregated, stepSize);
+            updated = ConductivityClipper.Clip(updated);
+
+            _persistence.UpdateCurrentDistribution(updated);
+            Workspace.SetInitialConductivityDistribution(updated);
+            return updated;
+        }
+
+        private static ConductivityDistribution AggregateGradient(IReadOnlyList<ReconstructionFrame> frames,
+                                                                  double regularizationWeight)
+        {
+            var accumulator = new Dictionary<int, double>();
+            foreach (var frame in frames)
+            {
+                foreach (var kvp in frame.ConductivityGradient.Conductivities)
+                {
+                    double reg = frame.CalculatedRegularization?.GetConductivity(kvp.Key) ?? 0.0;
+                    double contribution = kvp.Value - regularizationWeight * reg;
+                    accumulator[kvp.Key] = accumulator.TryGetValue(kvp.Key, out var existing)
+                        ? existing + contribution
+                        : contribution;
+                }
+            }
+
+            int frameCount = Math.Max(1, frames.Count);
+            var averaged = accumulator.ToDictionary(kvp => kvp.Key, kvp => kvp.Value / frameCount);
+            return new ConductivityDistribution(averaged);
+        }
+
+        private ConductivityDistribution ApplyOptimizers(ConductivityDistribution currentSigma,
+                                                         ConductivityDistribution gradient,
+                                                         double stepSize)
+        {
+            if (_runtimeContext == null || _runtimeContext.NumericOptimizers == null || _runtimeContext.NumericOptimizers.Count == 0)
+                return currentSigma;
+
+            if (_runtimeContext.NumericOptimizers.Count == 1)
+                return _runtimeContext.NumericOptimizers[0].numericOptimizer.OptimizationStep(currentSigma, gradient, stepSize);
+
+            var weightedSum = new Dictionary<int, double>();
+            double totalWeight = 0.0;
+
+            foreach (var (weight, optimizer) in _runtimeContext.NumericOptimizers)
+            {
+                var candidate = optimizer.OptimizationStep(currentSigma, gradient, stepSize);
+                foreach (var kvp in candidate.Conductivities)
+                {
+                    weightedSum[kvp.Key] = weightedSum.TryGetValue(kvp.Key, out var existing)
+                        ? existing + weight * kvp.Value
+                        : weight * kvp.Value;
+                }
+
+                totalWeight += weight;
+            }
+
+            if (totalWeight <= double.Epsilon)
+                return currentSigma;
+
+            var combined = weightedSum.ToDictionary(kvp => kvp.Key, kvp => kvp.Value / totalWeight);
+            return new ConductivityDistribution(combined);
+        }
+    }
+}

--- a/ServiceLayer/IBlockFemReconstructionService.cs
+++ b/ServiceLayer/IBlockFemReconstructionService.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading.Tasks;
+using Utility.Classes;
+
+namespace ServiceLayer
+{
+    /// <summary>
+    /// Service contract that orchestrates block-based FEM reconstruction using
+    /// the experimental block configuration pipeline. Implementations prepare
+    /// measurements, forward intermediate frames and surface aggregated results
+    /// to the UI.
+    /// </summary>
+    public interface IBlockFemReconstructionService
+    {
+        /// <summary>
+        /// Raised when a full reconstruction result has been produced from a cycle
+        /// of inverse iterations.
+        /// </summary>
+        event EventHandler<ReconstructionResult> ReconstructionUpdated;
+
+        /// <summary>
+        /// Raised for every intermediate reconstruction frame so the UI can update
+        /// live gradient and field visualisations.
+        /// </summary>
+        event EventHandler<ReconstructionFrame> ReconstructionFrameUpdated;
+
+        /// <summary>
+        /// Initializes the service based on the current <see cref="Utility.Classes.Application.Workspace"/>
+        /// block configuration and discretization.
+        /// </summary>
+        void Initialize();
+
+        /// <summary>
+        /// Executes a full reconstruction cycle using all prepared measurement frames.
+        /// </summary>
+        /// <param name="stepSize">Gradient descent step size.</param>
+        /// <param name="regularizationWeight">Weighting applied to the regularization gradient.</param>
+        /// <param name="excitationAmplitude">Excitation current amplitude for the measurement frames.</param>
+        /// <returns>The aggregated reconstruction result for the cycle.</returns>
+        Task<ReconstructionResult?> RunFullReconstructionCycleAsync(double stepSize,
+                                                                     double regularizationWeight,
+                                                                     double excitationAmplitude);
+
+        /// <summary>
+        /// Performs a single reconstruction cycle, emitting intermediate frames as soon as
+        /// they are available.
+        /// </summary>
+        /// <param name="stepSize">Gradient descent step size.</param>
+        /// <param name="regularizationWeight">Weighting applied to the regularization gradient.</param>
+        /// <param name="excitationAmplitude">Excitation current amplitude for the measurement frames.</param>
+        /// <returns>The aggregated reconstruction result for the cycle.</returns>
+        Task<ReconstructionResult?> StepReconstructionAsync(double stepSize,
+                                                             double regularizationWeight,
+                                                             double excitationAmplitude);
+    }
+}

--- a/ServiceLayer/Settings.cs
+++ b/ServiceLayer/Settings.cs
@@ -10,6 +10,7 @@ namespace ServiceLayer
             return BusinessLayer.Settings.ApplyContainerRegistration()
                 .RegisterType<IDAQService, DAQService>()
                 .RegisterType<IReconstructionService, ReconstructionService>()
+                .RegisterType<IBlockFemReconstructionService, BlockFemReconstructionService>()
                 .RegisterType<IReconstructionExportService, ReconstructionExportService>()
                 .RegisterType<IMeasurementService, MeasurementService>()
                 .RegisterType<ILogger, WorkspaceLogger>();

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -21,6 +21,8 @@ namespace Utility.Classes.Application
         private static IDiscretization? _originalDiscretization { get; set; } = null;
         private static IDiscretization? _initialDiscretization { get; set; } = null;
 
+        private static bool _useBlockConfiguration;
+
         private static int _maxIterationCount = 50;
         private static double _stepSize = 0.001;
         private static double _regularizationWeight = 1e-3;
@@ -91,6 +93,7 @@ namespace Utility.Classes.Application
             => _completeReconstructionConfiguration = configuration;
         public static void SetOriginalConductivityDistribution(ConductivityDistribution? sigma) => _originalConductivityDistribution = sigma;
         public static void SetInitialConductivityDistribution(ConductivityDistribution? sigma) => _initialConductivityDistribution = sigma;
+        public static void SetUseBlockConfiguration(bool enabled) => _useBlockConfiguration = enabled;
 
         public static User GetUser() => _user;
         public static EITReconstructionParameters GetReconstructionParameters() => _reconstructionParameters;
@@ -103,6 +106,7 @@ namespace Utility.Classes.Application
         public static CompleteReconstructionConfiguration? GetCompleteReconstructionConfiguration() => _completeReconstructionConfiguration;
         public static ConductivityDistribution? GetOriginalConductivityDistribution() => _originalConductivityDistribution;
         public static ConductivityDistribution? GetInitialConductivityDistribution() => _initialConductivityDistribution;
+        public static bool GetUseBlockConfiguration() => _useBlockConfiguration;
 
         public static void UpdateCurrentGlobalFemElements(FEMMesh mesh)
             => _currentGlobalFemElements = [.. mesh.GetElements().Cast<FEMElement>()];


### PR DESCRIPTION
## Summary
- add a block-based FEM reconstruction service that prepares measurements, drives BlockFemReconstructionPersistence, and updates workspace state
- expose a block configuration toggle plus mixed-method picker handling in the reconstruction view model and UI
- persist the block configuration flag when applying configurations and initialize pickers accordingly

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69282f314634833392fa4b5d7db05713)