### PR TITLE
Refine measurement pattern wiring

### DIFF
--- a/BusinessLayer/BlockFemReconstructionPersistence.cs
+++ b/BusinessLayer/BlockFemReconstructionPersistence.cs
@@ -157,12 +157,15 @@ namespace BusinessLayer
             double driveAmplitude = measurement.CurrentAmplitude.HasValue ? measurement.CurrentAmplitude.Value : 1.0;
 
             var electrodes = _mesh.GetElectrodes().Cast<FEMElectrode>().ToList();
-            int electrodeCount = electrodes.Count;
+            var realElectrodes = electrodes.Where(e => !e.IsVirtual).ToList();
+            int electrodeCount = realElectrodes.Count;
             if (electrodeCount < 2)
                 throw new InvalidOperationException("At least two electrodes are required for FEM boundary conditions.");
 
             // Main iteration over all measurement frames
             var frames = new List<ReconstructionFrame>(measurement.Frames.Count);
+            var patternDescription = measurement.PatternDescription;
+            int cycleLength = patternDescription?.CycleLength ?? electrodeCount;
 
             for (int frameIndex = 0; frameIndex < measurement.Frames.Count; frameIndex++)
             {
@@ -179,17 +182,21 @@ namespace BusinessLayer
                     el.Potential = 0.0;
                 }
 
-                // Set excitation and ground electrodes for current frame
-                // TODO: generic adaptation for different patterns
-                int excitationIndex = globalFrameIndex % electrodeCount;
-                int groundIndex = (globalFrameIndex + 1) % electrodeCount;
+                int requestedStep = measurement.StepIndices.Count > frameIndex
+                    ? measurement.StepIndices[frameIndex]
+                    : globalFrameIndex;
+                int normalizedStep = NormalizeStepIndex(requestedStep, Math.Max(1, cycleLength));
+                var step = patternDescription?.GetStep(normalizedStep);
 
-                var excitation = electrodes[excitationIndex];
+                // Drive electrodes are selected from the real (non-virtual) list so virtual
+                // contacts can remain passive measurement completion helpers.
+                var excitationPair = step?.Excitation ?? new ElectrodePair(normalizedStep, NormalizeElectrodeIndex(normalizedStep + 1, electrodeCount));
+                var excitation = realElectrodes[excitationPair.First];
                 excitation.IsExcitation = true;
                 excitation.IsMeasuring = false;
                 excitation.Current = driveAmplitude;
 
-                var ground = electrodes[groundIndex];
+                var ground = realElectrodes[excitationPair.Second];
                 ground.IsGround = true;
                 ground.IsMeasuring = false;
                 ground.Current = -driveAmplitude;
@@ -544,6 +551,18 @@ namespace BusinessLayer
             }
 
             return new ConductivityDistribution(combined);
+        }
+
+        private static int NormalizeStepIndex(int stepIndex, int cycleLength)
+        {
+            int normalized = stepIndex % cycleLength;
+            return normalized < 0 ? normalized + cycleLength : normalized;
+        }
+
+        private static int NormalizeElectrodeIndex(int index, int electrodeCount)
+        {
+            int normalized = index % electrodeCount;
+            return normalized < 0 ? normalized + electrodeCount : normalized;
         }
     }
 }

--- a/BusinessLayer/IMeasurementPersistence.cs
+++ b/BusinessLayer/IMeasurementPersistence.cs
@@ -60,8 +60,10 @@ namespace BusinessLayer
     /// <param name="Amplitude">Optional amplitude associated with the frames.</param>
     /// <param name="Pattern">Measurement pattern describing channel ordering.</param>
     /// <param name="MeasurementSetup">Whether driven electrodes are included in the frames.</param>
+    /// <param name="PatternDescription">Full description of the drive/measurement pattern that generated the frames.</param>
     public sealed record MeasurementSimulationResult(List<double[]> Frames,
                                                       double? Amplitude,
                                                       MeasurementPattern? Pattern,
-                                                      ElectrodeMeasurementSetup MeasurementSetup);
+                                                      ElectrodeMeasurementSetup MeasurementSetup,
+                                                      DrivePatternDescription? PatternDescription);
 }

--- a/BusinessLayer/MeasurementPersistence.cs
+++ b/BusinessLayer/MeasurementPersistence.cs
@@ -44,8 +44,13 @@ namespace BusinessLayer
             int electrodeCount = realElectrodes.Count;
 
             var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
+            var patternDescription = strategy.BuildDescription(electrodeCount,
+                                                               usePotentialDifferences
+                                                                   ? MeasurementRepresentation.PotentialDifference
+                                                                   : MeasurementRepresentation.Amplitude,
+                                                               measurementSetup);
             int cycleLength = electrodeCount > 0
-                ? Math.Max(1, strategy.GetCycleLength(electrodeCount))
+                ? Math.Max(1, patternDescription.CycleLength)
                 : 1;
 
             var frames = new List<double[]>(cycleLength);
@@ -64,13 +69,13 @@ namespace BusinessLayer
 
                 if (electrodeCount > 0)
                 {
-                    var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
-                    var excitation = realElectrodes[excitationIndex];
+                    var step = patternDescription.GetStep(i);
+                    var excitation = realElectrodes[step.Excitation.First];
                     excitation.IsExcitation = true;
                     excitation.IsMeasuring = false;
                     excitation.Current = excitationAmplitude;
 
-                    var ground = realElectrodes[groundIndex];
+                    var ground = realElectrodes[step.Excitation.Second];
                     ground.IsGround = true;
                     ground.IsMeasuring = false;
                     ground.Current = -excitationAmplitude;
@@ -82,9 +87,8 @@ namespace BusinessLayer
 
                 double[] potentials = PotentialClipper.Clip(result.GetElectrodePotentials());
                 var electrodeProjectionList = electrodes.Cast<Utility.Classes.Discretizer.Electrode>().ToList();
-                var pattern = MeasurementPatternBuilder.Build(electrodeProjectionList,
-                                                              measurementSetup,
-                                                              usePotentialDifferences);
+                var pattern = MeasurementPatternBuilder.BuildFromStep(electrodeProjectionList,
+                                                                      patternDescription.GetStep(i));
                 referencePattern ??= pattern;
                 var raw = pattern.ExtractRawMeasurement(potentials);
                 frames.Add(applyVirtuals
@@ -92,7 +96,7 @@ namespace BusinessLayer
                     : raw);
             }
 
