### PR TITLE
Align post processing visuals with reconstruction

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
@@ -18,6 +18,7 @@ using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.PostProcessing;
+using Utility.Rendering;
 
 namespace ElectricalImpedanceTomography.ViewModels
 {
@@ -47,7 +48,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         private bool _showContours = false;
 
         [ObservableProperty]
-        private string _selectedColormap = "Jet";
+        private ConductivityDisplayMode _selectedConductivityDisplayMode = ConductivityDisplayMode.Classic;
 
         [ObservableProperty]
         private string _activeSource = "No dataset loaded";
@@ -74,7 +75,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         // Collections
         public ObservableCollection<string> ConsoleLogs { get; } = new();
         public ObservableCollection<string> HistoryLog { get; } = new();
-        public List<string> Colormaps { get; } = new() { "Jet", "Hot", "Gray", "Parula" };
+        public IReadOnlyList<ConductivityDisplayMode> ConductivityDisplayModes { get; } = Enum.GetValues<ConductivityDisplayMode>();
 
         public ObservableCollection<IPostProcessing> PostProcessingOptions { get; } = new();
 
@@ -546,7 +547,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             UpdateStatistics();
             MeshUpdated?.Invoke(this, EventArgs.Empty);
-            AddToHistory(processor.Name);
+            AddToHistory($"Applied {processor.Name} ({FilterStrength:F0}% intensity)");
             Log($"Applied {processor.Name}.", "success");
         }
 
@@ -616,6 +617,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             ConsoleLogs.Add($"[{time}] {msg}");
         }
 
-        private void AddToHistory(string action) => HistoryLog.Insert(0, action);
+        private void AddToHistory(string action) => HistoryLog.Insert(0, $"[{DateTime.Now:HH:mm:ss}] {action}");
     }
 }

--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
@@ -117,18 +117,34 @@
                                 </Grid>
                                 <Slider Minimum="0" Maximum="100" Value="{Binding FilterStrength}" ThumbColor="{StaticResource BrandCyan}" MinimumTrackColor="{StaticResource BrandCyan}" MaximumTrackColor="#334155"/>
 
-                                <CollectionView ItemsSource="{Binding PostProcessingOptions}" SelectionMode="Single" SelectedItem="{Binding SelectedPostProcessor}" HeightRequest="260">
-                                    <CollectionView.ItemTemplate>
-                                        <DataTemplate x:DataType="post:IPostProcessing">
-                                            <Border Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 8" Padding="10" BackgroundColor="#111827" Margin="0,0,0,8">
-                                                <VerticalStackLayout Spacing="2">
-                                                    <Label Text="{Binding Name}" TextColor="White" FontAttributes="Bold" FontSize="13"/>
-                                                    <Label Text="{Binding Description}" TextColor="{StaticResource TextMuted}" FontSize="11" LineBreakMode="WordWrap"/>
-                                                </VerticalStackLayout>
-                                            </Border>
-                                        </DataTemplate>
-                                    </CollectionView.ItemTemplate>
-                                </CollectionView>
+                                    <CollectionView ItemsSource="{Binding PostProcessingOptions}" SelectionMode="Single" SelectedItem="{Binding SelectedPostProcessor}" HeightRequest="260">
+                                        <CollectionView.ItemTemplate>
+                                            <DataTemplate x:DataType="post:IPostProcessing">
+                                                <Border x:Name="OptionCard" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 8" Padding="10" BackgroundColor="#111827" Margin="0,0,0,8">
+                                                    <VisualStateManager.VisualStateGroups>
+                                                        <VisualStateGroup x:Name="SelectionStates">
+                                                            <VisualState x:Name="Normal">
+                                                                <VisualState.Setters>
+                                                                    <Setter Property="Stroke" Value="{StaticResource BorderColor}"/>
+                                                                    <Setter Property="BackgroundColor" Value="#111827"/>
+                                                                </VisualState.Setters>
+                                                            </VisualState>
+                                                            <VisualState x:Name="Selected">
+                                                                <VisualState.Setters>
+                                                                    <Setter Property="Stroke" Value="{StaticResource BrandCyan}"/>
+                                                                    <Setter Property="BackgroundColor" Value="#11222F"/>
+                                                                </VisualState.Setters>
+                                                            </VisualState>
+                                                        </VisualStateGroup>
+                                                    </VisualStateManager.VisualStateGroups>
+                                                    <VerticalStackLayout Spacing="2">
+                                                        <Label Text="{Binding Name}" TextColor="White" FontAttributes="Bold" FontSize="13"/>
+                                                        <Label Text="{Binding Description}" TextColor="{StaticResource TextMuted}" FontSize="11" LineBreakMode="WordWrap"/>
+                                                    </VerticalStackLayout>
+                                                </Border>
+                                            </DataTemplate>
+                                        </CollectionView.ItemTemplate>
+                                    </CollectionView>
 
                                 <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
                                     <Button Text="Apply Selected" Command="{Binding ApplySelectedPostProcessingCommand}" Style="{StaticResource ActionBtnStyle}"/>
