### PR TITLE
Refactor reconstruction context and video export

### DIFF
--- a/BusinessLayer/BlockFemReconstructionPersistence.cs
+++ b/BusinessLayer/BlockFemReconstructionPersistence.cs
@@ -59,15 +59,15 @@ namespace BusinessLayer
 
             RuntimeContext = ReconstructionConfigurationMaterializer.Materialize(configuration);
 
-            _mesh = RuntimeContext.Mesh;
-            _differentialEquationSolver = RuntimeContext.DifferentialEquationSolver;
-            _numericSolver = RuntimeContext.NumericSolver;
+            _mesh = RuntimeContext.RuntimeMesh;
+            _differentialEquationSolver = RuntimeContext.RuntimeDifferentialEquationSolver;
+            _numericSolver = RuntimeContext.RuntimeNumericSolver;
             _regularizers = RuntimeContext.Regularizers;
             _errorMetrics = RuntimeContext.ErrorMetrics;
             _numericOptimizers = RuntimeContext.NumericOptimizers;
             _initialDistributionType = RuntimeContext.InitialDistributionType;
-            _originalDistribution = RuntimeContext.OriginalDistribution;
-            _initialDistribution = RuntimeContext.InitialDistribution;
+            _originalDistribution = RuntimeContext.OriginalDistribution ?? throw new InvalidOperationException("Original distribution missing from runtime context.");
+            _initialDistribution = RuntimeContext.InitialDistribution ?? throw new InvalidOperationException("Initial distribution missing from runtime context.");
             _measurementSetup = RuntimeContext.MeasurementSetup;
             _usePotentialDifferences = RuntimeContext.UsePotentialDifferences;
             _connections = RuntimeContext.AllConnections;

--- a/BusinessLayer/IReconstructionPersistence.cs
+++ b/BusinessLayer/IReconstructionPersistence.cs
@@ -11,7 +11,7 @@ namespace BusinessLayer
     public interface IReconstructionPersistence
     {
         void SetConductivityDistributions(ConductivityDistribution original, ConductivityDistribution initial);
-        public void InitializeReconstruction(IDiscretization discretization, EITReconstructionParameters parameters, bool reinit);
+        public void InitializeReconstruction(IDiscretization discretization, ReconstructionRuntimeContext parameters, bool reinit);
 
         public ReconstructionFrame Step(double[] measurement, BoundaryCondition boundaryCondition, double gradientStepSize, double redularizationStepSize);
         public void Run(int maxIterationCount, double gradientStepSize, double redularizationStepSize);
@@ -55,7 +55,7 @@ namespace BusinessLayer
         public ReconstructionResult InverseSolveStepGraph(FEMMesh mesh, double[] measurement, BoundaryCondition boundaryCondition, double stepSize);
 
         // --- Persistence ---
-        void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters);
+        void SaveReconstruction(List<ReconstructionResult> frames, string name, ReconstructionRuntimeContext parameters);
         IEnumerable<ReconstructionInfo> GetReconstructions();
         List<ReconstructionResult> LoadReconstruction(string filePath);
 

--- a/BusinessLayer/ReconstructionConfigurationMaterializer.cs
+++ b/BusinessLayer/ReconstructionConfigurationMaterializer.cs
@@ -19,7 +19,7 @@ namespace BusinessLayer
             if (configuration == null)
                 throw new ArgumentNullException(nameof(configuration));
 
-            var parameters = new EITReconstructionParameters();
+            var parameters = new ReconstructionRuntimeContext();
 
             // Extract block parameters
             foreach (var block in configuration.Blocks)
@@ -106,22 +106,21 @@ namespace BusinessLayer
                 })
                 .ToList();
 
-            return new ReconstructionRuntimeContext(
-                mesh,
-                differentialEquationSolver,
-                numericSolver,
-                regularizers,
-                errorMetrics,
-                optimizers,
-                parameters.InitialDistributionType,
-                originalDistribution,
-                initialDistribution,
-                Workspace.GetElectrodeMeasurementSetup(),
-                parameters.UsePotentialDifferences,
-                configuration.AllConnections);
+            parameters.RuntimeMesh = mesh;
+            parameters.RuntimeDifferentialEquationSolver = differentialEquationSolver;
+            parameters.RuntimeNumericSolver = numericSolver;
+            parameters.Regularizers = regularizers;
+            parameters.ErrorMetrics = errorMetrics;
+            parameters.NumericOptimizers = optimizers;
+            parameters.OriginalDistribution = originalDistribution;
+            parameters.InitialDistribution = initialDistribution;
+            parameters.MeasurementSetup = Workspace.GetElectrodeMeasurementSetup();
+            parameters.AllConnections = configuration.AllConnections;
+
+            return parameters;
         }
 
-        private static void ApplyInitializationParameters(ConfiguredBlockSnapshot block, EITReconstructionParameters parameters)
+        private static void ApplyInitializationParameters(ConfiguredBlockSnapshot block, ReconstructionRuntimeContext parameters)
         {
             var parsed = ParseEnum<InitialDistributionTypes>(GetParameterValue(block, "init_method"));
 
@@ -129,7 +128,7 @@ namespace BusinessLayer
                 parameters.InitialDistributionType = parsed;
         }
 
-        private static void ApplyModelParameters(ConfiguredBlockSnapshot block, EITReconstructionParameters parameters)
+        private static void ApplyModelParameters(ConfiguredBlockSnapshot block, ReconstructionRuntimeContext parameters)
         {
             parameters.ConductivityMinimumBound = ParseDouble(GetParameterValue(block, "sigma_min"), parameters.ConductivityMinimumBound);
             parameters.ConductivityMaximumBound = ParseDouble(GetParameterValue(block, "sigma_max"), parameters.ConductivityMaximumBound);
@@ -137,34 +136,34 @@ namespace BusinessLayer
             parameters.ContactImpedanceVariation = ParseDouble(GetParameterValue(block, "contact_impedance_var"), parameters.ContactImpedanceVariation);
         }
 
