### PR TITLE
Add canvas rendering for post-processing results

### DIFF
--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewmodels="clr-namespace:ElectricalImpedanceTomography.ViewModels"
              xmlns:post="clr-namespace:Utility.Classes.PostProcessing;assembly=Utility"
+             xmlns:skia="clr-namespace:SkiaSharp.Views.Maui.Controls;assembly=SkiaSharp.Views.Maui.Controls"
              x:Class="ElectricalImpedanceTomography.Views.PostProcessingPage"
              Title="Post Processing"
              x:DataType="viewmodels:PostProcessingPageViewModel"
@@ -154,18 +155,30 @@
                         <Grid Padding="24" RowDefinitions="Auto,*" RowSpacing="12">
                             <VerticalStackLayout Spacing="4">
                                 <Label Text="Mesh visualization" TextColor="{StaticResource TextPrimary}" FontAttributes="Bold" FontSize="16"/>
-                                <Label Text="This view matches the meshing and reconstruction pages. Load a workspace or processed dataset to continue." TextColor="{StaticResource TextSecondary}" FontSize="12" LineBreakMode="WordWrap"/>
+                                <Label Text="{Binding CanvasMessage}" TextColor="{StaticResource TextSecondary}" FontSize="12" LineBreakMode="WordWrap"/>
                             </VerticalStackLayout>
 
                             <Border Grid.Row="1" BackgroundColor="#0b0e12" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 10" Padding="20" HorizontalOptions="Fill" VerticalOptions="Fill">
-                                <VerticalStackLayout Spacing="12" HorizontalOptions="Center" VerticalOptions="Center">
-                                    <Label Text="Visualization unavailable" TextColor="{StaticResource TextPrimary}" FontSize="18" FontAttributes="Bold" HorizontalTextAlignment="Center"/>
-                                    <Label Text="Mesh rendering now follows the same viewer used on the meshing and reconstruction pages. Reload your dataset to inspect results there." TextColor="{StaticResource TextSecondary}" FontSize="13" HorizontalTextAlignment="Center" LineBreakMode="WordWrap" WidthRequest="520"/>
-                                    <HorizontalStackLayout Spacing="8" HorizontalOptions="Center">
-                                        <Button Text="Load Workspace" Command="{Binding LoadLatestWorkspaceResultCommand}" Style="{StaticResource ToolbarBtn}"/>
-                                        <Button Text="Import File" Command="{Binding ImportSavedResultAsyncCommand}" Style="{StaticResource ToolbarBtn}"/>
-                                    </HorizontalStackLayout>
-                                </VerticalStackLayout>
+                                <Grid>
+                                    <skia:SKCanvasView x:Name="PostProcessingCanvas"
+                                                       PaintSurface="OnCanvasViewPaintSurface"
+                                                       IgnorePixelScaling="True"
+                                                       HorizontalOptions="Fill"
+                                                       VerticalOptions="Fill" />
+
+                                    <VerticalStackLayout Spacing="8" HorizontalOptions="Center" VerticalOptions="Center" IsVisible="True">
+                                        <VerticalStackLayout.Triggers>
+                                            <DataTrigger TargetType="VerticalStackLayout" Binding="{Binding HasMesh}" Value="True">
+                                                <Setter Property="IsVisible" Value="False" />
+                                            </DataTrigger>
+                                        </VerticalStackLayout.Triggers>
+                                        <Label Text="Visualization unavailable" TextColor="{StaticResource TextPrimary}" FontSize="18" FontAttributes="Bold" HorizontalTextAlignment="Center"/>
+                                        <HorizontalStackLayout Spacing="8" HorizontalOptions="Center">
+                                            <Button Text="Load Workspace" Command="{Binding LoadLatestWorkspaceResultCommand}" Style="{StaticResource ToolbarBtn}"/>
+                                            <Button Text="Import File" Command="{Binding ImportSavedResultAsyncCommand}" Style="{StaticResource ToolbarBtn}"/>
+                                        </HorizontalStackLayout>
+                                    </VerticalStackLayout>
+                                </Grid>
                             </Border>
                         </Grid>
                     </Border>

--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
@@ -1,16 +1,34 @@
 using ElectricalImpedanceTomography.ViewModels;
+using SkiaSharp;
+using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
+using System.Linq;
 
 namespace ElectricalImpedanceTomography.Views
 {
     public partial class PostProcessingPage : ContentPage
     {
         private readonly PostProcessingPageViewModel _viewModel;
+        private readonly SKPaint _femStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.White.WithAlpha(80), StrokeWidth = 0.75f, IsAntialias = true };
+        private readonly SKPaint _femFill = new() { Style = SKPaintStyle.Fill, IsAntialias = true };
+        private readonly SKPaint _lbmStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.Gray.WithAlpha(120), StrokeWidth = 1f, IsAntialias = true };
+        private readonly SKPaint _placeholderText = new()
+        {
+            Color = SKColors.LightGray,
+            TextSize = 28,
+            IsAntialias = true,
+            TextAlign = SKTextAlign.Center
+        };
+
+        private float _scale, _marginX, _marginY, _minX, _minY, _meshWidth, _meshHeight;
 
         public PostProcessingPage()
         {
             InitializeComponent();
             _viewModel = new PostProcessingPageViewModel();
             BindingContext = _viewModel;
+
+            _viewModel.MeshUpdated += (_, _) => PostProcessingCanvas?.InvalidateSurface();
         }
 
         protected override void OnAppearing()