@@ -136,56 +152,6 @@
                                             BackgroundColor="#1e293b" TextColor="{StaticResource BrandRed}"
                                             BorderColor="{StaticResource BrandRed}" BorderWidth="1"
                                             HeightRequest="40" CornerRadius="6" FontSize="12" FontAttributes="Bold"/>
-                                </Grid>
-                            </VerticalStackLayout>
-                        </Border>
-
-                        <!-- DISPLAY SETTINGS -->
-                        <Border Style="{StaticResource CardStyle}">
-                            <VerticalStackLayout Spacing="16">
-                                <Label Text="DISPLAY SETTINGS" Style="{StaticResource GroupHeaderStyle}"/>
-
-                                <Grid ColumnDefinitions="*, Auto">
-                                    <Label Text="Wireframe" TextColor="{StaticResource TextMain}" VerticalOptions="Center" FontSize="13"/>
-                                    <Switch IsToggled="{Binding ShowWireframe}" OnColor="{StaticResource BrandCyan}" ThumbColor="White" Grid.Column="1"/>
-                                </Grid>
-
-                                <BoxView HeightRequest="1" Color="{StaticResource BorderColor}"/>
-
-                                <Grid ColumnDefinitions="*, Auto">
-                                    <Label Text="Nodes" TextColor="{StaticResource TextMain}" VerticalOptions="Center" FontSize="13"/>
-                                    <Switch IsToggled="{Binding ShowNodes}" OnColor="{StaticResource BrandCyan}" ThumbColor="White" Grid.Column="1"/>
-                                </Grid>
-
-                                <BoxView HeightRequest="1" Color="{StaticResource BorderColor}"/>
-
-                                <Grid ColumnDefinitions="*, Auto">
-                                    <Label Text="Contours" TextColor="{StaticResource TextMain}" VerticalOptions="Center" FontSize="13"/>
-                                    <Switch IsToggled="{Binding ShowContours}" OnColor="{StaticResource BrandCyan}" ThumbColor="White" Grid.Column="1"/>
-                                </Grid>
-
-                                <BoxView HeightRequest="1" Color="{StaticResource BorderColor}"/>
-
-                                <!-- Cutoff sliders -->
-                                <VerticalStackLayout Spacing="6">
-                                    <Grid ColumnDefinitions="*, Auto" ColumnSpacing="10">
-                                        <Label Text="Min Cutoff" FontSize="12" TextColor="{StaticResource TextMuted}"/>
-                                        <Label Text="{Binding MinCutoff, StringFormat='{0:F2}'}" TextColor="{StaticResource BrandCyan}" FontSize="11" FontAttributes="Bold"/>
-                                    </Grid>
-                                    <Slider Minimum="0" Maximum="10" Value="{Binding MinCutoff}" ThumbColor="{StaticResource BrandCyan}" MinimumTrackColor="{StaticResource BrandCyan}" MaximumTrackColor="#334155"/>
-
-                                    <Grid ColumnDefinitions="*, Auto" ColumnSpacing="10">
-                                        <Label Text="Max Cutoff" FontSize="12" TextColor="{StaticResource TextMuted}"/>
-                                        <Label Text="{Binding MaxCutoff, StringFormat='{0:F2}'}" TextColor="{StaticResource BrandCyan}" FontSize="11" FontAttributes="Bold"/>
-                                    </Grid>
-                                    <Slider Minimum="0" Maximum="10" Value="{Binding MaxCutoff}" ThumbColor="{StaticResource BrandCyan}" MinimumTrackColor="{StaticResource BrandCyan}" MaximumTrackColor="#334155"/>
-                                </VerticalStackLayout>
-
-                                <BoxView HeightRequest="1" Color="{StaticResource BorderColor}" Margin="0,4"/>
-
-                                <Grid ColumnDefinitions="*, Auto">
-                                    <Label Text="Logarithmic Scale" TextColor="{StaticResource TextMain}" VerticalOptions="Center" FontSize="13"/>
-                                    <Switch IsToggled="{Binding IsLogScale}" OnColor="{StaticResource BrandCyan}" ThumbColor="White" Grid.Column="1"/>
                                 </Grid>
                             </VerticalStackLayout>
                         </Border>
