### PR TITLE
Improve post-processing defaults and filters

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
@@ -70,6 +70,9 @@ namespace ElectricalImpedanceTomography.ViewModels
         [ObservableProperty]
         private bool _hasMesh;
 
+        [ObservableProperty]
+        private string _canvasMessage = "No reconstruction available. Load a workspace result or import a file.";
+
         // Statistics Display
         [ObservableProperty]
         private string _statMin = "0.000";
@@ -106,10 +109,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         public PostProcessingPageViewModel()
         {
             InitializePostProcessors();
-            if (!LoadLatestWorkspaceResult())
-            {
-                BuildDemoMesh();
-            }
+            LoadLatestWorkspaceResult();
 
             Log("System initialized.", "info");
             AddToHistory("Init");
@@ -124,6 +124,12 @@ namespace ElectricalImpedanceTomography.ViewModels
             PostProcessingOptions.Add(new ThresholdFilterPostProcessing());
             PostProcessingOptions.Add(new SigmaClippingPostProcessing());
             PostProcessingOptions.Add(new NormalizationPostProcessing());
+            PostProcessingOptions.Add(new GaussianBlurPostProcessing());
+            PostProcessingOptions.Add(new BilateralFilterPostProcessing());
+            PostProcessingOptions.Add(new ContrastStretchPostProcessing());
+            PostProcessingOptions.Add(new GammaCorrectionPostProcessing());
+            PostProcessingOptions.Add(new HighPassEnhancementPostProcessing());
+            PostProcessingOptions.Add(new WinsorizedClippingPostProcessing());
             SelectedPostProcessor = PostProcessingOptions.FirstOrDefault();
         }
 
@@ -131,16 +137,29 @@ namespace ElectricalImpedanceTomography.ViewModels
         public bool LoadLatestWorkspaceResult()
         {
             var lastResult = Workspace.GetReconstructionResults().LastOrDefault();
-            if (lastResult?.GetDiscretization() is not Discretization mesh)
+
+            if (lastResult?.GetDiscretization() is Discretization mesh)
             {
-                Log("No reconstruction results available in workspace.", "warn");
-                _hasMesh = false;
-                return false;
+                var distribution = lastResult.GetReconstructedConductivityDistribution();
+                LoadDiscretization(mesh.DeepCopy(), new ConductivityDistribution(distribution.Conductivities), "Workspace result");
+                CanvasMessage = string.Empty;
+                return true;
             }
 
-            var distribution = lastResult.GetReconstructedConductivityDistribution();
-            LoadDiscretization(mesh.DeepCopy(), new ConductivityDistribution(distribution.Conductivities), "Workspace result");
-            return true;
+            var fallbackMesh = Workspace.GetDiscretization();
+            var fallbackSigma = Workspace.GetOriginalConductivityDistribution() ?? fallbackMesh?.GetConductivityDistribution();
+            if (fallbackMesh != null && fallbackSigma != null)
+            {
+                LoadDiscretization(fallbackMesh.DeepCopy(), new ConductivityDistribution(fallbackSigma.Conductivities), "Active workspace discretization");
+                CanvasMessage = string.Empty;
+                return true;
+            }
+
+            Log("No reconstruction results available in workspace.", "warn");
+            ActiveSource = "No dataset loaded";
+            CanvasMessage = "No reconstruction available in the workspace.";
+            HasMesh = false;
+            return false;
         }
 
         [RelayCommand]
@@ -199,8 +218,11 @@ namespace ElectricalImpedanceTomography.ViewModels
                     }
                 }
 
-                LastSavedPath = csvPath;
-                Log($"Saved post processed mesh as '{name}'.", "success");
+                var meshFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "EITApplication", "Meshes");
+                Directory.CreateDirectory(meshFolder);
+
+                LastSavedPath = $"Mesh: {meshFolder}, CSV: {csvPath}";
+                Log($"Saved post processed mesh as '{name}'. CSV exported to {csvPath}.", "success");
                 AddToHistory($"Saved {name}");
             }
             catch (Exception ex)