-        private static void ApplyMeasurementParameters(ConfiguredBlockSnapshot block, EITReconstructionParameters parameters)
+        private static void ApplyMeasurementParameters(ConfiguredBlockSnapshot block, ReconstructionRuntimeContext parameters)
         {
             parameters.UsePotentialDifferences = ParseBool(GetParameterValue(block, "use_potential_differences"));
             Workspace.SetElectrodeMeasurementSetup(ParseEnum<ElectrodeMeasurementSetup>(GetParameterValue(block, "electrode_setup")));
         }
 
-        private static void ApplySolverParameters(ConfiguredBlockSnapshot block, EITReconstructionParameters parameters)
+        private static void ApplySolverParameters(ConfiguredBlockSnapshot block, ReconstructionRuntimeContext parameters)
         {
             parameters.DifferentialEquationSolver = ParseEnum<DifferentialEquationSolver>(GetParameterValue(block, "solver_type"));
             parameters.NumericSolver = ParseEnum<NumericSolver>(GetParameterValue(block, "numeric_solver"));
         }
 
-        private static void ApplyRegularizerParameters(ConfiguredBlockSnapshot block, EITReconstructionParameters parameters)
+        private static void ApplyRegularizerParameters(ConfiguredBlockSnapshot block, ReconstructionRuntimeContext parameters)
         {
             parameters.RegularizationTechnique = ParseEnum<RegularizationTechnique>(GetParameterValue(block, "reg_tech"));
         }
 
-        private static void ApplyErrorMetricParameters(ConfiguredBlockSnapshot block, EITReconstructionParameters parameters)
+        private static void ApplyErrorMetricParameters(ConfiguredBlockSnapshot block, ReconstructionRuntimeContext parameters)
         {
             parameters.ErrorMetric = ParseEnum<ErrorMetric>(GetParameterValue(block, "metric_type"));
         }
 
-        private static void ApplyOptimizerParameters(ConfiguredBlockSnapshot block, EITReconstructionParameters parameters)
+        private static void ApplyOptimizerParameters(ConfiguredBlockSnapshot block, ReconstructionRuntimeContext parameters)
         {
             parameters.NumericOptimizer = ParseEnum<NumericOptimizer>(GetParameterValue(block, "opt_algo"));
         }
 
-        private static ConductivityDistribution BuildInitialDistribution(FEMMesh mesh, EITReconstructionParameters parameters, IReadOnlyList<ConfiguredBlockSnapshot> blocks)
+        private static ConductivityDistribution BuildInitialDistribution(FEMMesh mesh, ReconstructionRuntimeContext parameters, IReadOnlyList<ConfiguredBlockSnapshot> blocks)
         {
             var initBlock = blocks.FirstOrDefault(b => b.Type == BlockType.Initialization);
 
@@ -215,20 +214,4 @@ namespace BusinessLayer
         }
     }
 
-    /// <summary>
-    /// Container describing the runtime objects derived from the canvas configuration.
-    /// </summary>
-    public record ReconstructionRuntimeContext(
-        FEMMesh Mesh,
-        IDifferentialEquationSolver DifferentialEquationSolver,
-        INumericSolver NumericSolver,
-        List<(string id, double connectionWeight, IRegularizer regulizer)> Regularizers,
-        List<(string id, double connectionWeight, IErrorMetric errorMetric)> ErrorMetrics,
-        List<(string id, double connectionWeight, INumericOptimizer numericOptimizer)> NumericOptimizers,
-        InitialDistributionTypes InitialDistributionType,
-        ConductivityDistribution OriginalDistribution,
-        ConductivityDistribution InitialDistribution,
-        ElectrodeMeasurementSetup MeasurementSetup,
-        bool UsePotentialDifferences,
-        IReadOnlyList<WeightedConnectionSnapshot> AllConnections);
 }

--- a/BusinessLayer/ReconstructionPersistence.cs
+++ b/BusinessLayer/ReconstructionPersistence.cs
@@ -108,7 +108,7 @@ namespace BusinessLayer
         /// <param name="discretization">The mesh/grid to reconstruct (FEMMesh or LBMGrid).</param>
         /// <param name="parameters">User configuration for solvers and reconstruction.</param>
         /// <param name="reinit">If true forces re-initialization.</param>
-        public void InitializeReconstruction(IDiscretization discretization, EITReconstructionParameters parameters, bool reinit)
+        public void InitializeReconstruction(IDiscretization discretization, ReconstructionRuntimeContext parameters, bool reinit)
         {
             if(!_initialized || reinit)
             {
@@ -1805,7 +1805,7 @@ namespace BusinessLayer
         /// <summary>
         /// Persists the reconstruction frames and metadata via the repository implementation.
         /// </summary>
-        public void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters)
+        public void SaveReconstruction(List<ReconstructionResult> frames, string name, ReconstructionRuntimeContext parameters)
             => _reconstructionRepository.SaveReconstruction(frames, name, parameters);
 
         /// <summary>

--- a/DataAccessLayer/IReconstructionRepository.cs
+++ b/DataAccessLayer/IReconstructionRepository.cs
@@ -6,7 +6,7 @@ namespace DataAccessLayer
 {
     public interface IReconstructionRepository
     {
-        void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters);
+        void SaveReconstruction(List<ReconstructionResult> frames, string name, ReconstructionRuntimeContext parameters);
         IEnumerable<ReconstructionInfo> GetReconstructions();
         List<ReconstructionResult> LoadReconstruction(string filePath);
     }

--- a/DataAccessLayer/ReconstructionRepository.cs
+++ b/DataAccessLayer/ReconstructionRepository.cs
@@ -10,7 +10,7 @@ namespace DataAccessLayer
         private static string ReconDir => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                                                         "EITApplication", "Reconstructions");
 