@@ -229,9 +195,9 @@
 
                         <HorizontalStackLayout Spacing="8" VerticalOptions="Center">
                             <Label Text="Color" TextColor="{StaticResource TextMuted}" FontSize="11" VerticalOptions="Center"/>
-                            <Picker SelectedItem="{Binding SelectedColormap}" ItemsSource="{Binding Colormaps}" 
-                                    TextColor="White" TitleColor="{StaticResource TextMuted}" 
-                                   BackgroundColor="Transparent" FontSize="12" WidthRequest="80"/>
+                            <Picker SelectedItem="{Binding SelectedConductivityDisplayMode}" ItemsSource="{Binding ConductivityDisplayModes}"
+                                    TextColor="White" TitleColor="{StaticResource TextMuted}"
+                                   BackgroundColor="Transparent" FontSize="12" WidthRequest="140"/>
                         </HorizontalStackLayout>
                     </HorizontalStackLayout>
                 </Border>
@@ -355,9 +321,9 @@
                                 <CollectionView ItemsSource="{Binding HistoryLog}" HeightRequest="120">
                                     <CollectionView.ItemTemplate>
                                         <DataTemplate>
-                                            <Grid ColumnDefinitions="20, *">
+                                            <Grid ColumnDefinitions="20, *" ColumnSpacing="6">
                                                 <Label Text="&#xf058;" FontFamily="FontAwesome" TextColor="#10b981" FontSize="12" VerticalOptions="Center"/>
-                                                <Label Text="{Binding .}" Grid.Column="1" FontSize="12" TextColor="{StaticResource TextMuted}" VerticalOptions="Center"/>
+                                                <Label Text="{Binding .}" Grid.Column="1" FontSize="12" TextColor="White" VerticalOptions="Center" FontFamily="Consolas" LineBreakMode="WordWrap"/>
                                             </Grid>
                                         </DataTemplate>
                                     </CollectionView.ItemTemplate>