@@ -221,6 +243,16 @@ namespace ElectricalImpedanceTomography.ViewModels
                     discretization = repo.LoadFEMMesh(path);
                 }
 
+                if (discretization == null && path.EndsWith(".csv", StringComparison.OrdinalIgnoreCase))
+                {
+                    discretization = Workspace.GetDiscretization()?.DeepCopy();
+                    if (discretization == null)
+                    {
+                        Log("A conductivity CSV requires an active workspace discretization.", "warn");
+                        return;
+                    }
+                }
+
                 if (discretization == null)
                 {
                     Log("Unsupported file type for post processing.", "warn");
@@ -229,10 +261,14 @@ namespace ElectricalImpedanceTomography.ViewModels
 
                 var distribution = ApplySidecarConductivities(path, discretization.GetConductivityDistribution());
                 LoadDiscretization(discretization, distribution, Path.GetFileName(path));
+                CanvasMessage = string.Empty;
             }
             catch (Exception ex)
             {
                 Log($"Failed to load result: {ex.Message}", "error");
+                ActiveSource = "No dataset loaded";
+                HasMesh = false;
+                CanvasMessage = "Unable to load the selected file.";
             }
         }
 
@@ -273,6 +309,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             _originalDistribution = new ConductivityDistribution(distribution.Conductivities);
             ActiveSource = label;
             _cutoffsInitialized = false;
+            CanvasMessage = string.Empty;
 
             if (discretization is FEMMesh femMesh)
             {
@@ -283,9 +320,12 @@ namespace ElectricalImpedanceTomography.ViewModels
                 Nodes.Clear();
                 Elements.Clear();
                 Log("Loaded discretization cannot be displayed in this view.", "warn");
+                HasMesh = false;
+                CanvasMessage = "The loaded discretization cannot be rendered on the canvas.";
+                return;
             }
 
-            _hasMesh = true;
+            HasMesh = true;
             UpdateStatistics(resetCutoffs: true);
             MeshUpdated?.Invoke(this, EventArgs.Empty);
         }

--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
@@ -51,8 +51,28 @@
         </ResourceDictionary>
     </ContentPage.Resources>
 
-    <!-- Main Layout: 3 Columns -->
-    <Grid ColumnDefinitions="320, *, 280">
+    <!-- Page Layout -->
+    <Grid RowDefinitions="Auto,*" RowSpacing="12" Padding="16,12,16,20">
+
+        <!-- Page Header -->
+        <Border Grid.Row="0" Style="{StaticResource CardStyle}" Padding="16" BackgroundColor="#111827">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12" VerticalOptions="Center">
+                <VerticalStackLayout Spacing="4">
+                    <Label Text="Post Processing" FontSize="20" FontAttributes="Bold" TextColor="White"/>
+                    <Label Text="Refine and analyze the latest reconstruction results." TextColor="{StaticResource TextMuted}" FontSize="12"/>
+                    <Label Text="{Binding ActiveSource, StringFormat='Active dataset: {0}'}" TextColor="{StaticResource BrandCyan}" FontSize="12"/>
+                    <Label Text="{Binding LastSavedPath, StringFormat='Last saved: {0}'}" TextColor="{StaticResource TextMuted}" FontSize="11" LineBreakMode="WordWrap"/>
+                </VerticalStackLayout>
+
+                <HorizontalStackLayout Grid.Column="1" Spacing="8" VerticalOptions="Center">
+                    <Button Text="Load Workspace" Command="{Binding LoadLatestWorkspaceResultCommand}" Style="{StaticResource ActionBtnStyle}" HeightRequest="44"/>
+                    <Button Text="Import File" Command="{Binding ImportSavedResultAsyncCommand}" Style="{StaticResource ActionBtnStyle}" HeightRequest="44"/>
+                </HorizontalStackLayout>
+            </Grid>
+        </Border>
+
+        <!-- Main Layout: 3 Columns -->
+        <Grid Grid.Row="1" ColumnDefinitions="320, *, 280" ColumnSpacing="12">
 
         <!-- LEFT SIDEBAR: CONFIGURATION -->
         <Border Grid.Column="0" BackgroundColor="{StaticResource BgSidebar}" StrokeThickness="0" Stroke="{StaticResource BorderColor}" Padding="0">