-        public void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters)
+        public void SaveReconstruction(List<ReconstructionResult> frames, string name, ReconstructionRuntimeContext parameters)
         {
             if (frames == null || frames.Count == 0) throw new ArgumentException("No frames to save.", nameof(frames));
             if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name required.", nameof(name));

--- a/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/BaseReconstructionPageViewModel.cs
@@ -10,7 +10,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 {
     public partial class BaseReconstructionPageViewModel : BaseViewModel
     {
-        private EITReconstructionParameters _currentParameters;
+        private ReconstructionRuntimeContext _currentParameters;
 
         private static readonly DifferentialEquationSolver[] DifferentialEquationSolverValues = Enum.GetValues<DifferentialEquationSolver>();
         public IEnumerable<DifferentialEquationSolver> DifferentialEquationSolverOptions => DifferentialEquationSolverValues;
@@ -34,7 +34,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         public IEnumerable<MeasurementNoiseType> MeasurementNoiseTypeOptions => MeasurementNoiseTypeValues;
 
         [ObservableProperty]
-        private EITReconstructionParameters reconstructionParameters = Workspace.GetReconstructionParameters();
+        private ReconstructionRuntimeContext reconstructionParameters = Workspace.GetReconstructionParameters();
 
         public bool IsNoiseAmplitudeEnabled => ReconstructionParameters.MeasurementNoiseType != MeasurementNoiseType.None;
 
@@ -52,7 +52,7 @@ namespace ElectricalImpedanceTomography.ViewModels
                                              _currentParameters.ConductivityMaximumBound);
         }
 
-        partial void OnReconstructionParametersChanged(EITReconstructionParameters value)
+        partial void OnReconstructionParametersChanged(ReconstructionRuntimeContext value)
         {
             if (_currentParameters != null)
                 _currentParameters.PropertyChanged -= OnReconstructionParametersPropertyChanged;
@@ -67,14 +67,14 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         private void OnReconstructionParametersPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(EITReconstructionParameters.MeasurementNoiseType))
+            if (e.PropertyName == nameof(ReconstructionRuntimeContext.MeasurementNoiseType))
                 OnPropertyChanged(nameof(IsNoiseAmplitudeEnabled));
 
-            if (e.PropertyName == nameof(EITReconstructionParameters.DifferentialEquationSolver))
+            if (e.PropertyName == nameof(ReconstructionRuntimeContext.DifferentialEquationSolver))
                 OnPropertyChanged(nameof(IsLbmSolverSelected));
 
-            if (e.PropertyName == nameof(EITReconstructionParameters.ConductivityMinimumBound)
-                || e.PropertyName == nameof(EITReconstructionParameters.ConductivityMaximumBound))
+            if (e.PropertyName == nameof(ReconstructionRuntimeContext.ConductivityMinimumBound)
+                || e.PropertyName == nameof(ReconstructionRuntimeContext.ConductivityMaximumBound))
             {
                 var parameters = ReconstructionParameters;
                 if (parameters != null)

--- a/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MainPageViewModel.cs
@@ -33,7 +33,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         private bool hardwareConnected;
 
         [ObservableProperty]
-        private EITReconstructionParameters reconstructionParameters = Workspace.GetReconstructionParameters();
+        private ReconstructionRuntimeContext reconstructionParameters = Workspace.GetReconstructionParameters();
 
         [ObservableProperty]
         private User user = Workspace.GetUser();
@@ -50,7 +50,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         [ObservableProperty]
         private string latestReleaseDate = ApplicationInformation.LatestReleaseDate;
 
-        partial void OnReconstructionParametersChanged(EITReconstructionParameters value) => Workspace.SetReconstructionParameters(value);
+        partial void OnReconstructionParametersChanged(ReconstructionRuntimeContext value) => Workspace.SetReconstructionParameters(value);
         partial void OnCurrentAmplitudeChanged(double value) => CurrentImpedanceModel.Intensity = (float)Math.Clamp(value, 0, 1);
         partial void OnExcitationFrequencyChanged(double value) => CurrentImpedanceModel.Color = value > 1 ? Colors.Red : Colors.CornflowerBlue;
 

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -81,7 +81,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         private bool _updatingDrivePatternSelection;
         
         /// <summary>Tracks reconstruction parameters for change detection and UI sync.</summary>
-        private EITReconstructionParameters? _trackedParameters;
+        private ReconstructionRuntimeContext? _trackedParameters;
         
         /// <summary>Current measurement source selection mirrored from the workspace.</summary>
         private MeasurementSourceOption _selectedMeasurementSource = Workspace.GetMeasurementSource();
@@ -621,7 +621,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         /// <summary>
         /// Starts tracking changes on the given parameter object so the view model can reflect UI updates.
         /// </summary>
-        private void TrackReconstructionParameters(EITReconstructionParameters parameters)
+        private void TrackReconstructionParameters(ReconstructionRuntimeContext parameters)
         {
             if (_trackedParameters != null)
                 _trackedParameters.PropertyChanged -= OnTrackedParametersPropertyChanged;
@@ -636,11 +636,11 @@ namespace ElectricalImpedanceTomography.ViewModels
         /// </summary>
         private void OnTrackedParametersPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(EITReconstructionParameters.DrivePattern))
+            if (e.PropertyName == nameof(ReconstructionRuntimeContext.DrivePattern))
                 SyncDrivePatternSelection();
-            else if (e.PropertyName == nameof(EITReconstructionParameters.DifferentialEquationSolver)
-                     || e.PropertyName == nameof(EITReconstructionParameters.UseOmpParallelization)
-                     || e.PropertyName == nameof(EITReconstructionParameters.UseCudaAcceleration))
+            else if (e.PropertyName == nameof(ReconstructionRuntimeContext.DifferentialEquationSolver)
+                     || e.PropertyName == nameof(ReconstructionRuntimeContext.UseOmpParallelization)
+                     || e.PropertyName == nameof(ReconstructionRuntimeContext.UseCudaAcceleration))
                 UpdateParallelizationToggleState();
         }
 
@@ -1756,7 +1756,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         /// <summary>Restores UI and parameter defaults useful for quick experimentation.</summary>
         public void ResetAllToDefaults()
         {
-            var defaults = new EITReconstructionParameters();
+            var defaults = new ReconstructionRuntimeContext();
             ReconstructionParameters = defaults;
 
             MaxIterationCount = 50;
@@ -1895,248 +1895,23 @@ namespace ElectricalImpedanceTomography.ViewModels
         /// Generates a reconstruction video by rendering per‑frame images and encoding them into the
         /// requested container. Returns a rich result with success flag and file path or error details.
         /// </summary>
-        public async Task<VideoExportResult> ExportReconstructionVideoAsync(SKSize distributionCanvasSize,
-                                                                            SKSize colorbarCanvasSize,
-                                                                            SKSize residualCanvasSize,
-                                                                            PotentialDisplayMode mode,
-                                                                            VideoExportContainer container,
-                                                                            IProgress<VideoExportProgressReport>? progress = null,
-                                                                            CancellationToken cancellationToken = default)
+        public Task<VideoExportResult> ExportReconstructionVideoAsync(SKSize distributionCanvasSize,
+                                                                       SKSize colorbarCanvasSize,
+                                                                       SKSize residualCanvasSize,
+                                                                       PotentialDisplayMode mode,
+                                                                       VideoExportContainer container,
+                                                                       IProgress<VideoExportProgressReport>? progress = null,
+                                                                       CancellationToken cancellationToken = default)
         {
             _selectedDisplayMode = mode;
 
-            var frames = Workspace.GetReconstructionFrames().ToList();
-            if (frames.Count == 0)
-                return VideoExportResult.CreateFailure("No Frames", "There are no reconstruction frames to export.");
-
-            progress?.Report(new VideoExportProgressReport(0.0,
-                                                            "Preparing reconstruction frames for video generation..."));
-
-            var results = Workspace.GetReconstructionResults().ToList();
-            var fallbackDiscretization = results.Select(r => r.Discretization)
-                                                .FirstOrDefault(d => d != null)
-                                        ?? Workspace.GetDiscretization();
-
-            if (fallbackDiscretization == null)
-                return VideoExportResult.CreateFailure("No Mesh", "Unable to determine the discretization for rendering.");
-
-            var residualHistory = results
-                .Select(r => ReconstructionStatistics.CalculateResidual(r, true))
-                .ToList();
-
-            var distributionSize = ReconstructionVideoRenderer.NormalizeSize(distributionCanvasSize, 250, 250);
-            var colorbarSize = ReconstructionVideoRenderer.NormalizeSize(colorbarCanvasSize, 250, 20);
-            var residualSize = ReconstructionVideoRenderer.NormalizeSize(residualCanvasSize, 600, 170);
-
-            string directory = FileSystem.Current.AppDataDirectory;
-            Directory.CreateDirectory(directory);
-            string baseFileName = $"reconstruction_{DateTime.Now:yyyyMMdd_HHmmss}";
-            string mp4FilePath = Path.Combine(directory, baseFileName + ".mp4");
-            string aviFallbackFilePath = Path.Combine(directory, baseFileName + ".avi");
-            string requestedFilePath = container switch
-            {
-                VideoExportContainer.Avi => aviFallbackFilePath,
-                _ => mp4FilePath
-            };
-            string? finalFilePath = null;
-
-            try
-            {
-                await Task.Run(async () =>
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    int videoWidth = 0;
-                    int videoHeight = 0;
-                    double totalSteps = frames.Count + 1.0;
-                    string tempFrameDirectory = Path.Combine(FileSystem.Current.CacheDirectory,
-                                                             "VideoExportFrames",
-                                                             Guid.NewGuid().ToString("N"));
-
-                    Directory.CreateDirectory(tempFrameDirectory);
-
-                    var encodedFrames = new List<byte[]>(frames.Count);
-                    var frameImagePaths = new List<string>(frames.Count);
-
-                    try
-                    {
-                        for (int i = 0; i < frames.Count; i++)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-
-                            double progressValue = (i + 1) / totalSteps;
-                            progress?.Report(new VideoExportProgressReport(progressValue,
-                                                                            $"Rendering frame {i + 1} of {frames.Count}..."));
-
-                            var context = ReconstructionVideoRenderer.FindResultForFrame(results, i, out int resultIndex);
-                            int residualCount = resultIndex >= 0
-                                ? Math.Min(resultIndex + 1, residualHistory.Count)
-                                : residualHistory.Count;
-
-                            using var image = ReconstructionVideoRenderer.RenderFrameSnapshot(frames[i],
-                                                                                                 context,
-                                                                                                 fallbackDiscretization,
-                                                                                                 residualHistory,
-                                                                                                 residualCount,
-                                                                                                 distributionSize,
-                                                                                                 colorbarSize,
-                                                                                                 residualSize,
-                                                                                                 _selectedDisplayMode);
-
-                            if (videoWidth == 0 || videoHeight == 0)
-                            {
-                                videoWidth = image.Width;
-                                videoHeight = image.Height;
-                            }
-                            else if (image.Width != videoWidth || image.Height != videoHeight)
-                            {
-                                throw new InvalidOperationException("All exported frames must share the same dimensions.");
-                            }
-
-                            using var encodedFrame = image.Encode(SKEncodedImageFormat.Jpeg, 85);
-                            if (encodedFrame == null)
-                                throw new InvalidOperationException("Failed to encode video frame to JPEG.");
-
-                            var frameBytes = encodedFrame.ToArray();
-                            encodedFrames.Add(frameBytes);
-
-                            string framePath = Path.Combine(tempFrameDirectory, $"frame_{i:D6}.jpg");
-                            await File.WriteAllBytesAsync(framePath, frameBytes, cancellationToken).ConfigureAwait(false);
-                            frameImagePaths.Add(framePath);
-                        }
-
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        progress?.Report(new VideoExportProgressReport(
-                            Math.Min(0.98, frames.Count / (frames.Count + 1.0)),
-                            "Encoding video stream..."));
-
-                        bool mp4Created = false;
-
-                        if (container != VideoExportContainer.Avi)
-                        {
-                            mp4Created = await Mp4VideoExporter.TryExportAsync(frameImagePaths,
-                                                                              videoWidth,
-                                                                              videoHeight,
-                                                                              Workspace.ReconstructionVideoFramesPerSecond,
-                                                                              requestedFilePath,
-                                                                              cancellationToken).ConfigureAwait(false);
-
-                            if (mp4Created)
-                            {
-                                finalFilePath = requestedFilePath;
-                            }
-                        }
-
-                        if (!mp4Created)
-                        {
-                            if (encodedFrames.Count == 0)
-                                throw new InvalidOperationException("No frames were encoded for export.");
-
-                            if (File.Exists(mp4FilePath) && container != VideoExportContainer.Avi)
-                            {
-                                try
-                                {
-                                    File.Delete(mp4FilePath);
-                                }
-                                catch
-                                {
-                                    // Ignore failures when cleaning up a partial MP4 export.
-                                }
-                            }
-
-                            string aviTargetPath = container == VideoExportContainer.Avi
-                                ? requestedFilePath
-                                : aviFallbackFilePath;
-
-                            if (File.Exists(aviTargetPath))
-                            {
-                                try
-                                {
-                                    File.Delete(aviTargetPath);
-                                }
-                                catch
-                                {
-                                    // Ignore cleanup errors.
-                                }
-                            }
-
-                            using var stream = File.Create(aviTargetPath);
-                            using var videoStream = AviVideoWriter.BeginWrite(stream,
-                                                                             videoWidth,
-                                                                             videoHeight,
-                                                                             Workspace.ReconstructionVideoFramesPerSecond,
-                                                                             encodedFrames[0].Length,
-                                                                             AviVideoWriter.AviVideoCodec.MotionJpeg);
-
-                            foreach (var frame in encodedFrames)
-                            {
-                                cancellationToken.ThrowIfCancellationRequested();
-                                videoStream.WriteFrame(frame);
-                            }
-
-                            videoStream.Complete();
-                            finalFilePath = aviTargetPath;
-                        }
-                    }
-                    finally
-                    {
-                        try
-                        {
-                            if (Directory.Exists(tempFrameDirectory))
-                            {
-                                Directory.Delete(tempFrameDirectory, recursive: true);
-                            }
-                        }
-                        catch
-                        {
-                            // Ignore cleanup errors.
-                        }
-                    }
-                }, cancellationToken);
-
-                progress?.Report(new VideoExportProgressReport(1.0, "Video generation completed."));
-                string path = finalFilePath ?? requestedFilePath;
-                return VideoExportResult.CreateSuccess(path);
-            }
-            catch (OperationCanceledException)
-            {
-                foreach (var path in new[] { mp4FilePath, aviFallbackFilePath })
-                {
-                    if (File.Exists(path))
-                    {
-                        try
-                        {
-                            File.Delete(path);
-                        }
-                        catch
-                        {
-                            // Ignore any errors encountered during cleanup.
-                        }
-                    }
-                }
-
-                return VideoExportResult.CreateFailure("Export Aborted", "The video export was aborted.");
-            }
-            catch (Exception ex)
-            {
-                foreach (var path in new[] { mp4FilePath, aviFallbackFilePath })
-                {
-                    if (File.Exists(path))
-                    {
-                        try
-                        {
-                            File.Delete(path);
-                        }
-                        catch
-                        {
-                            // Ignore cleanup errors when reporting the failure.
-                        }
-                    }
-                }
-
-                return VideoExportResult.CreateFailure("Export Failed", ex.Message);
-            }
+            return ReconstructionVideoExportWorkflow.ExportAsync(distributionCanvasSize,
+                                                                 colorbarCanvasSize,
+                                                                 residualCanvasSize,
+                                                                 _selectedDisplayMode,
+                                                                 container,
+                                                                 progress,
+                                                                 cancellationToken);
         }
 
         /// <summary>

