### PR TITLE
Add iteration visualization toggle

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionPageViewModel.cs
@@ -84,7 +84,11 @@ namespace ElectricalImpedanceTomography.ViewModels
         
         /// <summary>Current measurement source selection mirrored from the workspace.</summary>
         private MeasurementSourceOption _selectedMeasurementSource = Workspace.GetMeasurementSource();
-        
+
+        /// <summary>Whether intermediate reconstruction frames should be visualised.</summary>
+        [ObservableProperty]
+        private bool visualizeIterations = true;
+
         /// <summary>Current potential render mode for video export.</summary>
         private PotentialDisplayMode _selectedDisplayMode = PotentialDisplayMode.Default;
 
@@ -186,6 +190,13 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             if (Enum.TryParse<NumericOptimizer>(value, out var parsed))
                 ReconstructionParameters.NumericOptimizer = parsed;
+        }
+
+        /// <summary>Propagates the visualization toggle to the services so they can throttle frame events.</summary>
+        partial void OnVisualizeIterationsChanged(bool value)
+        {
+            _reconstructionService.VisualizeIterations = value;
+            _blockReconstructionService.VisualizeIterations = value;
         }
 
         /// <summary>Total number of completed iterations in the current session.</summary>
@@ -530,6 +541,9 @@ namespace ElectricalImpedanceTomography.ViewModels
             _reconstructionService = reconstructionService;
             _blockReconstructionService = blockReconstructionService;
             _exportService = exportService;