-            return new MeasurementSimulationResult(frames, null, referencePattern, measurementSetup);
+            return new MeasurementSimulationResult(frames, null, referencePattern, measurementSetup, patternDescription);
         }
 
         /// <inheritdoc />
@@ -126,8 +130,13 @@ namespace BusinessLayer
             int electrodeCount = realElectrodes.Count;
 
             var strategy = DrivePatternStrategyProvider.GetStrategy(drivePattern);
+            var patternDescription = strategy.BuildDescription(electrodeCount,
+                                                               usePotentialDifferences
+                                                                   ? MeasurementRepresentation.PotentialDifference
+                                                                   : MeasurementRepresentation.Amplitude,
+                                                               measurementSetup);
             int cycleLength = electrodeCount > 0
-                ? Math.Max(1, strategy.GetCycleLength(electrodeCount))
+                ? Math.Max(1, patternDescription.CycleLength)
                 : 1;
 
             var frames = new List<double[]>(cycleLength);
@@ -146,14 +155,14 @@ namespace BusinessLayer
 
                 if (electrodeCount > 1)
                 {
-                    var (excitationIndex, groundIndex) = strategy.GetElectrodePair(electrodeCount, i);
+                    var step = patternDescription.GetStep(i);
 
-                    var excitation = realElectrodes[excitationIndex];
+                    var excitation = realElectrodes[step.Excitation.First];
                     excitation.IsExcitation = true;
                     excitation.IsMeasuring = false;
                     excitation.Current = excitationAmplitude;
 
-                    var ground = realElectrodes[groundIndex];
+                    var ground = realElectrodes[step.Excitation.Second];
                     ground.IsGround = true;
                     ground.IsMeasuring = false;
                     ground.Current = -excitationAmplitude;
@@ -182,9 +191,8 @@ namespace BusinessLayer
 
                 double[] electrodePotentials = PotentialClipper.Clip(grid.GetElectrodePotentials());
                 var electrodeProjectionList = electrodes.Cast<Utility.Classes.Discretizer.Electrode>().ToList();
-                var pattern = MeasurementPatternBuilder.Build(electrodeProjectionList,
-                                                              measurementSetup,
-                                                              usePotentialDifferences);
+                var pattern = MeasurementPatternBuilder.BuildFromStep(electrodeProjectionList,
+                                                                      patternDescription.GetStep(i));
                 referencePattern ??= pattern;
                 var raw = pattern.ExtractRawMeasurement(electrodePotentials);
                 frames.Add(applyVirtuals
@@ -192,7 +200,7 @@ namespace BusinessLayer
                     : raw);
             }
 
-            return new MeasurementSimulationResult(frames, excitationAmplitude, referencePattern, measurementSetup);
+            return new MeasurementSimulationResult(frames, excitationAmplitude, referencePattern, measurementSetup, patternDescription);
         }
 
         private static FEMMesh SolveFemForward(FEMMesh mesh, IDifferentialEquationSolver solver)

--- a/ServiceLayer/BlockFemReconstructionService.cs
+++ b/ServiceLayer/BlockFemReconstructionService.cs
@@ -168,22 +168,24 @@ namespace ServiceLayer
                        ?? throw new InvalidOperationException("Runtime mesh missing from reconstruction context.");
 
             var electrodes = mesh.GetElectrodes().Cast<Electrode>().ToList();
-            var preparedFrames = new List<double[]>();
 
             var allMeasurements = _measurementService.GetAllMeasurements();
             if (allMeasurements.Count == 0)
-                return new EITMeasurement(new List<double[]>(), _measurementService.CurrentPattern ?? new MeasurementPattern(0))
+            {
+                return new EITMeasurement(new List<double[]>(), _measurementService.CurrentPattern, _measurementService.CurrentPatternDescription)
                 {
                     CurrentAmplitude = excitationAmplitude
                 };
+            }
 
             int cycleLength = Math.Max(1, _measurementService.FramesPerCycle);
             int stepIndex = _frameIndex % cycleLength;
 
-            var prepared = _measurementService.PrepareMeasurementFrame(allMeasurements[stepIndex], electrodes);
-            preparedFrames.Add(prepared);
+            var context = _measurementService.BuildStepContext(electrodes, allMeasurements[stepIndex], stepIndex);
+            var preparedFrames = new List<double[]> { context.PreparedFrame };
+            var stepIndices = new List<int> { context.NormalizedStepIndex };
 
-            var measurement = new EITMeasurement(preparedFrames, _measurementService.CurrentPattern)
+            var measurement = new EITMeasurement(preparedFrames, context.Pattern, context.PatternDescription, stepIndices)
             {
                 CurrentAmplitude = _measurementService.RealMeasurementAmplitude ?? excitationAmplitude
             };

--- a/ServiceLayer/IMeasurementService.cs
+++ b/ServiceLayer/IMeasurementService.cs
@@ -18,7 +18,7 @@ namespace ServiceLayer
         void EnsureMeasurements(double excitationAmplitude);
         double[] GetMeasurementForStep(int stepIndex);
         IReadOnlyList<double[]> GetAllMeasurements();
