### PR TITLE
Fix workspace loading on post processing page

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
@@ -167,16 +167,21 @@ namespace ElectricalImpedanceTomography.ViewModels
         public bool LoadLatestWorkspaceResult()
         {
             var lastResult = Workspace.GetReconstructionResults().LastOrDefault();
+            var fallbackMesh = Workspace.GetDiscretization();
 
-            if (lastResult?.GetDiscretization() is Discretization mesh)
+            if (lastResult != null)
             {
                 var distribution = lastResult.GetReconstructedConductivityDistribution();
-                LoadDiscretization(mesh.DeepCopy(), new ConductivityDistribution(distribution.Conductivities), "Workspace result");
-                CanvasMessage = string.Empty;
-                return true;
+                var mesh = lastResult.GetDiscretization() ?? fallbackMesh?.GetDiscretization();
+
+                if (mesh != null)
+                {
+                    LoadDiscretization(mesh.DeepCopy(), new ConductivityDistribution(distribution.Conductivities), "Workspace result");
+                    CanvasMessage = string.Empty;
+                    return true;
+                }
             }
 
-            var fallbackMesh = Workspace.GetDiscretization();
             var fallbackSigma = Workspace.GetOriginalConductivityDistribution() ?? fallbackMesh?.GetConductivityDistribution();
             if (fallbackMesh != null && fallbackSigma != null)
             {


### PR DESCRIPTION
## Summary
- ensure the post processing page can load the most recent workspace reconstruction even when the result lacks its own discretization instance
- fall back to the active workspace mesh so the last reconstructed conductivity distribution is displayed

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet CLI not available in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693461308a408333ae4915f4ec6c1968)