+
+            _reconstructionService.VisualizeIterations = VisualizeIterations;
+            _blockReconstructionService.VisualizeIterations = VisualizeIterations;
 
             _elapsedTimer = new Timer(200)
             {

--- a/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
+++ b/ElectricalImpedanceTomography/Views/ReconstructionPage.xaml
@@ -190,7 +190,7 @@
                                 MaximumWidthRequest="180"
                                 Style="{StaticResource PanelSectionBorderStyle}"
                                 BackgroundColor="{AppThemeBinding Light=#25324A, Dark=#25324A}">
-                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
+                            <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="8">
                                 <Label Grid.Row="0" Text="Parameters" FontSize="Medium" FontAttributes="Bold" Margin="0,0,0,12"/>
                                 <Label Grid.Row="3" HorizontalOptions="Start" Text="Max Iteration Count" FontFamily="SF Pro Text" FontAttributes="None"/>
                                 <Entry Grid.Row="4" Text="{Binding MaxIterationCount}" MaximumWidthRequest="130" HorizontalOptions="Start"/>
@@ -207,12 +207,21 @@
                                        HorizontalOptions="Start"
                                        IsEnabled="{Binding IsNoiseAmplitudeEnabled}"/>
 
-                                <Label Grid.Row="13"
+                                <HorizontalStackLayout Grid.Row="13" Spacing="10">
+                                    <Label HorizontalOptions="Start"
+                                           VerticalOptions="Center"
+                                           Text="Visualize Iterations"
+                                           FontFamily="SF Pro Text"
+                                           FontAttributes="None"/>
+                                    <CheckBox IsChecked="{Binding VisualizeIterations}" HorizontalOptions="Start"/>
+                                </HorizontalStackLayout>
+
+                                <Label Grid.Row="14"
                                        HorizontalOptions="Start"
                                        Text="Conductivity Bounds [S]"
                                        FontFamily="SF Pro Text"
                                        FontAttributes="None"/>
-                                <Grid Grid.Row="14" ColumnDefinitions="*, *" ColumnSpacing="8">
+                                <Grid Grid.Row="15" ColumnDefinitions="*, *" ColumnSpacing="8">
                                     <Entry Grid.Column="0"
                                            Placeholder="Min"
                                            HorizontalOptions="Start"
@@ -227,13 +236,13 @@
                                            Text="{Binding ReconstructionParameters.ConductivityMaximumBound}"/>
                                 </Grid>
 
-                                <Label Grid.Row="15"
+                                <Label Grid.Row="16"
                                        HorizontalOptions="Start"
                                        Text="Potential Smoothing"
                                        FontFamily="SF Pro Text"
                                        FontAttributes="None"
                                        IsVisible="{Binding IsLbmSolverSelected}"/>
-                                <Grid Grid.Row="16" ColumnDefinitions="*,Auto" ColumnSpacing="8"
+                                <Grid Grid.Row="17" ColumnDefinitions="*,Auto" ColumnSpacing="8"
                                       IsVisible="{Binding IsLbmSolverSelected}">
                                     <Label Text="Filter"
                                            VerticalOptions="Center"
@@ -243,32 +252,32 @@
                                             HorizontalOptions="End"/>
                                 </Grid>
 
-                                <Label Grid.Row="17"
+                                <Label Grid.Row="18"
                                        HorizontalOptions="Start"
                                        Text="Conductivity Smoothing"
                                        FontFamily="SF Pro Text"
                                        FontAttributes="None"
                                        IsVisible="{Binding IsLbmSolverSelected}"/>
-                                <Grid Grid.Row="18" ColumnDefinitions="Auto" ColumnSpacing="8"
+                                <Grid Grid.Row="19" ColumnDefinitions="Auto" ColumnSpacing="8"
                                       IsVisible="{Binding IsLbmSolverSelected}">
                                     <Switch Grid.Column="1"
                                             IsToggled="{Binding ReconstructionParameters.UseLbmConductivityFilter}"
                                             HorizontalOptions="End"/>
                                 </Grid>
 
-                                <Label Grid.Row="19"
+                                <Label Grid.Row="20"
                                        HorizontalOptions="Start"
                                        Text="Virtual Electrode Method"
                                        FontFamily="SF Pro Text"
                                        FontAttributes="None"
                                        IsVisible="{Binding VirtualElectrodeSettings.UseVirtualElectrodes}"/>
-                                <Picker Grid.Row="20"
+                                <Picker Grid.Row="21"
                                         ItemsSource="{Binding VirtualElectrodeMethods}"
                                         SelectedItem="{Binding VirtualElectrodeSettings.Method}"
                                         IsVisible="{Binding VirtualElectrodeSettings.UseVirtualElectrodes}"
                                         MaximumWidthRequest="150"/>
 
-                                <Grid Grid.Row="21" ColumnDefinitions="Auto,*" ColumnSpacing="8"
+                                <Grid Grid.Row="22" ColumnDefinitions="Auto,*" ColumnSpacing="8"
                                       IsVisible="{Binding IsLinearCombinationMethod}">
                                     <Label Text="Alpha (0..1)"
                                            VerticalOptions="Center"
@@ -279,7 +288,7 @@
                                            HorizontalTextAlignment="End"/>
                                 </Grid>
 
-                                <Grid Grid.Row="22" ColumnDefinitions="Auto,*" ColumnSpacing="8"
+                                <Grid Grid.Row="23" ColumnDefinitions="Auto,*" ColumnSpacing="8"
                                       IsVisible="{Binding IsHarrachMethod}">
                                     <Label Text="Harrach λ"
                                            VerticalOptions="Center"
@@ -290,7 +299,7 @@
                                            HorizontalTextAlignment="End"/>
                                 </Grid>
 
-                                <Grid Grid.Row="23" ColumnDefinitions="Auto,*" ColumnSpacing="8"
+                                <Grid Grid.Row="24" ColumnDefinitions="Auto,*" ColumnSpacing="8"
                                       IsVisible="{Binding IsNdMethod}">
                                     <Label Text="ND Max Mode"
                                            VerticalOptions="Center"

--- a/ServiceLayer/BlockFemReconstructionService.cs
+++ b/ServiceLayer/BlockFemReconstructionService.cs
@@ -43,6 +43,9 @@ namespace ServiceLayer
         /// <inheritdoc />
         public event EventHandler<ReconstructionFrame>? ReconstructionFrameUpdated;
 
+        /// <inheritdoc />
+        public bool VisualizeIterations { get; set; } = true;
+
         public BlockFemReconstructionService(BlockFemReconstructionPersistence persistence,
                                              IMeasurementService measurementService,
                                              ILogger logger)
@@ -154,9 +157,8 @@ namespace ServiceLayer
                 // 3) Surface each frame to the workspace and UI, and buffer them for the current cycle.
                 foreach (var frame in frames)
                 {
-                    Workspace.AddReconstructionFrameToWorkspace(frame);
                     _cycleFrames.Add(frame);
-                    ReconstructionFrameUpdated?.Invoke(this, frame);
+                    PublishFrame(frame);
                 }
 
                 // 4) Advance the global frame counter by the number of frames produced.
@@ -199,6 +201,18 @@ namespace ServiceLayer
                 _logger.LogError(ex.Message);
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Adds a reconstruction frame to the workspace and optionally notifies listeners for live visualisation.
+        /// </summary>
+        /// <param name="frame">Frame to surface.</param>
+        private void PublishFrame(ReconstructionFrame frame)
+        {
+            Workspace.AddReconstructionFrameToWorkspace(frame);
+
+            if (VisualizeIterations)
+                ReconstructionFrameUpdated?.Invoke(this, frame);
         }
 
         // Creates an EITMeasurement representing the next frame to process, aligned with electrodes and

--- a/ServiceLayer/IBlockFemReconstructionService.cs
+++ b/ServiceLayer/IBlockFemReconstructionService.cs
@@ -25,6 +25,11 @@ namespace ServiceLayer
         event EventHandler<ReconstructionFrame> ReconstructionFrameUpdated;
 
         /// <summary>
+        /// Controls whether intermediate frames are propagated to listeners during a run.
+        /// </summary>
+        bool VisualizeIterations { get; set; }
+
+        /// <summary>
         /// Initializes the service based on the current <see cref="Utility.Classes.Application.Workspace"/>
         /// block configuration and discretization.
         /// </summary>

--- a/ServiceLayer/IReconstructionService.cs
+++ b/ServiceLayer/IReconstructionService.cs
@@ -12,6 +12,12 @@ namespace ServiceLayer
         // --- Background reconstruction control ---
         event EventHandler<ReconstructionResult> ReconstructionUpdated;
         event EventHandler<ReconstructionFrame> ReconstructionFrameUpdated;
+
+        /// <summary>
+        /// Determines whether intermediate reconstruction frames should be surfaced to listeners
+        /// during iterative runs.
+        /// </summary>
+        bool VisualizeIterations { get; set; }
         void StartBackgroundReconstruction(int maxIterationCount, double stepSize, double regularizationWeight, double excitationAmplitude);
         void PauseBackgroundReconstruction();
         void ResumeBackgroundReconstruction();

--- a/ServiceLayer/ReconstructionService.cs
+++ b/ServiceLayer/ReconstructionService.cs
@@ -66,6 +66,9 @@ namespace ServiceLayer
         /// </summary>
         public event EventHandler<ReconstructionFrame>? ReconstructionFrameUpdated;
 
+        /// <inheritdoc />
+        public bool VisualizeIterations { get; set; } = true;
+
         /// <summary>
         /// Construct service with a persistence backend and logger.
         /// </summary>
@@ -321,9 +324,8 @@ namespace ServiceLayer
 
                 // Advance frame counters and notify observers.
                 _simMeasurementIndex++;
-                Workspace.AddReconstructionFrameToWorkspace(frame);
                 _currentCycleFrames.Add(frame);
-                ReconstructionFrameUpdated?.Invoke(this, frame);
+                PublishFrame(frame);
 
                 // When the drive-pattern cycle ends, publish a reconstruction result and advance the iteration.
                 if (_simMeasurementIndex % Math.Max(1, _measurementService.FramesPerCycle) == 0)
@@ -365,9 +367,8 @@ namespace ServiceLayer
                 var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
                 _simMeasurementIndex++;
-                Workspace.AddReconstructionFrameToWorkspace(frame);
                 _currentCycleFrames.Add(frame);
-                ReconstructionFrameUpdated?.Invoke(this, frame);
+                PublishFrame(frame);
 
                 if (_simMeasurementIndex % Math.Max(1, _measurementService.FramesPerCycle) == 0)
                 {
@@ -505,9 +506,8 @@ namespace ServiceLayer
                         var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
                         // Persist frame for UI and later aggregation/inspection.
-                        Workspace.AddReconstructionFrameToWorkspace(frame);
                         _currentCycleFrames.Add(frame);
-                        ReconstructionFrameUpdated?.Invoke(this, frame);
+                        PublishFrame(frame);
                     }
 
                     // Accumulate gradients across the cycle and apply a single update step to conductivities.
@@ -559,9 +559,8 @@ namespace ServiceLayer
                         var preparedMeasurement = _measurementService.PrepareMeasurementFrame(measurement, electrodes.Cast<Electrode>().ToList(), i);
                         var frame = _reconstructionPersistence.Step(preparedMeasurement, bc, _stepSize, _regularizationWeight);
 
-                        Workspace.AddReconstructionFrameToWorkspace(frame);
                         _currentCycleFrames.Add(frame);
-                        ReconstructionFrameUpdated?.Invoke(this, frame);
+                        PublishFrame(frame);
 
                         // Some LBM workflows advance excitation markers on the grid for visualization.
                         lbmGrid.ShiftExcitationElectrodes(_drivePattern);
@@ -595,6 +594,18 @@ namespace ServiceLayer
 
                 return null;
             });
+        }
+
+        /// <summary>
+        /// Adds a reconstruction frame to the workspace and optionally notifies listeners for live visualisation.
+        /// </summary>
+        /// <param name="frame">Frame to surface.</param>
+        private void PublishFrame(ReconstructionFrame frame)
+        {
+            Workspace.AddReconstructionFrameToWorkspace(frame);
+
+            if (VisualizeIterations)
+                ReconstructionFrameUpdated?.Invoke(this, frame);
         }
 
 


### PR DESCRIPTION
## Summary
- add a checkbox on the reconstruction page to toggle visualization of iteration frames
- propagate the visualization preference to both reconstruction services to suppress intermediate frame events when disabled
- extend reconstruction service interfaces to expose the visualization setting

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693224e6359083339eab02f937d8397c)