-        double[] PrepareMeasurementFrame(double[] measurement, IList<Electrode> electrodes);
+        double[] PrepareMeasurementFrame(double[] measurement, IList<Electrode> electrodes, int stepIndex = 0);
 
         int FramesPerCycle { get; }
         double? RealMeasurementAmplitude { get; }

--- a/ServiceLayer/MeasurementService.cs
+++ b/ServiceLayer/MeasurementService.cs
@@ -42,6 +42,7 @@ namespace ServiceLayer
         private VirtualElectrodeSettings _virtualSettings = new();
         private int _framesPerCycle = 1;
         private ConductivityDistribution? _measurementConductivity;
+        private DrivePatternDescription? _patternDescription;
 
         public MeasurementService(IMeasurementPersistence measurementPersistence, ILogger logger)
         {
@@ -53,6 +54,7 @@ namespace ServiceLayer
         public double? RealMeasurementAmplitude => _realMeasurementAmplitude;
         public ElectrodeMeasurementSetup MeasurementSetup => _measurementSetup;
         public MeasurementPattern? CurrentPattern => _measurementPattern;
+        public DrivePatternDescription? CurrentPatternDescription => _patternDescription;
         public bool UsePotentialDifferences => _usePotentialDifferences;
 
         /// <summary>
@@ -90,6 +92,7 @@ namespace ServiceLayer
             _measurementSetup = Workspace.GetElectrodeMeasurementSetup();
             Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
             Workspace.SetMeasurementPattern(null);
+            _patternDescription = null;
 
             _framesPerCycle = Math.Max(1, DetermineCycleLength());
         }
@@ -112,6 +115,7 @@ namespace ServiceLayer
             Workspace.SetMeasurementPattern(null);
             _measurementSetup = Workspace.GetElectrodeMeasurementSetup();
             Workspace.SetElectrodeMeasurementSetup(_measurementSetup);
+            _patternDescription = null;
             _framesPerCycle = Math.Max(1, DetermineCycleLength());
         }
 
@@ -128,6 +132,7 @@ namespace ServiceLayer
                 throw new InvalidOperationException("Measurement service has not been initialised.");
 
             int electrodeCount = DetermineElectrodeCount();
+            RefreshPatternDescription(electrodeCount);
 
             if (_measurementSource == MeasurementSourceOption.Real)
             {
@@ -139,7 +144,7 @@ namespace ServiceLayer
                     _measurements.Clear();
                     _measurements.AddRange(measurement.Frames.Select(frame => (double[])frame.Clone()));
                     _realMeasurementAmplitude = measurement.CurrentAmplitude;
-                    AdoptMeasurementMetadata(measurement.Pattern, _measurements, electrodeCount, measurement.Pattern?.MeasurementSetup);
+                    AdoptMeasurementMetadata(measurement.Pattern, _measurements, electrodeCount, measurement.Pattern?.MeasurementSetup, measurement.PatternDescription);
                     _framesPerCycle = Math.Max(1, _measurements.Count);
                     return;
                 }
@@ -212,7 +217,7 @@ namespace ServiceLayer
             // Noise is injected only for simulated data so real measurements remain pristine.
             ApplyMeasurementNoise(_measurements, _noiseType, _noiseAmplitude);
             // Update measurement setup / pattern inference based on the freshly generated frames.
-            AdoptMeasurementMetadata(simulation.Pattern, _measurements, electrodeCount, simulation.MeasurementSetup);
+            AdoptMeasurementMetadata(simulation.Pattern, _measurements, electrodeCount, simulation.MeasurementSetup, simulation.PatternDescription);
             _framesPerCycle = Math.Max(1, _measurements.Count);
         }
 
@@ -237,32 +242,62 @@ namespace ServiceLayer
         /// Normalises a raw measurement snapshot to the solver ordering by applying optional
         /// virtual electrode completion and mapping it through the current measurement pattern.
         /// </summary>
-        public double[] PrepareMeasurementFrame(double[] measurement, IList<Electrode> electrodes)
+        public double[] PrepareMeasurementFrame(double[] measurement, IList<Electrode> electrodes, int stepIndex = 0)
         {
-            if (measurement == null)
-                throw new ArgumentNullException(nameof(measurement));
+            return BuildStepContext(electrodes, measurement, stepIndex).PreparedFrame;
+        }
+
+        /// <summary>
+        /// Builds a full context object for the requested drive-pattern step. The context
+        /// carries the raw frame, prepared frame, pattern and step description so downstream
+        /// services can consistently wire boundary conditions and misfit evaluation.
+        /// </summary>
+        public MeasurementStepContext BuildStepContext(IList<Electrode> electrodes, double[] frame, int stepIndex)
+        {
+            if (frame == null)
+                throw new ArgumentNullException(nameof(frame));
             if (electrodes == null)
                 throw new ArgumentNullException(nameof(electrodes));
 
             if (electrodes.Count == 0)
-                return measurement;
+            {
+                var emptyPattern = MeasurementPatternBuilder.Build(new List<Electrode>(), ElectrodeMeasurementSetup.Active, false);
+                return new MeasurementStepContext(stepIndex, 0, frame, frame, emptyPattern, null, null);
+            }
+
+            int driveElectrodeCount = GetDriveElectrodeCount(electrodes);
+            RefreshPatternDescription(driveElectrodeCount);
+
+            var description = _patternDescription;
+            int cycleLength = description?.CycleLength > 0
+                ? description!.CycleLength
+                : Math.Max(1, _measurements.Count);
+            int normalizedStep = NormalizeStepIndex(stepIndex, cycleLength);
 
             if (_virtualSettings.ShouldApplyVirtualElectrodes())
             {
                 var estimator = VirtualElectrodeEstimatorFactory.Create(_virtualSettings);
                 var context = BuildForwardContext(electrodes.ToList());
-                measurement = estimator.CompleteElectrodePotentials(electrodes.ToList(), measurement, _virtualSettings, context);
+                frame = estimator.CompleteElectrodePotentials(electrodes.ToList(), frame, _virtualSettings, context);
             }
 
+            MeasurementPattern pattern;
+            MeasurementPatternStep? step = null;
+            if (description != null)
+            {
+                step = description.GetStep(normalizedStep);
+                pattern = MeasurementPatternBuilder.BuildFromStep(electrodes, step);
+            }
+            else
+            {
+                pattern = MeasurementPatternBuilder.Build(electrodes, Workspace.GetElectrodeMeasurementSetup(), _usePotentialDifferences);
+            }
 
-            var electrodeProjection = electrodes.ToList();
-            var pattern = MeasurementPatternBuilder.Build(electrodeProjection,
-                                                          Workspace.GetElectrodeMeasurementSetup(),
-                                                          _usePotentialDifferences);
+            var prepared = pattern.MapMeasurement(frame);
             _measurementPattern = pattern;
             Workspace.SetMeasurementPattern(pattern);
 
-            return pattern.MapMeasurement(measurement);
+            return new MeasurementStepContext(stepIndex, normalizedStep, frame, prepared, pattern, description, step);
         }
 
         private int DetermineElectrodeCount()
