### PR TITLE
Clamp minimum LBM grid size

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/MeshingPageViewModel.cs
@@ -19,6 +19,7 @@ namespace ElectricalImpedanceTomography.ViewModels
     public partial class MeshingPageViewModel : BaseViewModel
     {
         private readonly IDAQService _daqService;
+        private const int MinLbmGridSize = 10;
 
         [ObservableProperty]
         private string name = string.Empty;
@@ -432,9 +433,29 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
         }
 
-        partial void OnNxChanged(int value) => AutoGenerateMesh();
+        partial void OnNxChanged(int value)
+        {
+            int clampedValue = Math.Max(MinLbmGridSize, value);
+            if (clampedValue != value)
+            {
+                Nx = clampedValue;
+                return;
+            }
 
-        partial void OnNyChanged(int value) => AutoGenerateMesh();
+            AutoGenerateMesh();
+        }
+
+        partial void OnNyChanged(int value)
+        {
+            int clampedValue = Math.Max(MinLbmGridSize, value);
+            if (clampedValue != value)
+            {
+                Ny = clampedValue;
+                return;
+            }
+
+            AutoGenerateMesh();
+        }
 
         partial void OnLayersChanged(int value) => AutoGenerateMesh();
 


### PR DESCRIPTION
## Summary
- clamp LBM grid size inputs to a minimum value to prevent invalid mesh generation
- regenerate meshes only after enforcing the minimum width and height

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693229e106408333bf5faa04f2796783)