--- a/ServiceLayer/IMeasurementService.cs
+++ b/ServiceLayer/IMeasurementService.cs
@@ -9,7 +9,7 @@ namespace ServiceLayer
     public interface IMeasurementService
     {
         void Initialize(IDiscretization discretization,
-                        EITReconstructionParameters parameters,
+                        ReconstructionRuntimeContext parameters,
                         DrivePattern drivePattern,
                         Func<IDifferentialEquationSolver?> solverAccessor,
                         ConductivityDistribution? measurementConductivity = null);

--- a/ServiceLayer/IReconstructionService.cs
+++ b/ServiceLayer/IReconstructionService.cs
@@ -7,7 +7,7 @@ namespace ServiceLayer
 {
     public interface IReconstructionService
     {
-        void InitializeReconstruction(IDiscretization discretization, EITReconstructionParameters parameters, bool reinit);
+        void InitializeReconstruction(IDiscretization discretization, ReconstructionRuntimeContext parameters, bool reinit);
 
         // --- Background reconstruction control ---
         event EventHandler<ReconstructionResult> ReconstructionUpdated;
@@ -23,7 +23,7 @@ namespace ServiceLayer
                                                                     double excitationAmplitude);
 
         // --- Persistence ---
-        void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters);
+        void SaveReconstruction(List<ReconstructionResult> frames, string name, ReconstructionRuntimeContext parameters);
         IEnumerable<ReconstructionInfo> GetReconstructions();
         List<ReconstructionResult> LoadReconstruction(string filePath);
     }