@@ -280,7 +315,8 @@ namespace ServiceLayer
             int electrodeCount = DetermineElectrodeCount();
             if (electrodeCount <= 0)
                 return 1;
-            return Math.Max(1, _drivePatternStrategy.GetCycleLength(electrodeCount));
+            RefreshPatternDescription(electrodeCount);
+            return Math.Max(1, _patternDescription?.CycleLength ?? _drivePatternStrategy.GetCycleLength(electrodeCount));
         }
 
         private static ConductivityDistribution CloneConductivityDistribution(ConductivityDistribution source)
@@ -288,6 +324,48 @@ namespace ServiceLayer
 
         private static PotentialDistribution ClonePotentialDistribution(PotentialDistribution source)
             => new PotentialDistribution(source.Potentials);
+
+        private void RefreshPatternDescription(int electrodeCount)
+        {
+            if (electrodeCount <= 0)
+            {
+                _patternDescription = null;
+                return;
+            }
+
+            var representation = _usePotentialDifferences
+                ? MeasurementRepresentation.PotentialDifference
+                : MeasurementRepresentation.Amplitude;
+
+            _patternDescription = _drivePatternStrategy.BuildDescription(electrodeCount,
+                                                                          representation,
+                                                                          _measurementSetup);
+        }
+
+        private MeasurementPattern ResolvePatternForStep(IList<Electrode> electrodes, int stepIndex)
+        {
+            if (electrodes == null)
+                throw new ArgumentNullException(nameof(electrodes));
+
+            int driveElectrodeCount = GetDriveElectrodeCount(electrodes);
+            RefreshPatternDescription(driveElectrodeCount);
+
+            if (_patternDescription == null)
+            {
+                var fallback = MeasurementPatternBuilder.Build(electrodes,
+                                                               Workspace.GetElectrodeMeasurementSetup(),
+                                                               _usePotentialDifferences);
+                _measurementPattern = fallback;
+                Workspace.SetMeasurementPattern(fallback);
+                return fallback;
+            }
+
+            var step = _patternDescription.GetStep(stepIndex);
+            var pattern = MeasurementPatternBuilder.BuildFromStep(electrodes, step);
+            _measurementPattern = pattern;
+            Workspace.SetMeasurementPattern(pattern);
+            return pattern;
+        }
 
         private static int GetDriveElectrodeCount(IEnumerable<Electrode> electrodes)
         {
@@ -344,8 +422,12 @@ namespace ServiceLayer
         private void AdoptMeasurementMetadata(MeasurementPattern? pattern,
                                               IReadOnlyList<double[]> frames,
                                               int electrodeCount,
-                                              ElectrodeMeasurementSetup? enforcedSetup)
+                                              ElectrodeMeasurementSetup? enforcedSetup,
+                                              DrivePatternDescription? description = null)
         {
+            if (description != null)
+                _patternDescription = description;
+
             if (pattern != null)
             {
                 if (_measurementSetup != pattern.MeasurementSetup)
@@ -508,6 +590,15 @@ namespace ServiceLayer
             {
                 RealElectrodeCount = electrodes.Count(e => !e.IsVirtual)
             };
+        }
+
+        private static int NormalizeStepIndex(int stepIndex, int cycleLength)
+        {
+            if (cycleLength <= 0)
+                return 0;
+
+            int normalized = stepIndex % cycleLength;
+            return normalized < 0 ? normalized + cycleLength : normalized;
         }
     }
 }

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -229,7 +229,7 @@ namespace ServiceLayer
         ///
         /// The solver expects exactly one source and one sink per step; this method enforces that contract.
         /// </summary>
