### PR TITLE
Sync initial conductivity distribution on page load

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -101,6 +101,9 @@ namespace ElectricalImpedanceTomography.ViewModels
         /// <summary>True when the NdMap spectral interpolation method is active.</summary>
         public bool IsNdMethod => VirtualElectrodeSettings.UseVirtualElectrodes && VirtualElectrodeSettings.Method == VirtualElectrodeMethod.NdMapSpectralInterpolation;
 
+        /// <summary>Tracks the last initial distribution type applied to the workspace.</summary>
+        private InitialDistributionTypes _lastAppliedInitialDistributionType;
+
         private const string MixedPickerLabel = "Mixed";
 
         /// <summary>
@@ -566,6 +569,8 @@ namespace ElectricalImpedanceTomography.ViewModels
             _blockReconstructionService.ReconstructionUpdated += OnServiceReconstructionUpdated;
             _blockReconstructionService.ReconstructionFrameUpdated += OnServiceFrameUpdated;
             RefreshMethodPickerOptions();
+
+            _lastAppliedInitialDistributionType = ReconstructionParameters.InitialDistributionType;
         }
 
         /// <summary>
@@ -1202,6 +1207,57 @@ namespace ElectricalImpedanceTomography.ViewModels
         {
             _discretization = Workspace.GetDiscretization();
             RefreshMeasurementSourceSelection();
+        }
+
+        /// <summary>
+        /// Applies the configured initial conductivity distribution to the active discretization
+        /// and updates workspace snapshots so canvases render the expected state when the page opens
+        /// or when the initial distribution method changes.
+        /// </summary>
+        /// <param name="force">When true, reapply even if a matching initial distribution already exists.</param>
+        public void SyncInitialDistribution(bool force = false)
+        {
+            var mesh = Workspace.GetDiscretization();
+            var parameters = ReconstructionParameters;
+
+            if (mesh == null || parameters == null)
+                return;
+
+            if (!force &&
+                Workspace.GetInitialConductivityDistribution() != null &&
+                _lastAppliedInitialDistributionType == parameters.InitialDistributionType)
+            {
+                return;
+            }
+
+            var originalSnapshot = Workspace.GetOriginalConductivityDistribution()
+                                   ?? Workspace.GetOriginalDiscretization()?.GetConductivityDistribution();
+            if (originalSnapshot != null)
+            {
+                Workspace.SetOriginalConductivityDistribution(new ConductivityDistribution(originalSnapshot.Conductivities));
+            }
+
+            var initial = ConductivityDistributionFactory.CreateInitialDistribution(mesh, parameters.InitialDistributionType);
+            var initialCopy = new ConductivityDistribution(initial.Conductivities);
+
+            mesh.SetConductivityDistribution(new ConductivityDistribution(initialCopy.Conductivities));
+            Workspace.SetInitialConductivityDistribution(initialCopy);
+            Workspace.SetInitialDiscretization(mesh.DeepCopy());
+
+            _lastAppliedInitialDistributionType = parameters.InitialDistributionType;
+        }
+
+        /// <summary>
+        /// Marks the current initial distribution selection as applied so the view model
+        /// does not regenerate it unnecessarily on the next sync.
+        /// </summary>
+        public void AcknowledgeInitialDistributionUpdate()
+        {
+            var parameters = ReconstructionParameters;
+            if (parameters != null)
+            {
+                _lastAppliedInitialDistributionType = parameters.InitialDistributionType;
+            }
         }
 
         /// <summary>Refreshes the current reconstruction parameters from the workspace and pickers.</summary>

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -166,7 +166,11 @@
                                             TextColor="#E5EEFF"
                                             CornerRadius="8"/>
                                 </Grid>
-                                <Picker Grid.Row="2" ItemsSource="{Binding InitialDistributionOptions}" SelectedItem="{Binding ReconstructionParameters.InitialDistributionType}" MaximumWidthRequest="150"/>
+                                <Picker Grid.Row="2"
+                                        ItemsSource="{Binding InitialDistributionOptions}"
+                                        SelectedItem="{Binding ReconstructionParameters.InitialDistributionType}"
+                                        SelectedIndexChanged="OnInitialDistributionPickerChanged"
+                                        MaximumWidthRequest="150"/>
                                 <Label Grid.Row="3" HorizontalOptions="Start" Text="DE Solver" FontFamily="SF Pro Text" FontAttributes="None"/>
                                 <Picker Grid.Row="4" ItemsSource="{Binding DifferentialEquationSolverOptions}" SelectedItem="{Binding ReconstructionParameters.DifferentialEquationSolver}" WidthRequest="150"/>
                                 <Label Grid.Row="5" HorizontalOptions="Start" Text="Error Metric" FontFamily="SF Pro Text" FontAttributes="None"/>

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml.cs
@@ -236,6 +236,9 @@ public partial class ReconstructionPage : ContentPage
             _viewModel.RefreshMeasurementSourceOptions();
             _viewModel.LoadAvailableReconstructions();
             _viewModel.RefreshMethodPickerOptions();
+            _viewModel.SyncInitialDistribution();
+            InitialDistributionCanvas.InvalidateSurface();
+            InitialColorbarCanvas.InvalidateSurface();
         }
 
     protected override void OnDisappearing()
@@ -269,6 +272,15 @@ public partial class ReconstructionPage : ContentPage
 
     private void OnInitialDistributionEdited(object? sender, EventArgs e)
     {
+        _viewModel.AcknowledgeInitialDistributionUpdate();
+        InitialDistributionCanvas.InvalidateSurface();
+        InitialColorbarCanvas.InvalidateSurface();
+    }
+
+    private void OnInitialDistributionPickerChanged(object? sender, EventArgs e)
+    {
+        _viewModel.SyncInitialDistribution(true);
+        _viewModel.AcknowledgeInitialDistributionUpdate();
         InitialDistributionCanvas.InvalidateSurface();
         InitialColorbarCanvas.InvalidateSurface();
     }


### PR DESCRIPTION
## Summary
- sync the reconstruction workspace with the selected initial conductivity method when the page appears or picker changes
- preserve original and initial conductivity distributions with deep copies to avoid reference corruption when editing
- refresh initial distribution visuals after updates

## Testing
- ⚠️ `dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj -nologo` (fails: dotnet not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692aee240b88833380e08423f1f671fb)