@@ -96,7 +116,7 @@
                                 </Grid>
                                 <Slider Minimum="0" Maximum="100" Value="{Binding FilterStrength}" ThumbColor="{StaticResource BrandCyan}" MinimumTrackColor="{StaticResource BrandCyan}" MaximumTrackColor="#334155"/>
 
-                                <CollectionView ItemsSource="{Binding PostProcessingOptions}" SelectionMode="Single" SelectedItem="{Binding SelectedPostProcessor}" HeightRequest="180">
+                                <CollectionView ItemsSource="{Binding PostProcessingOptions}" SelectionMode="Single" SelectedItem="{Binding SelectedPostProcessor}" HeightRequest="260">
                                     <CollectionView.ItemTemplate>
                                         <DataTemplate>
                                             <Border Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 8" Padding="10" BackgroundColor="#111827">
@@ -175,7 +195,7 @@
         </Border>
 
         <!-- CENTER: CANVAS & CONSOLE -->
-        <Grid Grid.Column="1" RowDefinitions="*, 200">
+        <Grid Grid.Column="1" RowDefinitions="*, 220" RowSpacing="8">
 
             <!-- 1. FEM Canvas Area -->
             <Grid Grid.Row="0" BackgroundColor="{StaticResource BgMain}">
@@ -210,9 +230,25 @@
                             <Label Text="Color" TextColor="{StaticResource TextMuted}" FontSize="11" VerticalOptions="Center"/>
                             <Picker SelectedItem="{Binding SelectedColormap}" ItemsSource="{Binding Colormaps}" 
                                     TextColor="White" TitleColor="{StaticResource TextMuted}" 
-                                    BackgroundColor="Transparent" FontSize="12" WidthRequest="80"/>
+                                   BackgroundColor="Transparent" FontSize="12" WidthRequest="80"/>
                         </HorizontalStackLayout>
                     </HorizontalStackLayout>
+                </Border>
+
+                <!-- Empty state overlay -->
+                <Border BackgroundColor="#D90b1120" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 16" Padding="20" VerticalOptions="Center" HorizontalOptions="Center">
+                    <Border.Triggers>
+                        <DataTrigger TargetType="Border" Binding="{Binding HasMesh}" Value="True">
+                            <Setter Property="IsVisible" Value="False" />
+                        </DataTrigger>
+                    </Border.Triggers>
+                    <VerticalStackLayout Spacing="12" WidthRequest="320" HorizontalOptions="Center" VerticalOptions="Center">
+                        <Label Text="{Binding CanvasMessage}" TextColor="{StaticResource TextMain}" FontSize="14" HorizontalTextAlignment="Center" LineBreakMode="WordWrap"/>
+                        <HorizontalStackLayout Spacing="8" HorizontalOptions="Center">
+                            <Button Text="Load Workspace" Command="{Binding LoadLatestWorkspaceResultCommand}" Style="{StaticResource ActionBtnStyle}" HeightRequest="36" WidthRequest="140"/>
+                            <Button Text="Import File" Command="{Binding ImportSavedResultAsyncCommand}" Style="{StaticResource ActionBtnStyle}" HeightRequest="36" WidthRequest="120"/>
+                        </HorizontalStackLayout>
+                    </VerticalStackLayout>
                 </Border>
             </Grid>
 
@@ -341,5 +377,6 @@
                 </ScrollView>
             </Grid>
         </Border>