--- a/ServiceLayer/MeasurementService.cs
+++ b/ServiceLayer/MeasurementService.cs
@@ -61,7 +61,7 @@ namespace ServiceLayer
         /// future <see cref="EnsureMeasurements"/> calls can generate or adopt frames.
         /// </summary>
         public void Initialize(IDiscretization discretization,
-                               EITReconstructionParameters parameters,
+                               ReconstructionRuntimeContext parameters,
                                DrivePattern drivePattern,
                                Func<IDifferentialEquationSolver?> solverAccessor,
                                ConductivityDistribution? measurementConductivity = null)

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -93,11 +93,11 @@ namespace ServiceLayer
         /// <param name="discretization">Target discretization (FEM/LBM) to reconstruct on.</param>
         /// <param name="parameters">Reconstruction parameters selected by the user.</param>
         /// <param name="reinit">Whether to reinitialize persistence internal caches/state.</param>
-        public void InitializeReconstruction(IDiscretization discretization, EITReconstructionParameters parameters, bool reinit)
+        public void InitializeReconstruction(IDiscretization discretization, ReconstructionRuntimeContext parameters, bool reinit)
         {
             try
             {
-                Workspace.AddLogMessage("Reconstruction Service", "Reconstruction initialization started with the specified EITReconstructionParameters object.");
+                Workspace.AddLogMessage("Reconstruction Service", "Reconstruction initialization started with the specified runtime context.");
 
                 // 1) Surface discretization (mesh/grid) globally and cache locally for quick access.
                 Workspace.SetDiscretization(discretization);
@@ -594,7 +594,7 @@ namespace ServiceLayer
         /// <summary>
         /// Persists a reconstruction to storage using the underlying persistence implementation.
         /// </summary>
-        public void SaveReconstruction(List<ReconstructionResult> frames, string name, EITReconstructionParameters parameters)
+        public void SaveReconstruction(List<ReconstructionResult> frames, string name, ReconstructionRuntimeContext parameters)
         {
             try
             {

--- a/Utility/ClassDiagram1.cd
+++ b/Utility/ClassDiagram1.cd
@@ -187,11 +187,11 @@
       <FileName>Classes\Models\InverseModel.cs</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Utility.Classes.ReconstructionParameters.EITReconstructionParameters" Collapsed="true">
+  <Class Name="Utility.Classes.ReconstructionParameters.ReconstructionRuntimeContext" Collapsed="true">
     <Position X="9.5" Y="5.5" Width="2.5" />
     <TypeIdentifier>
       <HashCode>AAAAAQAEAAAAAAAACACBAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
-      <FileName>Classes\ReconstructionParameters\EITReconstructionParameters.cs</FileName>
+      <FileName>Classes\ReconstructionParameters\ReconstructionRuntimeContext.cs</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Utility.Classes.ReconstructionParameters.FiniteElementDESolver" Collapsed="true" BaseTypeListCollapsed="true">

--- a/Utility/Classes/Application/Workspace.cs
+++ b/Utility/Classes/Application/Workspace.cs
@@ -16,7 +16,7 @@ namespace Utility.Classes.Application
         private const int MaxMessageCount = 200;
 
         private static User _user { get; set; } = new DefaultUser(0, "No User");
-        private static EITReconstructionParameters _reconstructionParameters = new();
+        private static ReconstructionRuntimeContext _reconstructionParameters = new();
         private static IDiscretization? _discretization{ get; set; } = null;
         private static IDiscretization? _originalDiscretization { get; set; } = null;
         private static IDiscretization? _initialDiscretization { get; set; } = null;
@@ -58,7 +58,7 @@ namespace Utility.Classes.Application
 
         public static event Action<ElectrodeMeasurementSetup>? ElectrodeMeasurementSetupChanged;
 
-        public static void Initialize(User user, EITReconstructionParameters? eITReconstructionParameters, IDiscretization? discretization)
+        public static void Initialize(User user, ReconstructionRuntimeContext? eITReconstructionParameters, IDiscretization? discretization)
         {
             if(_initialized) return;
 
@@ -76,7 +76,7 @@ namespace Utility.Classes.Application
         }
 
         public static void SetUser(User user) => _user = user;
-        public static void SetReconstructionParameters(EITReconstructionParameters eITReconstructionParameters)
+        public static void SetReconstructionParameters(ReconstructionRuntimeContext eITReconstructionParameters)
         {
             _reconstructionParameters = eITReconstructionParameters;
             _conductivityMinimumBound = eITReconstructionParameters.ConductivityMinimumBound;
@@ -96,7 +96,7 @@ namespace Utility.Classes.Application
         public static void SetUseBlockConfiguration(bool enabled) => _useBlockConfiguration = enabled;
 
         public static User GetUser() => _user;
-        public static EITReconstructionParameters GetReconstructionParameters() => _reconstructionParameters;
+        public static ReconstructionRuntimeContext GetReconstructionParameters() => _reconstructionParameters;
         public static IDiscretization? GetDiscretization() => _discretization;
         public static IDiscretization? GetOriginalDiscretization() => _originalDiscretization;
         public static IDiscretization? GetInitialDiscretization() => _initialDiscretization;

--- a/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockDefinition.cs
+++ b/Utility/Classes/Configurations/ReconstructionConfiguration/ReconstructionBlockDefinition.cs
@@ -15,7 +15,7 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
             string title,
             string iconColor,
             Func<IEnumerable<ConfigurationParameter>> parameterFactory,
-            Action<ReconstructionConfigurationBlock, EITReconstructionParameters>? applyParameters = null)
+            Action<ReconstructionConfigurationBlock, ReconstructionRuntimeContext>? applyParameters = null)
         {
             Type = type;
             Title = title;
@@ -28,6 +28,6 @@ namespace Utility.Classes.Configurations.ReconstructionConfiguration
         public string Title { get; }
         public string IconColor { get; }
         public Func<IEnumerable<ConfigurationParameter>> ParameterFactory { get; }
-        public Action<ReconstructionConfigurationBlock, EITReconstructionParameters> ApplyParameters { get; }
+        public Action<ReconstructionConfigurationBlock, ReconstructionRuntimeContext> ApplyParameters { get; }
     }
 }

--- a/Utility/Classes/ReconstructionParameters/ReconstructionRuntimeContext.cs
+++ b/Utility/Classes/ReconstructionParameters/ReconstructionRuntimeContext.cs
@@ -1,15 +1,22 @@
 ﻿using Utility.Classes.Discretizer;
-using CommunityToolkit.Mvvm.ComponentModel;
+using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Factories;
 using Utility.Classes.Measurement;
+using Utility.Classes.Reconstruction;
 using Utility.Classes.Reconstruction.VirtualElectrodes;
+using Utility.Classes.Solvers;
+using Utility.Classes.Solvers.FiniteElementSolver;
+using Utility.Classes.Solvers.NumericOptimizers;
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Collections.Generic;
 
 namespace Utility.Classes.ReconstructionParameters
 {
     /// <summary>
-    /// Data transfer object that captures all user-configurable reconstruction options.
+    /// Data transfer object that captures all user-configurable reconstruction options and runtime
+    /// components materialized from either the classic parameters or the block configuration pipeline.
     /// </summary>
-    public partial class EITReconstructionParameters : ObservableObject
+    public partial class ReconstructionRuntimeContext : ObservableObject
     {
         [ObservableProperty]
         private DifferentialEquationSolver differentialEquationSolver = DifferentialEquationSolver.FEM;
@@ -88,9 +95,23 @@ namespace Utility.Classes.ReconstructionParameters
         private LatticeBoltzmannRelaxationModel lbmRelaxationModel = LatticeBoltzmannRelaxationModel.BGK;
 
         /// <summary>
+        /// Runtime references constructed from the block-based pipeline when available.
+        /// </summary>
+        public FEMMesh? RuntimeMesh { get; set; }
+        public IDifferentialEquationSolver? RuntimeDifferentialEquationSolver { get; set; }
+        public INumericSolver? RuntimeNumericSolver { get; set; }
+        public List<(string id, double connectionWeight, IRegularizer regulizer)> Regularizers { get; set; } = new();
+        public List<(string id, double connectionWeight, IErrorMetric errorMetric)> ErrorMetrics { get; set; } = new();
+        public List<(string id, double connectionWeight, INumericOptimizer numericOptimizer)> NumericOptimizers { get; set; } = new();
+        public ConductivityDistribution? OriginalDistribution { get; set; }
+        public ConductivityDistribution? InitialDistribution { get; set; }
+        public ElectrodeMeasurementSetup MeasurementSetup { get; set; } = ElectrodeMeasurementSetup.Active;
+        public IReadOnlyList<WeightedConnectionSnapshot>? AllConnections { get; set; }
+
+        /// <summary>
         /// Creates a parameter set using the default reconstruction configuration.
         /// </summary>
-        public EITReconstructionParameters()
+        public ReconstructionRuntimeContext()
         {
             DifferentialEquationSolver = DifferentialEquationSolver.FEM;
             RegularizationTechnique = RegularizationTechnique.None;
@@ -111,7 +132,7 @@ namespace Utility.Classes.ReconstructionParameters
         /// Creates a parameter set with the provided solver, regularisation,
         /// and noise configuration.
         /// </summary>
-        public EITReconstructionParameters(DifferentialEquationSolver differentialEquationSolver,
+        public ReconstructionRuntimeContext(DifferentialEquationSolver differentialEquationSolver,
                                            RegularizationTechnique regularizationTechnique,
                                            ErrorMetric errorMetric,
                                            NumericSolver numericSolver,

--- a/Utility/Exports/ReconstructionVideoExportWorkflow.cs
+++ b/Utility/Exports/ReconstructionVideoExportWorkflow.cs
@@ -1,0 +1,265 @@
+﻿using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Utility.Classes;
+using Utility.Rendering;
+
+namespace Utility.Exports
+{
+    /// <summary>
+    /// Encapsulates the reconstruction video export workflow so the view model can delegate
+    /// heavy generation logic while keeping UI state management local.
+    /// </summary>
+    public static class ReconstructionVideoExportWorkflow
+    {
+        /// <summary>
+        /// Generates a reconstruction video by rendering per-frame images and encoding them into the
+        /// requested container. Returns a rich result with success flag and file path or error details.
+        /// </summary>
+        public static async Task<VideoExportResult> ExportAsync(SKSize distributionCanvasSize,
+                                                                SKSize colorbarCanvasSize,
+                                                                SKSize residualCanvasSize,
+                                                                PotentialDisplayMode mode,
+                                                                VideoExportContainer container,
+                                                                IProgress<VideoExportProgressReport>? progress = null,
+                                                                CancellationToken cancellationToken = default)
+        {
+            var frames = Workspace.GetReconstructionFrames().ToList();
+            if (frames.Count == 0)
+                return VideoExportResult.CreateFailure("No Frames", "There are no reconstruction frames to export.");
+
+            progress?.Report(new VideoExportProgressReport(0.0,
+                                                            "Preparing reconstruction frames for video generation..."));
+
+            var results = Workspace.GetReconstructionResults().ToList();
+            var fallbackDiscretization = results.Select(r => r.Discretization)
+                                                .FirstOrDefault(d => d != null)
+                                        ?? Workspace.GetDiscretization();
+
+            if (fallbackDiscretization == null)
+                return VideoExportResult.CreateFailure("No Mesh", "Unable to determine the discretization for rendering.");
+
+            var residualHistory = results
+                .Select(r => ReconstructionStatistics.CalculateResidual(r, true))
+                .ToList();
+
+            var distributionSize = ReconstructionVideoRenderer.NormalizeSize(distributionCanvasSize, 250, 250);
+            var colorbarSize = ReconstructionVideoRenderer.NormalizeSize(colorbarCanvasSize, 250, 20);
+            var residualSize = ReconstructionVideoRenderer.NormalizeSize(residualCanvasSize, 600, 170);
+
+            string directory = FileSystem.Current.AppDataDirectory;
+            Directory.CreateDirectory(directory);
+            string baseFileName = $"reconstruction_{DateTime.Now:yyyyMMdd_HHmmss}";
+            string mp4FilePath = Path.Combine(directory, baseFileName + ".mp4");
+            string aviFallbackFilePath = Path.Combine(directory, baseFileName + ".avi");
+            string requestedFilePath = container switch
+            {
+                VideoExportContainer.Avi => aviFallbackFilePath,
+                _ => mp4FilePath
+            };
+            string? finalFilePath = null;
+
+            try
+            {
+                await Task.Run(async () =>
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    int videoWidth = 0;
+                    int videoHeight = 0;
+                    double totalSteps = frames.Count + 1.0;
+                    string tempFrameDirectory = Path.Combine(FileSystem.Current.CacheDirectory,
+                                                             "VideoExportFrames",
+                                                             Guid.NewGuid().ToString("N"));
+
+                    Directory.CreateDirectory(tempFrameDirectory);
+
+                    var encodedFrames = new List<byte[]>(frames.Count);
+                    var frameImagePaths = new List<string>(frames.Count);
+
+                    try
+                    {
+                        for (int i = 0; i < frames.Count; i++)
+                        {
+                            cancellationToken.ThrowIfCancellationRequested();
+
+                            double progressValue = (i + 1) / totalSteps;
+                            progress?.Report(new VideoExportProgressReport(progressValue,
+                                                                            $"Rendering frame {i + 1} of {frames.Count}..."));
+
+                            var context = ReconstructionVideoRenderer.FindResultForFrame(results, i, out int resultIndex);
+                            int residualCount = resultIndex >= 0
+                                ? Math.Min(resultIndex + 1, residualHistory.Count)
+                                : residualHistory.Count;
+
+                            using var image = ReconstructionVideoRenderer.RenderFrameSnapshot(frames[i],
+                                                                                             context,
+                                                                                             fallbackDiscretization,
+                                                                                             residualHistory,
+                                                                                             residualCount,
+                                                                                             distributionSize,
+                                                                                             colorbarSize,
+                                                                                             residualSize,
+                                                                                             mode);
+
+                            if (videoWidth == 0 || videoHeight == 0)
+                            {
+                                videoWidth = image.Width;
+                                videoHeight = image.Height;
+                            }
+                            else if (image.Width != videoWidth || image.Height != videoHeight)
+                            {
+                                throw new InvalidOperationException("All exported frames must share the same dimensions.");
+                            }
+
+                            using var encodedFrame = image.Encode(SKEncodedImageFormat.Jpeg, 85);
+                            if (encodedFrame == null)
+                                throw new InvalidOperationException("Failed to encode video frame to JPEG.");
+
+                            var frameBytes = encodedFrame.ToArray();
+                            encodedFrames.Add(frameBytes);
+
+                            string framePath = Path.Combine(tempFrameDirectory, $"frame_{i:D6}.jpg");
+                            await File.WriteAllBytesAsync(framePath, frameBytes, cancellationToken).ConfigureAwait(false);
+                            frameImagePaths.Add(framePath);
+                        }
+
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        progress?.Report(new VideoExportProgressReport(
+                            Math.Min(0.98, frames.Count / (frames.Count + 1.0)),
+                            "Encoding video stream..."));
+
+                        bool mp4Created = false;
+
+                        if (container != VideoExportContainer.Avi)
+                        {
+                            mp4Created = await Mp4VideoExporter.TryExportAsync(frameImagePaths,
+                                                                              videoWidth,
+                                                                              videoHeight,
+                                                                              Workspace.ReconstructionVideoFramesPerSecond,
+                                                                              requestedFilePath,
+                                                                              cancellationToken).ConfigureAwait(false);
+
+                            if (mp4Created)
+                            {
+                                finalFilePath = requestedFilePath;
+                            }
+                        }
+
+                        if (!mp4Created)
+                        {
+                            if (encodedFrames.Count == 0)
+                                throw new InvalidOperationException("No frames were encoded for export.");
+
+                            if (File.Exists(mp4FilePath) && container != VideoExportContainer.Avi)
+                            {
+                                try
+                                {
+                                    File.Delete(mp4FilePath);
+                                }
+                                catch
+                                {
+                                    // Ignore failures when cleaning up a partial MP4 export.
+                                }
+                            }
+
+                            string aviTargetPath = container == VideoExportContainer.Avi
+                                ? requestedFilePath
+                                : aviFallbackFilePath;
+
+                            if (File.Exists(aviTargetPath))
+                            {
+                                try
+                                {
+                                    File.Delete(aviTargetPath);
+                                }
+                                catch
+                                {
+                                    // Ignore cleanup errors.
+                                }
+                            }
+
+                            using var stream = File.Create(aviTargetPath);
+                            using var videoStream = AviVideoWriter.BeginWrite(stream,
+                                                                             videoWidth,
+                                                                             videoHeight,
+                                                                             Workspace.ReconstructionVideoFramesPerSecond,
+                                                                             encodedFrames[0].Length,
+                                                                             AviVideoWriter.AviVideoCodec.MotionJpeg);
+
+                            foreach (var frame in encodedFrames)
+                            {
+                                cancellationToken.ThrowIfCancellationRequested();
+                                videoStream.WriteFrame(frame);
+                            }
+
+                            videoStream.Complete();
+                            finalFilePath = aviTargetPath;
+                        }
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            if (Directory.Exists(tempFrameDirectory))
+                            {
+                                Directory.Delete(tempFrameDirectory, recursive: true);
+                            }
+                        }
+                        catch
+                        {
+                            // Ignore cleanup errors.
+                        }
+                    }
+                }, cancellationToken);
+
+                progress?.Report(new VideoExportProgressReport(1.0, "Video generation completed."));
+                string path = finalFilePath ?? requestedFilePath;
+                return VideoExportResult.CreateSuccess(path);
+            }
+            catch (OperationCanceledException)
+            {
+                foreach (var path in new[] { mp4FilePath, aviFallbackFilePath })
+                {
+                    if (File.Exists(path))
+                    {
+                        try
+                        {
+                            File.Delete(path);
+                        }
+                        catch
+                        {
+                            // Ignore any errors encountered during cleanup.
+                        }
+                    }
+                }
+
+                return VideoExportResult.CreateFailure("Export Aborted", "The video export was aborted.");
+            }
+            catch (Exception ex)
+            {
+                foreach (var path in new[] { mp4FilePath, aviFallbackFilePath })
+                {
+                    if (File.Exists(path))
+                    {
+                        try
+                        {
+                            File.Delete(path);
+                        }
+                        catch
+                        {
+                            // Ignore cleanup errors when reporting the failure.
+                        }
+                    }
+                }
+
+                return VideoExportResult.CreateFailure("Export Failed", ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move reconstruction video export workflow out of the page view model into a shared utility helper
- replace the legacy reconstruction parameter DTO with the ReconstructionRuntimeContext across workspace, services, and persistence
- align reconstruction configuration materialization and block FEM persistence with the new runtime context object

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929d843fd448333a0e1764c96aacf56)