### PR TITLE
Preserve block reconstruction state between runs

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -589,12 +589,31 @@ namespace ElectricalImpedanceTomography.ViewModels
             // If block configuration was used, then this paths runs only
             if (ShouldUseBlockConfiguration)
             {
-                _blockReconstructionService.Initialize();
-                _initializedDiscretization = Workspace.GetDiscretization();
-                IterationCount = 0;
-                _resetMetricsOnStart = true;
-                _lastBlockConfiguration = Workspace.GetCompleteReconstructionConfiguration();
-                _blockInitialized = true;
+                var mesh = _discretization ?? throw new NullReferenceException("Mesh was null during reconstruction initialization, check calling code!");
+
+                var signature = CreateCurrentRunSignature(mesh);
+                bool isSameRun = _lastRunSignature?.Equals(signature) ?? false;
+
+                var config = Workspace.GetCompleteReconstructionConfiguration();
+                bool configurationChanged = _lastBlockConfiguration != config;
+                bool discretizationChanged = _initializedDiscretization != mesh;
+
+                if (configurationChanged || discretizationChanged)
+                    isSameRun = false;
+
+                if (!_blockInitialized || !isSameRun)
+                {
+                    _blockReconstructionService.Initialize();
+                    _blockInitialized = true;
+                    _initializedDiscretization = mesh;
+                    IterationCount = 0;
+                }
+
+                if (!isSameRun)
+                    _resetMetricsOnStart = true;
+
+                _lastRunSignature = signature;
+                _lastBlockConfiguration = config;
                 return;
             }
 


### PR DESCRIPTION
## Summary
- prevent block reconstruction from reinitializing when parameters and configuration remain unchanged
- keep metrics and iteration counters intact for repeated play actions unless inputs change

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d61dbceb48333a31904e5da465e58)