-        private void ApplyDrivePatternToElectrodes<TElectrode>(IList<TElectrode> electrodes, double excitationAmplitude, int stepIndex)
+        private void ApplyDrivePatternToElectrodes<TElectrode>(IList<TElectrode> electrodes, double excitationAmplitude, int stepIndex, MeasurementPatternStep? patternStep)
             where TElectrode : Electrode
         {
             if (electrodes.Count == 0)
@@ -254,7 +254,9 @@ namespace ServiceLayer
             if (realElectrodes.Count == 0)
                 return; // Edge case: no real electrodes configured
 
-            var (excitationIndex, groundIndex) = GetDrivePatternPair(realElectrodes.Count, stepIndex);
+            var (excitationIndex, groundIndex) = patternStep != null
+                ? (patternStep.Excitation.First, patternStep.Excitation.Second)
+                : GetDrivePatternPair(realElectrodes.Count, stepIndex);
 
             // Assign excitation electrode and inject current.
             var excitation = realElectrodes[excitationIndex].Electrode;
@@ -300,14 +302,14 @@ namespace ServiceLayer
                 int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(driveElectrodeCount));
                 int stepIndex = _simMeasurementIndex % cycleLength;
                 var measurement = _measurementService.GetMeasurementForStep(stepIndex);
+                var context = _measurementService.BuildStepContext(electrodes.Cast<Electrode>().ToList(), measurement, stepIndex);
 
-                // Recompute electrode roles for this step and build BC.
+                // Recompute electrode roles for this step and build BC using the explicit pattern step if available.
                 double effectiveAmplitude = _excitationAmplitude; // Use configured amplitude
-                ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, stepIndex);
+                ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, context.NormalizedStepIndex, context.Step);
 
                 var bc = new FEMBoundaryCondition(electrodes);
-                // Expand the raw measurement vector to match the solver ordering (injecting NaNs for excluded electrodes).
-                var preparedMeasurement = _measurementService.PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
+                var preparedMeasurement = context.PreparedFrame;
 
                 // Delegate one optimization step to the persistence layer.
                 var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
@@ -349,11 +351,13 @@ namespace ServiceLayer
                 int cycleLength = Math.Max(1, _drivePatternStrategy.GetCycleLength(driveElectrodeCount));
                 int stepIndex = _simMeasurementIndex % cycleLength;
                 double effectiveAmplitude = _excitationAmplitude;
-                ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, stepIndex);
+                var measurement = _measurementService.GetMeasurementForStep(stepIndex);
+                var context = _measurementService.BuildStepContext(electrodes.Cast<Electrode>().ToList(), measurement, stepIndex);
+
+                ApplyDrivePatternToElectrodes(electrodes, effectiveAmplitude, context.NormalizedStepIndex, context.Step);
 
                 var bc = new LBMBoundaryCondition(electrodes);
-                double[] measurement = _measurementService.GetMeasurementForStep(stepIndex);
-                var preparedMeasurement = _measurementService.PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
+                var preparedMeasurement = context.PreparedFrame;
                 var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
                 _simMeasurementIndex++;
@@ -492,7 +496,7 @@ namespace ServiceLayer
                         var bc = new FEMBoundaryCondition(electrodes);
                         var measurement = measurements[i];
                         // Convert the measurement snapshot to the solver layout for the current electrode roles.
-                        var preparedMeasurement = _measurementService.PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
+                        var preparedMeasurement = _measurementService.PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList(), i);
 
                         var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
@@ -548,7 +552,7 @@ namespace ServiceLayer
                         var bc = new LBMBoundaryCondition(electrodes);
 
                         var measurement = measurements[i];
-                        var preparedMeasurement = _measurementService.PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList());
+                        var preparedMeasurement = _measurementService.PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList(), i);
                         var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
                         Workspace.AddReconstructionFrameToWorkspace(frame);

--- a/Utility/Classes/Measurement/DrivePattern.cs
+++ b/Utility/Classes/Measurement/DrivePattern.cs
@@ -3,6 +3,8 @@
     public enum DrivePattern
     {
         Adjecent = 1,
-        Opposite = 2
+        Opposite = 2,
+        Trigonometric = 3,
+        Fourier = 4
     }
 }

--- a/Utility/Classes/Measurement/DrivePatternDescription.cs
+++ b/Utility/Classes/Measurement/DrivePatternDescription.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Utility.Classes.Measurement
+{
+    /// <summary>
+    /// Compact value object representing a pair of electrodes. The same
+    /// structure is used for both the driven excitation pair and individual
+    /// measurement pairs. When amplitudes are measured the <see cref="Second"/>
+    /// index is equal to <see cref="First"/>; potential-difference sampling
+    /// uses distinct indices.
+    /// </summary>
+    public readonly record struct ElectrodePair(int First, int Second)
+    {
+        public override string ToString() => $"({First}, {Second})";
+    }
+
+    /// <summary>
+    /// Describes a single step in a drive pattern: which electrodes are used
+    /// for excitation/ground and which pairs are sampled as measurements.
+    /// </summary>
+    public sealed class MeasurementPatternStep
+    {
+        public MeasurementPatternStep(ElectrodePair excitation,
+                                      IEnumerable<ElectrodePair> measurementPairs,
+                                      MeasurementRepresentation representation,
+                                      ElectrodeMeasurementSetup measurementSetup)
+        {
+            Excitation = excitation;
+            MeasurementPairs = new ReadOnlyCollection<ElectrodePair>(measurementPairs.ToList());
+            Representation = representation;
+            MeasurementSetup = measurementSetup;
+        }
+
+        /// <summary>The excitation/ground pair used for this step.</summary>
+        public ElectrodePair Excitation { get; }
+
+        /// <summary>Electrode pairs that should be sampled in this step.</summary>
+        public IReadOnlyList<ElectrodePair> MeasurementPairs { get; }
+
+        /// <summary>Whether values represent amplitudes or differences.</summary>
+        public MeasurementRepresentation Representation { get; }
+
+        /// <summary>
+        /// Whether measurements on the excitation/ground electrodes are allowed
+        /// (<see cref="ElectrodeMeasurementSetup.Active"/>) or explicitly
+        /// excluded (<see cref="ElectrodeMeasurementSetup.NonActive"/>).
+        /// </summary>
+        public ElectrodeMeasurementSetup MeasurementSetup { get; }
+    }
+
+    /// <summary>
+    /// Full description of a drive pattern expressed as a sequence of
+    /// <see cref="MeasurementPatternStep"/> instances. The description makes the
+    /// chosen measurement representation and inclusion mode explicit so the
+    /// reconstruction pipeline can reason about arbitrary patterns without
+    /// guessing.
+    /// </summary>
+    public sealed class DrivePatternDescription
+    {
+        public DrivePatternDescription(MeasurementRepresentation representation,
+                                       ElectrodeMeasurementSetup measurementSetup,
+                                       IReadOnlyList<MeasurementPatternStep> steps)
+        {
+            Representation = representation;
+            MeasurementSetup = measurementSetup;
+            Steps = steps ?? throw new ArgumentNullException(nameof(steps));
+        }
+
+        /// <summary>Amplitude vs. potential-difference measurement mode.</summary>
+        public MeasurementRepresentation Representation { get; }
+
+        /// <summary>Active vs. passive inclusion of driven electrodes.</summary>
+        public ElectrodeMeasurementSetup MeasurementSetup { get; }
+
+        /// <summary>Steps in the pattern, one per excitation pair.</summary>
+        public IReadOnlyList<MeasurementPatternStep> Steps { get; }
+
+        /// <summary>Total number of distinct excitation steps.</summary>
+        public int CycleLength => Steps.Count;
+
+        /// <summary>Returns the step for the specified (possibly wrapped) index.</summary>
+        public MeasurementPatternStep GetStep(int index)
+        {
+            if (Steps.Count == 0)
+                throw new InvalidOperationException("Pattern description contains no steps.");
+
+            int normalized = index % Steps.Count;
+            if (normalized < 0)
+                normalized += Steps.Count;
+
+            return Steps[normalized];
+        }
+    }
+}