+    </Grid>
     </Grid>
 </ContentPage>

--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
@@ -21,6 +21,13 @@ namespace ElectricalImpedanceTomography.Views
         private readonly SKPaint _fillPaint = new() { Style = SKPaintStyle.Fill, IsAntialias = true };
         private readonly SKPaint _borderPaint = new() { Style = SKPaintStyle.Stroke, Color = SKColor.Parse("#475569"), StrokeWidth = 2, IsAntialias = true };
         private readonly SKPaint _histogramBarPaint = new() { Color = SKColor.Parse("#22d3ee"), Style = SKPaintStyle.Fill, IsAntialias = true };
+        private readonly SKPaint _messagePaint = new()
+        {
+            Color = SKColors.LightGray,
+            TextSize = 18,
+            IsAntialias = true,
+            TextAlign = SKTextAlign.Center
+        };
 
         public PostProcessingPage()
         {
@@ -31,6 +38,13 @@ namespace ElectricalImpedanceTomography.Views
             // Redraw triggers
             _viewModel.PropertyChanged += (s, e) => RequestRedraw();
             _viewModel.MeshUpdated += (s, e) => RequestRedraw();
+        }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            if (!_viewModel.HasMesh)
+                _viewModel.LoadLatestWorkspaceResult();
         }
 
         private void RequestRedraw()
@@ -94,6 +108,17 @@ namespace ElectricalImpedanceTomography.Views
             var canvas = e.Surface.Canvas;
             canvas.Clear(SKColors.Transparent);
             var info = e.Info;
+
+            if (!_viewModel.HasMesh || _viewModel.Elements.Count == 0)
+            {
+                canvas.Clear(SKColor.Parse("#0b1120"));
+                var message = string.IsNullOrWhiteSpace(_viewModel.CanvasMessage)
+                    ? "No reconstruction loaded."
+                    : _viewModel.CanvasMessage;
+                var center = new SKPoint(info.Width / 2f, info.Height / 2f);
+                canvas.DrawText(message, center.X, center.Y, _messagePaint);
+                return;
+            }
 
             // Transform View
             canvas.Translate(info.Width / 2 + _translateX, info.Height / 2 + _translateY);

--- a/Utility/Classes/PostProcessing/BilateralFilterPostProcessing.cs
+++ b/Utility/Classes/PostProcessing/BilateralFilterPostProcessing.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using Utility.Classes.Discretizer;
+
+namespace Utility.Classes.PostProcessing
+{
+    public class BilateralFilterPostProcessing : IWeightedPostProcessing
+    {
+        public string Name => "Bilateral Filter";
+        public string Description => "Reduces noise while preserving edges by weighting by similarity.";
+
+        public double Weight { get; set; } = 0.5;
+
+        public ConductivityDistribution Process(IDiscretization discretization, ConductivityDistribution source)
+        {
+            var neighbors = PostProcessingHelpers.BuildElementNeighbors(discretization);
+            var values = source.Conductivities;
+            var result = new Dictionary<int, double>(values.Count);
+
+            double rangeSigma = Math.Max(0.05, Weight);
+            double spatialWeight = 0.8; // single hop neighbors only
+
+            foreach (var kvp in values)
+            {
+                double accum = kvp.Value;
+                double totalWeight = 1.0;
+
+                if (neighbors.TryGetValue(kvp.Key, out var adjacent))
+                {
+                    foreach (var id in adjacent)
+                    {
+                        if (!values.TryGetValue(id, out var nVal))
+                            continue;
+
+                        double range = kvp.Value - nVal;
+                        double similarity = Math.Exp(-(range * range) / (2 * rangeSigma * rangeSigma + 1e-9));
+                        double weight = Math.Exp(-1.0 / (2 * spatialWeight * spatialWeight)) * similarity;
+
+                        accum += nVal * weight;
+                        totalWeight += weight;
+                    }
+                }
+
+                result[kvp.Key] = accum / totalWeight;
+            }
+
+            return new ConductivityDistribution(result);
+        }
+    }
+}