@@ -20,6 +38,117 @@ namespace ElectricalImpedanceTomography.Views
             {
                 _viewModel.LoadLatestWorkspaceResult();
             }
+
+            PostProcessingCanvas?.InvalidateSurface();
+        }
+
+        private void OnCanvasViewPaintSurface(object? sender, SkiaSharp.Views.Maui.SKPaintSurfaceEventArgs e)
+        {
+            var canvas = e.Surface.Canvas;
+            var info = e.Info;
+            canvas.Clear(SKColors.Transparent);
+
+            if (!_viewModel.HasMesh)
+            {
+                DrawPlaceholder(canvas, info, _viewModel.CanvasMessage);
+                return;
+            }
+
+            var conductivities = _viewModel.ElementConductivities().ToList();
+            if (conductivities.Count == 0)
+            {
+                DrawPlaceholder(canvas, info, "No conductivity data available.");
+                return;
+            }
+
+            if (_viewModel.LbmGrid is LBMGrid lbm)
+            {
+                DrawLbmGrid(canvas, info, lbm);
+                return;
+            }
+
+            if (_viewModel.FemMesh is FEMMesh fem)
+            {
+                DrawFemMesh(canvas, info, fem);
+                return;
+            }
+
+            DrawPlaceholder(canvas, info, "Mesh could not be rendered.");
+        }
+
+        private void DrawLbmGrid(SKCanvas canvas, SKImageInfo info, LBMGrid grid)
+        {
+            float cellW = (float)info.Width / grid.Nx;
+            float cellH = (float)info.Height / grid.Ny;
+
+            foreach (var el in grid.GetElements().Cast<LBMElement>())
+            {
+                var (x, y) = grid.ToLattice(el.Id);
+                var rect = SKRect.Create(x * cellW, y * cellH, cellW, cellH);
+                double sigma = _viewModel.GetConductivityValue(el.Id, el.Conductivity);
+                var color = ColorForValue(_viewModel.ProcessValue(sigma));
+
+                using var fill = new SKPaint { Style = SKPaintStyle.Fill, Color = color, IsAntialias = true };
+                canvas.DrawRect(rect, fill);
+                canvas.DrawRect(rect, _lbmStroke);
+            }
+        }
+
+        private void DrawFemMesh(SKCanvas canvas, SKImageInfo info, FEMMesh mesh)
+        {
+            const float pad = 10f;
+            float availW = info.Width - 2 * pad;
+            float availH = info.Height - 2 * pad;
+            var verts = mesh.Vertices;
+            _minX = (float)verts.Min(v => v.X);
+            _minY = (float)verts.Min(v => v.Y);
+            var maxX = (float)verts.Max(v => v.X);
+            var maxY = (float)verts.Max(v => v.Y);
+            _meshWidth = maxX - _minX;
+            _meshHeight = maxY - _minY;
+            _scale = Math.Min(availW / _meshWidth, availH / _meshHeight);
+            float usedW = _meshWidth * _scale;
+            float usedH = _meshHeight * _scale;
+            _marginX = pad + (availW - usedW) / 2f;
+            _marginY = pad + (availH - usedH) / 2f;
+
+            using var path = new SKPath();
+
+            foreach (var el in mesh.ElementsTyped)
+            {
+                var p1 = ToCanvas(el.Vertices[0]);
+                var p2 = ToCanvas(el.Vertices[1]);
+                var p3 = ToCanvas(el.Vertices[2]);
+
+                path.Reset();
+                path.MoveTo(p1);
+                path.LineTo(p2);
+                path.LineTo(p3);
+                path.Close();
+
+                double sigma = _viewModel.GetConductivityValue(el.Id, el.Conductivity);
+                _femFill.Color = ColorForValue(_viewModel.ProcessValue(sigma));
+                canvas.DrawPath(path, _femFill);
+                canvas.DrawPath(path, _femStroke);
+            }
+        }
+
+        private SKPoint ToCanvas(FEMVertex v) => new((float)(v.X - _minX) * _scale + _marginX, PostProcessingCanvas.CanvasSize.Height - ((float)(v.Y - _minY) * _scale + _marginY));
+
+        private SKColor ColorForValue(double normalized)
+        {
+            float t = (float)Math.Clamp(normalized, 0, 1);
+            byte r = (byte)(255 * t);
+            byte b = (byte)(255 * (1 - t));
+            return new SKColor(r, 20, b, 255);
+        }
+
+        private void DrawPlaceholder(SKCanvas canvas, SKImageInfo info, string message)
+        {
+            canvas.DrawText(string.IsNullOrWhiteSpace(message) ? "No reconstruction available." : message,
+                            info.Width / 2f,
+                            info.Height / 2f,
+                            _placeholderText);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a Skia canvas to the post-processing page to visualize reconstructed conductivity data
- wire the page to load the latest workspace reconstruction by default and refresh when commands run
- keep a placeholder view and status messaging when no reconstruction is available

## Testing
- dotnet build (fails: dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934661ef47c83339cc6d2056d19681d)