--- a/Utility/Classes/Measurement/DrivePatternStrategy.cs
+++ b/Utility/Classes/Measurement/DrivePatternStrategy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace Utility.Classes.Measurement
 {
@@ -8,6 +9,15 @@ namespace Utility.Classes.Measurement
         (int Excitation, int Ground) GetElectrodePair(int electrodeCount, int stepIndex);
 
         int GetCycleLength(int electrodeCount);
+
+        /// <summary>
+        /// Builds a full measurement pattern description so callers know exactly
+        /// which excitation pair and measurement pairs belong to each step.
+        /// </summary>
+        DrivePatternDescription BuildDescription(int electrodeCount,
+                                                 MeasurementRepresentation representation,
+                                                 ElectrodeMeasurementSetup measurementSetup,
+                                                 int measurementCount = 0);
     }
 
     public abstract class DrivePatternStrategyBase : IDrivePatternStrategy
@@ -21,6 +31,86 @@ namespace Utility.Classes.Measurement
         }
 
         public abstract (int Excitation, int Ground) GetElectrodePair(int electrodeCount, int stepIndex);
+
+        public virtual DrivePatternDescription BuildDescription(int electrodeCount,
+                                                                 MeasurementRepresentation representation,
+                                                                 ElectrodeMeasurementSetup measurementSetup,
+                                                                 int measurementCount = 0)
+        {
+            int cycleLength = Math.Max(1, GetCycleLength(electrodeCount));
+            var steps = new List<MeasurementPatternStep>(cycleLength);
+
+            for (int i = 0; i < cycleLength; i++)
+            {
+                var (excitation, ground) = GetElectrodePair(electrodeCount, i);
+                var measurementPairs = BuildMeasurementPairs(electrodeCount,
+                                                             excitation,
+                                                             ground,
+                                                             representation,
+                                                             measurementSetup,
+                                                             measurementCount);
+
+                steps.Add(new MeasurementPatternStep(new ElectrodePair(excitation, ground),
+                                                     measurementPairs,
+                                                     representation,
+                                                     measurementSetup));
+            }
+
+            return new DrivePatternDescription(representation, measurementSetup, steps);
+        }
+
+        /// <summary>
+        /// Generates measurement pairs for the given excitation step. Amplitude
+        /// mode samples a single electrode (N–N); potential-difference mode samples
+        /// consecutive electrodes while respecting the active/passive setting.
+        /// </summary>
+        protected virtual IReadOnlyList<ElectrodePair> BuildMeasurementPairs(int electrodeCount,
+                                                                            int excitation,
+                                                                            int ground,
+                                                                            MeasurementRepresentation representation,
+                                                                            ElectrodeMeasurementSetup measurementSetup,
+                                                                            int measurementCount)
+        {
+            var pairs = new List<ElectrodePair>();
+            if (electrodeCount <= 0)
+                return pairs;
+
+            var excluded = new HashSet<int>();
+            if (measurementSetup == ElectrodeMeasurementSetup.NonActive)
+            {
+                excluded.Add(excitation);
+                excluded.Add(ground);
+            }
+
+            int availableCount = measurementCount > 0 ? measurementCount : electrodeCount;
+
+            if (representation == MeasurementRepresentation.Amplitude)
+            {
+                for (int i = 0; i < electrodeCount && pairs.Count < availableCount; i++)
+                {
+                    if (excluded.Contains(i))
+                        continue;
+
+                    pairs.Add(new ElectrodePair(i, i));
+                }
+            }
+            else
+            {
+                for (int i = 0; i < electrodeCount && pairs.Count < availableCount; i++)
+                {
+                    if (excluded.Contains(i))
+                        continue;
+
+                    int next = NormalizeElectrodeIndex(i + 1, electrodeCount);
+                    if (measurementSetup == ElectrodeMeasurementSetup.NonActive && excluded.Contains(next))
+                        continue;
+
+                    pairs.Add(new ElectrodePair(i, next));
+                }
+            }
+
+            return pairs;
+        }
 
         protected static int NormalizeStepIndex(int stepIndex, int cycleLength)
         {
@@ -71,6 +161,42 @@ namespace Utility.Classes.Measurement
         }
     }
 