--- a/Utility/Classes/PostProcessing/ContrastStretchPostProcessing.cs
+++ b/Utility/Classes/PostProcessing/ContrastStretchPostProcessing.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes.Discretizer;
+
+namespace Utility.Classes.PostProcessing
+{
+    public class ContrastStretchPostProcessing : IPostProcessing
+    {
+        public string Name => "Contrast Stretch";
+        public string Description => "Expands values between the 5th and 95th percentile for better contrast.";
+
+        public ConductivityDistribution Process(IDiscretization discretization, ConductivityDistribution source)
+        {
+            var values = source.Conductivities;
+            var ordered = values.Values.OrderBy(v => v).ToList();
+            if (ordered.Count == 0)
+                return source;
+
+            double low = Percentile(ordered, 0.05);
+            double high = Percentile(ordered, 0.95);
+            if (high - low < 1e-9)
+                return source;
+
+            var min = ordered.First();
+            var max = ordered.Last();
+            var result = new Dictionary<int, double>(values.Count);
+
+            foreach (var kvp in values)
+            {
+                double normalized = Math.Clamp((kvp.Value - low) / (high - low), 0.0, 1.0);
+                result[kvp.Key] = min + normalized * (max - min);
+            }
+
+            return new ConductivityDistribution(result);
+        }
+
+        private static double Percentile(IReadOnlyList<double> ordered, double p)
+        {
+            int idx = (int)Math.Clamp(Math.Round(p * (ordered.Count - 1)), 0, ordered.Count - 1);
+            return ordered[idx];
+        }
+    }
+}

--- a/Utility/Classes/PostProcessing/GammaCorrectionPostProcessing.cs
+++ b/Utility/Classes/PostProcessing/GammaCorrectionPostProcessing.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes.Discretizer;
+
+namespace Utility.Classes.PostProcessing
+{
+    public class GammaCorrectionPostProcessing : IWeightedPostProcessing
+    {
+        public string Name => "Gamma Correction";
+        public string Description => "Adjusts brightness by applying a gamma curve to conductivity values.";
+
+        public double Weight { get; set; } = 0.5;
+
+        public ConductivityDistribution Process(IDiscretization discretization, ConductivityDistribution source)
+        {
+            var values = source.Conductivities;
+            if (values.Count == 0)
+                return source;
+
+            double min = values.Values.Min();
+            double max = values.Values.Max();
+            double range = Math.Max(1e-9, max - min);
+            double gamma = 0.5 + Weight * 2.0; // 0.5 .. 2.5
+
+            var result = new Dictionary<int, double>(values.Count);
+            foreach (var kvp in values)
+            {
+                double norm = Math.Clamp((kvp.Value - min) / range, 0.0, 1.0);
+                double adjusted = Math.Pow(norm, gamma);
+                result[kvp.Key] = min + adjusted * range;
+            }
+
+            return new ConductivityDistribution(result);
+        }
+    }
+}

--- a/Utility/Classes/PostProcessing/GaussianBlurPostProcessing.cs
+++ b/Utility/Classes/PostProcessing/GaussianBlurPostProcessing.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using Utility.Classes.Discretizer;
+
+namespace Utility.Classes.PostProcessing
+{
+    public class GaussianBlurPostProcessing : IWeightedPostProcessing
+    {
+        public string Name => "Gaussian Blur";
+        public string Description => "Smooths conductivity using a soft Gaussian-weighted neighborhood.";
+
+        public double Weight { get; set; } = 0.45;
+
+        public ConductivityDistribution Process(IDiscretization discretization, ConductivityDistribution source)
+        {
+            var neighbors = PostProcessingHelpers.BuildElementNeighbors(discretization);
+            var values = source.Conductivities;
+            var result = new Dictionary<int, double>(values.Count);
+
+            double sigma = Math.Clamp(Weight, 0.05, 1.0);
+            double neighborWeight = Math.Exp(-1.0 / (2 * sigma * sigma));
+
+            foreach (var kvp in values)
+            {
+                double accum = kvp.Value;
+                double totalWeight = 1.0;
+
+                if (neighbors.TryGetValue(kvp.Key, out var adjacent))
+                {
+                    foreach (var id in adjacent)
+                    {
+                        if (!values.TryGetValue(id, out var nVal))
+                            continue;
+
+                        accum += nVal * neighborWeight;
+                        totalWeight += neighborWeight;
+                    }
+                }
+
+                result[kvp.Key] = accum / totalWeight;
+            }
+
+            return new ConductivityDistribution(result);
+        }
+    }
+}