--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
@@ -5,6 +5,7 @@ using SkiaSharp.Views.Maui;
 using System.Linq;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using Utility.Rendering;
 
 namespace ElectricalImpedanceTomography.Views
 {
@@ -146,7 +147,7 @@ namespace ElectricalImpedanceTomography.Views
             {
                 var vertices = element.Vertices;
                 double value = _viewModel.ProcessValue(_viewModel.GetConductivityValue(element.Id, element.Conductivity));
-                _fillPaint.Color = GetHeatColor(value, _viewModel.SelectedColormap);
+                _fillPaint.Color = GetHeatColor(value, _viewModel.SelectedConductivityDisplayMode);
 
                 using var path = new SKPath();
                 path.MoveTo((float)vertices[0].X, (float)vertices[0].Y);
@@ -186,7 +187,7 @@ namespace ElectricalImpedanceTomography.Views
 
                 var (x, y) = grid.ToLattice(element.Id);
                 double value = _viewModel.ProcessValue(_viewModel.GetConductivityValue(element.Id, element.Conductivity));
-                _fillPaint.Color = GetHeatColor(value, _viewModel.SelectedColormap);
+                _fillPaint.Color = GetHeatColor(value, _viewModel.SelectedConductivityDisplayMode);
 
                 var rect = SKRect.Create((float)x, (float)y, 1f, 1f);
                 canvas.DrawRect(rect, _fillPaint);
@@ -240,30 +241,143 @@ namespace ElectricalImpedanceTomography.Views
         }
 
         // --- Colormap Helper ---
-        private SKColor GetHeatColor(double norm, string colormap)
+        private static readonly (double Position, SKColor Color)[] EnhancedDivergingPalette =
+        {
+            (0.0, SKColor.Parse("#2B83BA")),
+            (0.17, SKColor.Parse("#74ADD1")),
+            (0.33, SKColor.Parse("#E0F3F8")),
+            (0.5, SKColor.Parse("#FFFFBF")),
+            (0.67, SKColor.Parse("#FEE08B")),
+            (0.83, SKColor.Parse("#FC8D59")),
+            (1.0, SKColor.Parse("#D53E4F"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] MatlabJetPalette =
+        {
+            (0.0, SKColor.Parse("#00007F")),
+            (0.125, SKColor.Parse("#0000FF")),
+            (0.375, SKColor.Parse("#00FFFF")),
+            (0.625, SKColor.Parse("#FFFF00")),
+            (0.875, SKColor.Parse("#FF0000")),
+            (1.0, SKColor.Parse("#7F0000"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] ParulaPalette =
+        {
+            (0.0, SKColor.Parse("#352A87")),
+            (0.16, SKColor.Parse("#2462BE")),
+            (0.33, SKColor.Parse("#1F9AD6")),
+            (0.5, SKColor.Parse("#3BB6A5")),
+            (0.66, SKColor.Parse("#74C476")),
+            (0.83, SKColor.Parse("#B6D051")),
+            (1.0, SKColor.Parse("#FDE724"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] ViridisPalette =
+        {
+            (0.0, SKColor.Parse("#440154")),
+            (0.2, SKColor.Parse("#414487")),
+            (0.4, SKColor.Parse("#2A788E")),
+            (0.6, SKColor.Parse("#22A884")),
+            (0.8, SKColor.Parse("#7AD151")),
+            (1.0, SKColor.Parse("#FDE725"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] PlasmaPalette =
+        {
+            (0.0, SKColor.Parse("#0D0887")),
+            (0.16, SKColor.Parse("#5B02A3")),
+            (0.33, SKColor.Parse("#9A179B")),
+            (0.5, SKColor.Parse("#CB4679")),
+            (0.66, SKColor.Parse("#ED7953")),
+            (0.83, SKColor.Parse("#FDB42F")),
+            (1.0, SKColor.Parse("#F0F921"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] MagmaPalette =
+        {
+            (0.0, SKColor.Parse("#000004")),
+            (0.16, SKColor.Parse("#1C1044")),
+            (0.33, SKColor.Parse("#4F0C6B")),
+            (0.5, SKColor.Parse("#822681")),
+            (0.66, SKColor.Parse("#B73779")),
+            (0.83, SKColor.Parse("#F1605D")),
+            (1.0, SKColor.Parse("#FCFDBF"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] CividisPalette =
+        {
+            (0.0, SKColor.Parse("#00204C")),
+            (0.2, SKColor.Parse("#00366F")),
+            (0.4, SKColor.Parse("#39558C")),
+            (0.6, SKColor.Parse("#7B7B78")),
+            (0.8, SKColor.Parse("#B8B972")),
+            (1.0, SKColor.Parse("#FAF976"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] CoolWarmPalette =
+        {
+            (0.0, SKColor.Parse("#3B4CC0")),
+            (0.16, SKColor.Parse("#5C86C5")),
+            (0.33, SKColor.Parse("#93B5D7")),
+            (0.5, SKColor.Parse("#E6E6E6")),
+            (0.66, SKColor.Parse("#E5B08A")),
+            (0.83, SKColor.Parse("#D25C4D")),
+            (1.0, SKColor.Parse("#8B1A1A"))
+        };
+
+        private SKColor GetHeatColor(double norm, ConductivityDisplayMode mode)
         {
             norm = Math.Clamp(norm, 0, 1);
-            byte r = 0, g = 0, b = 0;
+            return mode switch
+            {
+                ConductivityDisplayMode.Classic => ColorForValue(norm),
+                ConductivityDisplayMode.EnhancedDiverging => InterpolatePalette(EnhancedDivergingPalette, norm),
+                ConductivityDisplayMode.Rainbow => SKColor.FromHsv((float)(norm * 360f), 100f, 100f),
+                ConductivityDisplayMode.MatlabJet => InterpolatePalette(MatlabJetPalette, norm),
+                ConductivityDisplayMode.Parula => InterpolatePalette(ParulaPalette, norm),
+                ConductivityDisplayMode.Viridis => InterpolatePalette(ViridisPalette, norm),
+                ConductivityDisplayMode.Plasma => InterpolatePalette(PlasmaPalette, norm),
+                ConductivityDisplayMode.Magma => InterpolatePalette(MagmaPalette, norm),
+                ConductivityDisplayMode.Cividis => InterpolatePalette(CividisPalette, norm),
+                ConductivityDisplayMode.CoolWarm => InterpolatePalette(CoolWarmPalette, norm),
+                _ => ColorForValue(norm)
+            };
+        }
 
-            if (colormap == "Gray")
+        private static SKColor ColorForValue(double norm)
+        {
+            byte r = (byte)(255 * norm);
+            byte b = (byte)(255 * (1 - norm));
+            return new SKColor(r, 0, b);
+        }
+
+        private static SKColor InterpolatePalette((double Position, SKColor Color)[] palette, double t)
+        {
+            if (t <= palette[0].Position)
+                return palette[0].Color;
+            for (int i = 0; i < palette.Length - 1; i++)
             {
-                byte c = (byte)(norm * 255);
-                return new SKColor(c, c, c);
+                var (posA, colorA) = palette[i];
+                var (posB, colorB) = palette[i + 1];
+                if (t >= posA && t <= posB)
+                {
+                    double range = posB - posA;
+                    double localT = range <= 0 ? 0 : (t - posA) / range;
+                    return Lerp(colorA, colorB, localT);
+                }
             }
-            else if (colormap == "Hot")
-            {
-                r = (byte)(norm < 0.33 ? norm * 3 * 255 : 255);
-                g = (byte)(norm < 0.33 ? 0 : (norm < 0.66 ? (norm - 0.33) * 3 * 255 : 255));
-                b = (byte)(norm < 0.66 ? 0 : (norm - 0.66) * 3 * 255);
-            }
-            else // Jet
-            {
-                if (norm < 0.25) { r = 0; g = (byte)(4 * norm * 255); b = 255; }
-                else if (norm < 0.5) { r = 0; g = 255; b = (byte)(255 - 4 * (norm - 0.25) * 255); }
-                else if (norm < 0.75) { r = (byte)(4 * (norm - 0.5) * 255); g = 255; b = 0; }
-                else { r = 255; g = (byte)(255 - 4 * (norm - 0.75) * 255); b = 0; }
-            }
-            return new SKColor(r, g, b);
+
+            return palette[^1].Color;
+        }
+
+        private static SKColor Lerp(SKColor a, SKColor b, double t)
+        {
+            byte r = (byte)(a.Red + (b.Red - a.Red) * t);
+            byte g = (byte)(a.Green + (b.Green - a.Green) * t);
+            byte bl = (byte)(a.Blue + (b.Blue - a.Blue) * t);
+            byte al = (byte)(a.Alpha + (b.Alpha - a.Alpha) * t);
+            return new SKColor(r, g, bl, al);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove the old display settings panel and align post-processing visuals with the reconstruction/meshing experience
- Add the reconstruction conductivity coloring options and highlight the selected post-processing tool in the list
- Improve history entries so actions are shown with readable text

## Testing
- `dotnet build ElectricalImpedanceTomography/ElectricalImpedanceTomography.csproj -nologo` *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693440a51e188333b926203f2e656d78)