+    internal sealed class TrigonometricDrivePatternStrategy : DrivePatternStrategyBase
+    {
+        public override (int Excitation, int Ground) GetElectrodePair(int electrodeCount, int stepIndex)
+        {
+            int cycleLength = GetCycleLength(electrodeCount);
+            int normalizedStep = NormalizeStepIndex(stepIndex, cycleLength);
+
+            int excitation = normalizedStep;
+            int offset = Math.Max(2, (int)Math.Round(electrodeCount / 4.0));
+            int ground = NormalizeElectrodeIndex(excitation + offset, electrodeCount);
+
+            if (ground == excitation)
+                ground = NormalizeElectrodeIndex(excitation + 1, electrodeCount);
+
+            return (excitation, ground);
+        }
+    }
+
+    internal sealed class FourierDrivePatternStrategy : DrivePatternStrategyBase
+    {
+        public override (int Excitation, int Ground) GetElectrodePair(int electrodeCount, int stepIndex)
+        {
+            int cycleLength = GetCycleLength(electrodeCount);
+            int normalizedStep = NormalizeStepIndex(stepIndex, cycleLength);
+
+            int excitation = normalizedStep;
+            int harmonic = 1 + (normalizedStep % Math.Max(1, electrodeCount / 2));
+            int ground = NormalizeElectrodeIndex(excitation + harmonic, electrodeCount);
+
+            if (ground == excitation)
+                ground = NormalizeElectrodeIndex(excitation + 1, electrodeCount);
+
+            return (excitation, ground);
+        }
+    }
+
     public static class DrivePatternStrategyProvider
     {
         private static readonly ConcurrentDictionary<DrivePattern, IDrivePatternStrategy> Strategies = new();
@@ -79,6 +205,8 @@ namespace Utility.Classes.Measurement
         {
             Strategies[DrivePattern.Adjecent] = new AdjacentDrivePatternStrategy();
             Strategies[DrivePattern.Opposite] = new OppositeDrivePatternStrategy();
+            Strategies[DrivePattern.Trigonometric] = new TrigonometricDrivePatternStrategy();
+            Strategies[DrivePattern.Fourier] = new FourierDrivePatternStrategy();
         }
 
         public static void RegisterStrategy(DrivePattern pattern, IDrivePatternStrategy strategy, bool overwrite = false)

--- a/Utility/Classes/Measurement/EITMeasurement.cs
+++ b/Utility/Classes/Measurement/EITMeasurement.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 ﻿namespace Utility.Classes.Measurement
 {
     public class EITMeasurement
@@ -15,7 +19,16 @@
 
         public MeasurementPattern? Pattern { get; set; }
 
-        public EITMeasurement(List<double[]> frames, MeasurementPattern? pattern = null)
+        /// <summary>Optional drive/measurement description that generated the frames.</summary>
+        public DrivePatternDescription? PatternDescription { get; set; }
+
+        /// <summary>
+        /// Tracks which drive-pattern step each frame corresponds to so excitation/ground
+        /// assignment can be reproduced downstream.
+        /// </summary>
+        public List<int> StepIndices { get; } = new();
+
+        public EITMeasurement(List<double[]> frames, MeasurementPattern? pattern = null, DrivePatternDescription? patternDescription = null, List<int>? stepIndices = null)
         {
             Frames = frames;
 
@@ -26,6 +39,8 @@
 
             FrameSize = Frames[0].Length;
             Pattern = pattern;
+            PatternDescription = patternDescription;
+            StepIndices = stepIndices ?? Enumerable.Range(0, Frames.Count).ToList();
         }
 
         public EITMeasurement(double[,] measurementFrames)
@@ -38,11 +53,12 @@
                     frame[j] = measurementFrames[i, j];
 
                 Frames.Add(frame);
+                StepIndices.Add(i);
             }
         }
 
 
-        public EITMeasurement(List<double[]> frames, double currentAmplitude, MeasurementPattern? pattern = null)
+        public EITMeasurement(List<double[]> frames, double currentAmplitude, MeasurementPattern? pattern = null, DrivePatternDescription? patternDescription = null, List<int>? stepIndices = null)
         {
             Frames = frames;
 
@@ -54,6 +70,8 @@
             FrameSize = Frames[0].Length;
             CurrentAmplitude = currentAmplitude;
             Pattern = pattern;
+            PatternDescription = patternDescription;
+            StepIndices = stepIndices ?? Enumerable.Range(0, Frames.Count).ToList();
         }
 
         public double[] GetNextFrame()

--- a/Utility/Classes/Measurement/MeasurementPattern.cs
+++ b/Utility/Classes/Measurement/MeasurementPattern.cs
@@ -213,6 +213,29 @@ namespace Utility.Classes.Measurement
             return BuildDifferencePattern(electrodes, setup);
         }
 