--- a/Utility/Classes/PostProcessing/HighPassEnhancementPostProcessing.cs
+++ b/Utility/Classes/PostProcessing/HighPassEnhancementPostProcessing.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes.Discretizer;
+
+namespace Utility.Classes.PostProcessing
+{
+    public class HighPassEnhancementPostProcessing : IWeightedPostProcessing
+    {
+        public string Name => "Unsharp Mask";
+        public string Description => "Sharpens features by combining the original with a blurred subtraction.";
+
+        public double Weight { get; set; } = 0.4;
+
+        public ConductivityDistribution Process(IDiscretization discretization, ConductivityDistribution source)
+        {
+            var blur = new GaussianBlurPostProcessing { Weight = 0.6 }.Process(discretization, source);
+            var min = source.Conductivities.Values.Min();
+            var max = source.Conductivities.Values.Max();
+            double range = Math.Max(1e-9, max - min);
+
+            var result = new Dictionary<int, double>(source.Conductivities.Count);
+            foreach (var kvp in source.Conductivities)
+            {
+                double blurred = blur.Conductivities.TryGetValue(kvp.Key, out var b) ? b : kvp.Value;
+                double enhanced = kvp.Value + (kvp.Value - blurred) * Weight;
+                result[kvp.Key] = Math.Clamp(enhanced, min - 0.1 * range, max + 0.1 * range);
+            }
+
+            return new ConductivityDistribution(result);
+        }
+    }
+}

--- a/Utility/Classes/PostProcessing/WinsorizedClippingPostProcessing.cs
+++ b/Utility/Classes/PostProcessing/WinsorizedClippingPostProcessing.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes.Discretizer;
+
+namespace Utility.Classes.PostProcessing
+{
+    public class WinsorizedClippingPostProcessing : IPostProcessing
+    {
+        public string Name => "Winsorized Clipping";
+        public string Description => "Suppresses extreme outliers by clamping to percentile bounds.";
+
+        public ConductivityDistribution Process(IDiscretization discretization, ConductivityDistribution source)
+        {
+            var values = source.Conductivities;
+            if (values.Count == 0)
+                return source;
+
+            var ordered = values.Values.OrderBy(v => v).ToList();
+            double low = Percentile(ordered, 0.02);
+            double high = Percentile(ordered, 0.98);
+
+            var result = new Dictionary<int, double>(values.Count);
+            foreach (var kvp in values)
+            {
+                result[kvp.Key] = Math.Clamp(kvp.Value, low, high);
+            }
+
+            return new ConductivityDistribution(result);
+        }
+
+        private static double Percentile(IReadOnlyList<double> ordered, double p)
+        {
+            int idx = (int)Math.Clamp(Math.Round(p * (ordered.Count - 1)), 0, ordered.Count - 1);
+            return ordered[idx];
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show clear header/empty-state messaging on the post-processing canvas and reload the latest workspace discretization by default
- add six new post-processing options and expose them in the UI with improved option list space
- harden loading/saving flows (workspace, CSV, STL) and clarify saved output locations

## Testing
- `dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj` *(fails: dotnet SDK not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69336a1c68a083339e472d2aae050254)