### PR TITLE
Align block reconstruction step cadence and preserve original distribution

### DIFF
--- a/BusinessLayer/BlockFemReconstructionPersistence.cs
+++ b/BusinessLayer/BlockFemReconstructionPersistence.cs
@@ -142,7 +142,7 @@ namespace BusinessLayer
         /// </summary>
         /// <param name="measurement">Measurement frames mapped to the solver ordering.</param>
         /// <returns>Collection of reconstruction frames, one entry per measurement frame.</returns>
-        public List<ReconstructionFrame> Step(EITMeasurement measurement)
+        public List<ReconstructionFrame> Step(EITMeasurement measurement, int frameOffset = 0)
         {
             // Basic error checking
             if (measurement == null)
@@ -167,6 +167,7 @@ namespace BusinessLayer
             for (int frameIndex = 0; frameIndex < measurement.Frames.Count; frameIndex++)
             {
                 var currentFrame = measurement.Frames[frameIndex];
+                int globalFrameIndex = frameOffset + frameIndex;
 
                 // Reset electrode states
                 foreach (var el in electrodes)
@@ -180,8 +181,8 @@ namespace BusinessLayer
 
                 // Set excitation and ground electrodes for current frame
                 // TODO: generic adaptation for different patterns
-                int excitationIndex = frameIndex % electrodeCount;
-                int groundIndex = (frameIndex + 1) % electrodeCount;
+                int excitationIndex = globalFrameIndex % electrodeCount;
+                int groundIndex = (globalFrameIndex + 1) % electrodeCount;
 
                 var excitation = electrodes[excitationIndex];
                 excitation.IsExcitation = true;

--- a/BusinessLayer/ReconstructionConfigurationMaterializer.cs
+++ b/BusinessLayer/ReconstructionConfigurationMaterializer.cs
@@ -56,10 +56,11 @@ namespace BusinessLayer
             var numericSolver = NumericSolverFactory.Create(parameters.NumericSolver, parameters.UseOmpParallelization, parameters.UseCudaAcceleration);
             var differentialEquationSolver = DifferentialEquationSolverFactory.Create(mesh, parameters.DifferentialEquationSolver, numericSolver);
 
-            // Capture the current mesh conductivities as the immutable "target"/original distribution
-            // and apply the user-selected initialization distribution to the mesh so reconstruction starts
-            // from that state instead of the target.
-            var originalDistribution = new ConductivityDistribution(mesh.GetConductivityDistribution().Conductivities);
+            // Capture the target/original distribution from the workspace snapshot when available
+            // so the initialization logic cannot overwrite the ground truth by reference.
+            var originalDistribution = Workspace.GetOriginalConductivityDistribution()
+                                      ?? Workspace.GetOriginalDiscretization()?.GetConductivityDistribution()
+                                      ?? new ConductivityDistribution(mesh.GetConductivityDistribution().Conductivities);
             var initialDistribution = BuildInitialDistribution(mesh, parameters, configuration.Blocks);
 
             // Ensure the reconstruction begins from the configured initial distribution instead of the

--- a/ServiceLayer/BlockFemReconstructionService.cs
+++ b/ServiceLayer/BlockFemReconstructionService.cs
@@ -27,6 +27,8 @@ namespace ServiceLayer
 
         private ReconstructionRuntimeContext? _runtimeContext;
         private bool _initialized;
+        private int _frameIndex;
+        private readonly List<ReconstructionFrame> _cycleFrames = new();
 
         /// <inheritdoc />
         public event EventHandler<ReconstructionResult>? ReconstructionUpdated;
@@ -77,6 +79,8 @@ namespace ServiceLayer
 
             Workspace.SetReconstructionFrames(new List<ReconstructionFrame>());
             Workspace.SetReconstructionResults(new List<ReconstructionResult>());
+            _cycleFrames.Clear();
+            _frameIndex = 0;
             _initialized = true;
         }
 
@@ -84,15 +88,25 @@ namespace ServiceLayer
         public Task<ReconstructionResult?> RunFullReconstructionCycleAsync(double stepSize,
                                                                            double regularizationWeight,
                                                                            double excitationAmplitude)
-            => Task.Run(() => ExecuteReconstructionCycle(stepSize, regularizationWeight, excitationAmplitude));
+            => Task.Run(() =>
+            {
+                ReconstructionResult? result = null;
+                int cycleLength = Math.Max(1, _measurementService.FramesPerCycle);
+                for (int i = 0; i < cycleLength; i++)
+                {
+                    result = ExecuteReconstructionStep(stepSize, regularizationWeight, excitationAmplitude);
+                }
+
+                return result;
+            });
 
         /// <inheritdoc />
         public Task<ReconstructionResult?> StepReconstructionAsync(double stepSize,
                                                                     double regularizationWeight,
                                                                     double excitationAmplitude)
-            => Task.Run(() => ExecuteReconstructionCycle(stepSize, regularizationWeight, excitationAmplitude));
+            => Task.Run(() => ExecuteReconstructionStep(stepSize, regularizationWeight, excitationAmplitude));
 
-        private ReconstructionResult? ExecuteReconstructionCycle(double stepSize,
+        private ReconstructionResult? ExecuteReconstructionStep(double stepSize,
                                                                   double regularizationWeight,
                                                                   double excitationAmplitude)
         {
@@ -104,18 +118,24 @@ namespace ServiceLayer
             try
             {
                 var measurement = PrepareMeasurement(excitationAmplitude);
-                var frames = _persistence.Step(measurement);
+                var frames = _persistence.Step(measurement, _frameIndex);
 
                 foreach (var frame in frames)
                 {
                     Workspace.AddReconstructionFrameToWorkspace(frame);
+                    _cycleFrames.Add(frame);
                     ReconstructionFrameUpdated?.Invoke(this, frame);
                 }
+
+                _frameIndex += frames.Count;
+
+                if (_frameIndex % Math.Max(1, _measurementService.FramesPerCycle) != 0)
+                    return null;
 
                 var mesh = _runtimeContext.RuntimeMesh
                           ?? throw new InvalidOperationException("Runtime mesh missing from reconstruction context.");
                 var previous = mesh.GetConductivityDistribution();
-                var updated = ApplyGradientUpdate(frames, previous, stepSize, regularizationWeight);
+                var updated = ApplyGradientUpdate(_cycleFrames, previous, stepSize, regularizationWeight);
                 if (updated == null)
                     return null;
 
@@ -123,9 +143,10 @@ namespace ServiceLayer
                                                       _runtimeContext.OriginalDistribution,
                                                       previous,
                                                       updated,
-                                                      frames);
+                                                      new List<ReconstructionFrame>(_cycleFrames));
 
                 Workspace.AddReconstructionResultToWorkspace(result);
+                _cycleFrames.Clear();
                 ReconstructionUpdated?.Invoke(this, result);
                 return result;
             }
@@ -149,11 +170,18 @@ namespace ServiceLayer
             var electrodes = mesh.GetElectrodes().Cast<Electrode>().ToList();
             var preparedFrames = new List<double[]>();
 
-            foreach (var frame in _measurementService.GetAllMeasurements())
-            {
-                var prepared = _measurementService.PrepareMeasurementFrame(frame, electrodes);
-                preparedFrames.Add(prepared);
-            }
+            var allMeasurements = _measurementService.GetAllMeasurements();
+            if (allMeasurements.Count == 0)
+                return new EITMeasurement(new List<double[]>(), _measurementService.CurrentPattern ?? new MeasurementPattern(0))
+                {
+                    CurrentAmplitude = excitationAmplitude
+                };
+
+            int cycleLength = Math.Max(1, _measurementService.FramesPerCycle);
+            int stepIndex = _frameIndex % cycleLength;
+
+            var prepared = _measurementService.PrepareMeasurementFrame(allMeasurements[stepIndex], electrodes);
+            preparedFrames.Add(prepared);
 
             var measurement = new EITMeasurement(preparedFrames, _measurementService.CurrentPattern)
             {

--- a/ServiceLayer/IBlockFemReconstructionService.cs
+++ b/ServiceLayer/IBlockFemReconstructionService.cs
@@ -42,8 +42,8 @@ namespace ServiceLayer
                                                                      double excitationAmplitude);
 
         /// <summary>
-        /// Performs a single reconstruction cycle, emitting intermediate frames as soon as
-        /// they are available.
+        /// Performs a single reconstruction step. Intermediate frames are emitted immediately
+        /// and a reconstruction result is only produced when the drive-pattern cycle completes.
         /// </summary>
         /// <param name="stepSize">Gradient descent step size.</param>
         /// <param name="regularizationWeight">Weighting applied to the regularization gradient.</param>


### PR DESCRIPTION
## Summary
- update the block FEM reconstruction service to process one drive-pattern step at a time, buffering frames until a cycle completes before applying conductivity updates and publishing results
- allow the block persistence layer to offset excitation/ground selection so successive steps advance through the pattern without processing all frames at once
- keep the original conductivity distribution from the workspace snapshot when materializing block configurations to avoid it being overwritten by initialization

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b47f2107c83338a63f68823d14ed7)