+        public static MeasurementPattern BuildFromStep(IReadOnlyList<Electrode> electrodes,
+                                                       MeasurementPatternStep step)
+        {
+            if (electrodes == null)
+                throw new ArgumentNullException(nameof(electrodes));
+            if (step == null)
+                throw new ArgumentNullException(nameof(step));
+
+            int electrodeCount = electrodes.Count;
+            var channels = new List<MeasurementChannel>(step.MeasurementPairs.Count);
+
+            foreach (var pair in step.MeasurementPairs)
+            {
+                int targetIndex = pair.First;
+                channels.Add(new MeasurementChannel(targetIndex, pair.First, pair.Second));
+            }
+
+            return new MeasurementPattern(step.Representation,
+                                          step.MeasurementSetup,
+                                          electrodeCount,
+                                          channels);
+        }
+
         private static MeasurementPattern BuildAmplitudePattern(IReadOnlyList<Electrode> electrodes,
                                                                 ElectrodeMeasurementSetup setup)
         {

--- a/Utility/Classes/Measurement/MeasurementPatterns.cs
+++ b/Utility/Classes/Measurement/MeasurementPatterns.cs
@@ -1,0 +1,50 @@
+namespace Utility.Classes.Measurement
+{
+    /// <summary>
+    /// Provides convenient factory helpers for common electrode drive patterns.
+    /// Each method delegates to the registered <see cref="IDrivePatternStrategy"/>
+    /// so that callers receive a fully specified <see cref="DrivePatternDescription"/>.
+    /// </summary>
+    public static class MeasurementPatterns
+    {
+        public static DrivePatternDescription Adjacent(int electrodeCount,
+                                                       MeasurementRepresentation representation,
+                                                       ElectrodeMeasurementSetup measurementSetup,
+                                                       int measurementCount = 0)
+            => Build(DrivePattern.Adjecent, electrodeCount, representation, measurementSetup, measurementCount);
+
+        public static DrivePatternDescription Opposite(int electrodeCount,
+                                                       MeasurementRepresentation representation,
+                                                       ElectrodeMeasurementSetup measurementSetup,
+                                                       int measurementCount = 0)
+            => Build(DrivePattern.Opposite, electrodeCount, representation, measurementSetup, measurementCount);
+
+        public static DrivePatternDescription Trigonometric(int electrodeCount,
+                                                             MeasurementRepresentation representation,
+                                                             ElectrodeMeasurementSetup measurementSetup,
+                                                             int measurementCount = 0)
+            => Build(DrivePattern.Trigonometric, electrodeCount, representation, measurementSetup, measurementCount);
+
+        public static DrivePatternDescription Fourier(int electrodeCount,
+                                                      MeasurementRepresentation representation,
+                                                      ElectrodeMeasurementSetup measurementSetup,
+                                                      int measurementCount = 0)
+            => Build(DrivePattern.Fourier, electrodeCount, representation, measurementSetup, measurementCount);
+
+        /// <summary>
+        /// Generic entry point that leverages the configured drive-pattern
+        /// strategies. Custom patterns can be registered through
+        /// <see cref="DrivePatternStrategyProvider.RegisterStrategy"/> and will be
+        /// reachable via this helper.
+        /// </summary>
+        public static DrivePatternDescription Build(DrivePattern pattern,
+                                                    int electrodeCount,
+                                                    MeasurementRepresentation representation,
+                                                    ElectrodeMeasurementSetup measurementSetup,
+                                                    int measurementCount = 0)
+        {
+            var strategy = DrivePatternStrategyProvider.GetStrategy(pattern);
+            return strategy.BuildDescription(electrodeCount, representation, measurementSetup, measurementCount);
+        }
+    }
+}

--- a/Utility/Classes/Measurement/MeasurementStepContext.cs
+++ b/Utility/Classes/Measurement/MeasurementStepContext.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+namespace Utility.Classes.Measurement
+{
+    /// <summary>
+    /// Aggregates all information required to process a single drive-pattern step:
+    /// - The raw and prepared measurement frames
+    /// - The measurement pattern used to map channels
+    /// - The underlying pattern description and concrete step (excitation/measurement pairs)
+    /// - The normalised step index so callers can align excitation, measurement and boundary conditions
+    /// </summary>
+    public sealed class MeasurementStepContext
+    {
+        public MeasurementStepContext(int requestedStepIndex,
+                                      int normalizedStepIndex,
+                                      double[] rawFrame,
+                                      double[] preparedFrame,
+                                      MeasurementPattern pattern,
+                                      DrivePatternDescription? patternDescription,
+                                      MeasurementPatternStep? step)
+        {
+            RequestedStepIndex = requestedStepIndex;
+            NormalizedStepIndex = normalizedStepIndex;
+            RawFrame = rawFrame;
+            PreparedFrame = preparedFrame;
+            Pattern = pattern;
+            PatternDescription = patternDescription;
+            Step = step;
+        }
+
+        /// <summary>The step index requested by the caller (may be outside the cycle length).</summary>
+        public int RequestedStepIndex { get; }
+
+        /// <summary>Step index wrapped to the pattern cycle length.</summary>
+        public int NormalizedStepIndex { get; }
+
+        /// <summary>The raw measurement frame before sanitisation or padding.</summary>
+        public double[] RawFrame { get; }
+
+        /// <summary>Measurement frame mapped to solver ordering with NaN padding applied.</summary>
+        public double[] PreparedFrame { get; }
+
+        /// <summary>Pattern used to map measurement channels for the step.</summary>
+        public MeasurementPattern Pattern { get; }
+
+        /// <summary>Full drive/measurement pattern description if one is available.</summary>
+        public DrivePatternDescription? PatternDescription { get; }
+
+        /// <summary>Concrete step within the drive/measurement cycle (excitation and measurement pairs).</summary>
+        public MeasurementPatternStep? Step { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- propagate drive pattern descriptions through measurement simulation results and EIT measurements so reconstruction steps know the originating excitation pairs
- add a reusable measurement step context to simplify measurement preparation and boundary wiring in both reconstruction pipelines
- drive block FEM boundary conditions from the described excitation pairs instead of implicit adjacent selection

## Testing
- Not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d65ffcc6c8333863217dd4a449a6c)