### PR TITLE
Fix block reconstruction initialization

### DIFF
--- a/BusinessLayer/ReconstructionConfigurationMaterializer.cs
+++ b/BusinessLayer/ReconstructionConfigurationMaterializer.cs
@@ -62,6 +62,12 @@ namespace BusinessLayer
             var originalDistribution = new ConductivityDistribution(mesh.GetConductivityDistribution().Conductivities);
             var initialDistribution = BuildInitialDistribution(mesh, parameters, configuration.Blocks);
 
+            // Ensure the reconstruction begins from the configured initial distribution instead of the
+            // mesh's original conductivities. Copy the generated distribution into the mesh so all
+            // downstream components (measurement simulation, gradients, etc.) operate on the correct
+            // starting state.
+            mesh.SetConductivityDistribution(new ConductivityDistribution(initialDistribution.Conductivities));
+
             var errorMetrics = configuration.Blocks
                 .Where(b => b.Type == BlockType.ErrorMetric)
                 .Select(block =>

--- a/ServiceLayer/BlockFemReconstructionService.cs
+++ b/ServiceLayer/BlockFemReconstructionService.cs
@@ -53,8 +53,14 @@ namespace ServiceLayer
                               ?? throw new InvalidOperationException("Failed to materialize reconstruction runtime context.");
 
             Workspace.SetDiscretization(_runtimeContext.Mesh);
-            Workspace.SetOriginalConductivityDistribution(_runtimeContext.OriginalDistribution);
-            Workspace.SetInitialConductivityDistribution(_runtimeContext.InitialDistribution);
+
+            // Store independent snapshots of the original and initial distributions so later updates
+            // to the mesh conductivity do not mutate these references through shared dictionaries.
+            var originalSnapshot = new ConductivityDistribution(_runtimeContext.OriginalDistribution.Conductivities);
+            var initialSnapshot = new ConductivityDistribution(_runtimeContext.InitialDistribution.Conductivities);
+
+            Workspace.SetOriginalConductivityDistribution(originalSnapshot);
+            Workspace.SetInitialConductivityDistribution(initialSnapshot);
             Workspace.SetElectrodeMeasurementSetup(_runtimeContext.MeasurementSetup);
 
             var parameters = Workspace.GetReconstructionParameters();


### PR DESCRIPTION
## Summary
- apply configured initial conductivity distribution to the FEM mesh when materializing block reconstructions
- snapshot original and initial distributions when initializing the block reconstruction service to avoid shared references being mutated

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928d2514f0c833398309358e944b175)