### PR TITLE
Enhance post processing UI and refinement tools

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
@@ -74,6 +74,7 @@ namespace ElectricalImpedanceTomography.ViewModels
         public IReadOnlyList<ConductivityDisplayMode> ConductivityDisplayModes { get; } = Enum.GetValues<ConductivityDisplayMode>();
 
         public ObservableCollection<IPostProcessing> PostProcessingOptions { get; } = new();
+        public ObservableCollection<PostProcessingGroup> PostProcessingGroups { get; } = new();
 
         [ObservableProperty]
         private IPostProcessing? _selectedPostProcessor;
@@ -144,18 +145,51 @@ namespace ElectricalImpedanceTomography.ViewModels
         private void InitializePostProcessors()
         {
             PostProcessingOptions.Clear();
-            PostProcessingOptions.Add(new LaplacianSmoothingPostProcessing());
-            PostProcessingOptions.Add(new MedianFilterPostProcessing());
-            PostProcessingOptions.Add(new EdgeEnhancementPostProcessing());
-            PostProcessingOptions.Add(new ThresholdFilterPostProcessing());
-            PostProcessingOptions.Add(new SigmaClippingPostProcessing());
-            PostProcessingOptions.Add(new NormalizationPostProcessing());
-            PostProcessingOptions.Add(new GaussianBlurPostProcessing());
-            PostProcessingOptions.Add(new BilateralFilterPostProcessing());
-            PostProcessingOptions.Add(new ContrastStretchPostProcessing());
-            PostProcessingOptions.Add(new GammaCorrectionPostProcessing());
-            PostProcessingOptions.Add(new HighPassEnhancementPostProcessing());
-            PostProcessingOptions.Add(new WinsorizedClippingPostProcessing());
+            PostProcessingGroups.Clear();
+
+            var smoothing = new PostProcessingGroup(
+                "Smoothing & Denoising",
+                "Reduce noise while retaining overall structure.",
+                new IPostProcessing[]
+                {
+                    new LaplacianSmoothingPostProcessing(),
+                    new MedianFilterPostProcessing(),
+                    new GaussianBlurPostProcessing(),
+                    new BilateralFilterPostProcessing(),
+                    new MeanFilterPostProcessing(),
+                    new AnisotropicDiffusionPostProcessing()
+                });
+
+            var enhancement = new PostProcessingGroup(
+                "Enhancement & Refinement",
+                "Sharpen or emphasize edges and gradients.",
+                new IPostProcessing[]
+                {
+                    new EdgeEnhancementPostProcessing(),
+                    new HighPassEnhancementPostProcessing(),
+                    new AdaptiveSharpenPostProcessing(),
+                    new ContrastStretchPostProcessing(),
+                    new GammaCorrectionPostProcessing()
+                });
+
+            var normalization = new PostProcessingGroup(
+                "Normalization & Clipping",
+                "Constrain or normalize ranges for stability.",
+                new IPostProcessing[]
+                {
+                    new ThresholdFilterPostProcessing(),
+                    new SigmaClippingPostProcessing(),
+                    new WinsorizedClippingPostProcessing(),
+                    new NormalizationPostProcessing()
+                });
+
+            foreach (var group in new[] { smoothing, enhancement, normalization })
+            {
+                PostProcessingGroups.Add(group);
+                foreach (var option in group)
+                    PostProcessingOptions.Add(option);
+            }
+
             SelectedPostProcessor = PostProcessingOptions.FirstOrDefault();
         }
 

--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
@@ -90,10 +90,36 @@
                             <Border BackgroundColor="#0b0e12" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 8" Padding="12">
                                 <VerticalStackLayout Spacing="10">
                                     <Label Text="Post Processing Options" Style="{StaticResource HeaderLabel}" Margin="0,0,0,6"/>
-                                    <CollectionView ItemsSource="{Binding PostProcessingOptions}" SelectionMode="Single" SelectedItem="{Binding SelectedPostProcessor}" HeightRequest="260">
+                                    <CollectionView ItemsSource="{Binding PostProcessingGroups}" SelectionMode="Single" SelectedItem="{Binding SelectedPostProcessor}" HeightRequest="280" IsGrouped="True" ItemsLayout="VerticalList">
+                                        <CollectionView.GroupHeaderTemplate>
+                                            <DataTemplate x:DataType="post:PostProcessingGroup">
+                                                <VerticalStackLayout Spacing="2" Padding="4,8,0,4">
+                                                    <Label Text="{Binding Title}" TextColor="{StaticResource TextSecondary}" FontAttributes="Bold" FontSize="13"/>
+                                                    <Label Text="{Binding Description}" TextColor="{StaticResource TextMuted}" FontSize="11" LineBreakMode="WordWrap"/>
+                                                </VerticalStackLayout>
+                                            </DataTemplate>
+                                        </CollectionView.GroupHeaderTemplate>
                                         <CollectionView.ItemTemplate>
                                             <DataTemplate x:DataType="post:IPostProcessing">
-                                                <Border BackgroundColor="#13161C" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 6" Padding="10">
+                                                <Border x:Name="OptionCard" BackgroundColor="#13161C" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 6" Padding="10" StrokeThickness="1">
+                                                    <VisualStateManager.VisualStateGroups>
+                                                        <VisualStateGroup x:Name="CommonStates">
+                                                            <VisualState x:Name="Normal">
+                                                                <VisualState.Setters>
+                                                                    <Setter Property="BackgroundColor" Value="#13161C" />
+                                                                    <Setter Property="Stroke" Value="{StaticResource BorderColor}" />
+                                                                    <Setter Property="StrokeThickness" Value="1" />
+                                                                </VisualState.Setters>
+                                                            </VisualState>
+                                                            <VisualState x:Name="Selected">
+                                                                <VisualState.Setters>
+                                                                    <Setter Property="BackgroundColor" Value="#0c1b23" />
+                                                                    <Setter Property="Stroke" Value="{StaticResource PrimaryAccent}" />
+                                                                    <Setter Property="StrokeThickness" Value="2" />
+                                                                </VisualState.Setters>
+                                                            </VisualState>
+                                                        </VisualStateGroup>
+                                                    </VisualStateManager.VisualStateGroups>
                                                     <VerticalStackLayout>
                                                         <Label Text="{Binding Name}" TextColor="{StaticResource TextPrimary}" FontAttributes="Bold"/>
                                                         <Label Text="{Binding Description}" TextColor="{StaticResource TextMuted}" FontSize="12" LineBreakMode="WordWrap"/>
@@ -110,19 +136,24 @@
                                 </VerticalStackLayout>
                             </Border>
 
-                            <Border BackgroundColor="#0b0e12" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 8" Padding="12">
-                                <VerticalStackLayout Spacing="8">
-                                    <Label Text="History" Style="{StaticResource HeaderLabel}" Margin="0,0,0,6"/>
-                                    <CollectionView ItemsSource="{Binding HistoryLog}" HeightRequest="120">
-                                        <CollectionView.ItemTemplate>
-                                            <DataTemplate>
-                                                <Label Text="{Binding .}" TextColor="{StaticResource TextSecondary}" FontSize="12" LineBreakMode="WordWrap"/>
-                                            </DataTemplate>
-                                        </CollectionView.ItemTemplate>
-                                    </CollectionView>
-                                    <Button Text="Export" Command="{Binding ExportDataCommand}" Style="{StaticResource ToolbarBtn}"/>
-                                </VerticalStackLayout>
-                            </Border>
+                              <Border BackgroundColor="#0b0e12" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 8" Padding="12">
+                                  <VerticalStackLayout Spacing="8">
+                                      <Label Text="History" Style="{StaticResource HeaderLabel}" Margin="0,0,0,6"/>
+                                      <CollectionView ItemsSource="{Binding HistoryLog}" HeightRequest="140" ItemsLayout="VerticalList" SelectionMode="None" BackgroundColor="#0b121d" Margin="0,4,0,0">
+                                          <CollectionView.ItemTemplate>
+                                              <DataTemplate>
+                                                  <Border Stroke="{StaticResource BorderColor}" StrokeThickness="0" Padding="6,4" BackgroundColor="#0f172a">
+                                                      <Label Text="{Binding .}" TextColor="{StaticResource TextPrimary}" FontSize="12" LineBreakMode="WordWrap"/>
+                                                  </Border>
+                                              </DataTemplate>
+                                          </CollectionView.ItemTemplate>
+                                          <CollectionView.EmptyView>
+                                              <Label Text="No actions yet." TextColor="{StaticResource TextMuted}" FontSize="12"/> 
+                                          </CollectionView.EmptyView>
+                                      </CollectionView>
+                                      <Button Text="Export" Command="{Binding ExportDataCommand}" Style="{StaticResource ToolbarBtn}"/>
+                                  </VerticalStackLayout>
+                              </Border>
                         </VerticalStackLayout>
                     </ScrollView>
                 </Grid>
@@ -159,14 +190,22 @@
                             </VerticalStackLayout>
 
                             <Border Grid.Row="1" BackgroundColor="#0b0e12" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 10" Padding="20" HorizontalOptions="Fill" VerticalOptions="Fill">
-                                <Grid>
-                                    <skia:SKCanvasView x:Name="PostProcessingCanvas"
+                                <Grid ColumnDefinitions="*,90" ColumnSpacing="12">
+                                    <skia:SKCanvasView Grid.Column="0" x:Name="PostProcessingCanvas"
                                                        PaintSurface="OnCanvasViewPaintSurface"
                                                        IgnorePixelScaling="True"
                                                        HorizontalOptions="Fill"
                                                        VerticalOptions="Fill" />
 
-                                    <VerticalStackLayout Spacing="8" HorizontalOptions="Center" VerticalOptions="Center" IsVisible="True">
+                                    <skia:SKCanvasView Grid.Column="1" x:Name="ColorBarCanvas"
+                                                       IsVisible="{Binding HasMesh}"
+                                                       PaintSurface="OnColorBarPaintSurface"
+                                                       IgnorePixelScaling="True"
+                                                       WidthRequest="70"
+                                                       HorizontalOptions="Center"
+                                                       VerticalOptions="Fill" />
+
+                                    <VerticalStackLayout Spacing="8" Grid.ColumnSpan="2" HorizontalOptions="Center" VerticalOptions="Center" IsVisible="True">
                                         <VerticalStackLayout.Triggers>
                                             <DataTrigger TargetType="VerticalStackLayout" Binding="{Binding HasMesh}" Value="True">
                                                 <Setter Property="IsVisible" Value="False" />
@@ -219,12 +258,17 @@
                             <Border BackgroundColor="#0f172a" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 8" Padding="12">
                                 <VerticalStackLayout Spacing="8">
                                     <Label Text="History" TextColor="{StaticResource TextSecondary}" FontSize="12"/>
-                                    <CollectionView ItemsSource="{Binding HistoryLog}" HeightRequest="140">
+                                    <CollectionView ItemsSource="{Binding HistoryLog}" HeightRequest="160" ItemsLayout="VerticalList" SelectionMode="None" BackgroundColor="#0b121d" Margin="0,4,0,0">
                                         <CollectionView.ItemTemplate>
                                             <DataTemplate>
-                                                <Label Text="{Binding .}" TextColor="{StaticResource TextPrimary}" FontSize="12" LineBreakMode="WordWrap"/>
+                                                <Border Stroke="{StaticResource BorderColor}" StrokeThickness="0" Padding="6,4" BackgroundColor="#0f172a">
+                                                    <Label Text="{Binding .}" TextColor="{StaticResource TextPrimary}" FontSize="12" LineBreakMode="WordWrap"/>
+                                                </Border>
                                             </DataTemplate>
                                         </CollectionView.ItemTemplate>
+                                        <CollectionView.EmptyView>
+                                            <Label Text="No actions yet." TextColor="{StaticResource TextMuted}" FontSize="12"/> 
+                                        </CollectionView.EmptyView>
                                     </CollectionView>
                                 </VerticalStackLayout>
                             </Border>

--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
@@ -12,6 +12,8 @@ namespace ElectricalImpedanceTomography.Views
         private readonly SKPaint _femStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.White.WithAlpha(80), StrokeWidth = 0.75f, IsAntialias = true };
         private readonly SKPaint _femFill = new() { Style = SKPaintStyle.Fill, IsAntialias = true };
         private readonly SKPaint _lbmStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.Gray.WithAlpha(120), StrokeWidth = 1f, IsAntialias = true };
+        private readonly SKPaint _legendStroke = new() { Style = SKPaintStyle.Stroke, Color = SKColors.White.WithAlpha(80), StrokeWidth = 1f, IsAntialias = true };
+        private readonly SKPaint _legendText = new() { Color = SKColors.LightGray, TextSize = 12, IsAntialias = true };
         private readonly SKPaint _placeholderText = new()
         {
             Color = SKColors.LightGray,
@@ -29,6 +31,16 @@ namespace ElectricalImpedanceTomography.Views
             BindingContext = _viewModel;
 
             _viewModel.MeshUpdated += (_, _) => PostProcessingCanvas?.InvalidateSurface();
+            _viewModel.PropertyChanged += (_, args) =>
+            {
+                if (args.PropertyName == nameof(PostProcessingPageViewModel.MinCutoff)
+                    || args.PropertyName == nameof(PostProcessingPageViewModel.MaxCutoff)
+                    || args.PropertyName == nameof(PostProcessingPageViewModel.IsLogScale)
+                    || args.PropertyName == nameof(PostProcessingPageViewModel.HasMesh))
+                {
+                    ColorBarCanvas?.InvalidateSurface();
+                }
+            };
         }
 
         protected override void OnAppearing()
@@ -40,6 +52,7 @@ namespace ElectricalImpedanceTomography.Views
             }
 
             PostProcessingCanvas?.InvalidateSurface();
+            ColorBarCanvas?.InvalidateSurface();
         }
 
         private void OnCanvasViewPaintSurface(object? sender, SkiaSharp.Views.Maui.SKPaintSurfaceEventArgs e)
@@ -64,12 +77,14 @@ namespace ElectricalImpedanceTomography.Views
             if (_viewModel.LbmGrid is LBMGrid lbm)
             {
                 DrawLbmGrid(canvas, info, lbm);
+                ColorBarCanvas?.InvalidateSurface();
                 return;
             }
 
             if (_viewModel.FemMesh is FEMMesh fem)
             {
                 DrawFemMesh(canvas, info, fem);
+                ColorBarCanvas?.InvalidateSurface();
                 return;
             }
 
@@ -149,6 +164,37 @@ namespace ElectricalImpedanceTomography.Views
                             info.Width / 2f,
                             info.Height / 2f,
                             _placeholderText);
+        }
+
+        private void OnColorBarPaintSurface(object? sender, SkiaSharp.Views.Maui.SKPaintSurfaceEventArgs e)
+        {
+            var canvas = e.Surface.Canvas;
+            var info = e.Info;
+            canvas.Clear(SKColors.Transparent);
+
+            if (!_viewModel.HasMesh)
+                return;
+
+            var barRect = SKRect.Create(info.Width * 0.25f, 10, info.Width * 0.35f, info.Height - 30);
+            using var shader = SKShader.CreateLinearGradient(
+                new SKPoint(barRect.Left, barRect.Bottom),
+                new SKPoint(barRect.Left, barRect.Top),
+                new[] { ColorForValue(0), ColorForValue(1) },
+                null,
+                SKShaderTileMode.Clamp);
+
+            using var fill = new SKPaint { Shader = shader, Style = SKPaintStyle.Fill, IsAntialias = true };
+            canvas.DrawRect(barRect, fill);
+            canvas.DrawRect(barRect, _legendStroke);
+
+            float labelX = barRect.Right + 6f;
+            string minText = _viewModel.MinCutoff.ToString("0.###");
+            string maxText = _viewModel.MaxCutoff.ToString("0.###");
+            string midText = ((_viewModel.MinCutoff + _viewModel.MaxCutoff) / 2.0).ToString("0.###");
+
+            canvas.DrawText(maxText, labelX, barRect.Top + _legendText.TextSize, _legendText);
+            canvas.DrawText(midText, labelX, barRect.MidY + _legendText.TextSize * 0.35f, _legendText);
+            canvas.DrawText(minText, labelX, barRect.Bottom, _legendText);
         }
     }
 }

--- a/Utility/Classes/PostProcessing/AdaptiveSharpenPostProcessing.cs
+++ b/Utility/Classes/PostProcessing/AdaptiveSharpenPostProcessing.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes.Discretizer;
+
+namespace Utility.Classes.PostProcessing
+{
+    public class AdaptiveSharpenPostProcessing : IWeightedPostProcessing
+    {
+        public string Name => "Adaptive Sharpen";
+        public string Description => "Boosts local contrast relative to the neighborhood while capping overshoot.";
+
+        public double Weight { get; set; } = 0.35;
+
+        public ConductivityDistribution Process(IDiscretization discretization, ConductivityDistribution source)
+        {
+            var neighbors = PostProcessingHelpers.BuildElementNeighbors(discretization);
+            var values = source.Conductivities;
+            var result = new Dictionary<int, double>(values.Count);
+
+            foreach (var kvp in values)
+            {
+                if (!neighbors.TryGetValue(kvp.Key, out var adjacent) || adjacent.Count == 0)
+                {
+                    result[kvp.Key] = kvp.Value;
+                    continue;
+                }
+
+                double center = kvp.Value;
+                double mean = adjacent
+                    .Select(id => values.TryGetValue(id, out var v) ? v : center)
+                    .DefaultIfEmpty(center)
+                    .Average();
+
+                double detail = center - mean;
+                double boost = 1.0 + Weight;
+                double sharpened = mean + detail * boost;
+
+                // Clamp to avoid runaway highlights/darks
+                double minNeighbor = adjacent.Min(id => values.TryGetValue(id, out var v) ? v : center);
+                double maxNeighbor = adjacent.Max(id => values.TryGetValue(id, out var v) ? v : center);
+                result[kvp.Key] = Math.Clamp(sharpened, minNeighbor - detail, maxNeighbor + detail);
+            }
+
+            return new ConductivityDistribution(result);
+        }
+    }
+}

--- a/Utility/Classes/PostProcessing/AnisotropicDiffusionPostProcessing.cs
+++ b/Utility/Classes/PostProcessing/AnisotropicDiffusionPostProcessing.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using Utility.Classes.Discretizer;
+
+namespace Utility.Classes.PostProcessing
+{
+    public class AnisotropicDiffusionPostProcessing : IWeightedPostProcessing
+    {
+        public string Name => "Anisotropic Diffusion";
+        public string Description => "Edge-preserving smoothing that diffuses within regions while respecting strong gradients.";
+
+        public double Weight { get; set; } = 0.4;
+
+        public ConductivityDistribution Process(IDiscretization discretization, ConductivityDistribution source)
+        {
+            var neighbors = PostProcessingHelpers.BuildElementNeighbors(discretization);
+            var values = source.Conductivities;
+            var result = new Dictionary<int, double>(values.Count);
+            double sensitivity = Math.Max(0.05, Weight);
+
+            foreach (var kvp in values)
+            {
+                if (!neighbors.TryGetValue(kvp.Key, out var adjacent) || adjacent.Count == 0)
+                {
+                    result[kvp.Key] = kvp.Value;
+                    continue;
+                }
+
+                double center = kvp.Value;
+                double update = 0;
+                int count = 0;
+
+                foreach (var neighborId in adjacent)
+                {
+                    var neighbor = values.TryGetValue(neighborId, out var v) ? v : center;
+                    double diff = neighbor - center;
+                    double conductance = Math.Exp(-(diff * diff) / (2 * sensitivity * sensitivity));
+                    update += conductance * diff;
+                    count++;
+                }
+
+                result[kvp.Key] = center + update / Math.Max(1, count);
+            }
+
+            return new ConductivityDistribution(result);
+        }
+    }
+}

--- a/Utility/Classes/PostProcessing/MeanFilterPostProcessing.cs
+++ b/Utility/Classes/PostProcessing/MeanFilterPostProcessing.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Linq;
+using Utility.Classes.Discretizer;
+
+namespace Utility.Classes.PostProcessing
+{
+    public class MeanFilterPostProcessing : IPostProcessing
+    {
+        public string Name => "Neighborhood Averaging";
+        public string Description => "Smooths the conductivity field by replacing each cell with the mean of its neighbors.";
+
+        public ConductivityDistribution Process(IDiscretization discretization, ConductivityDistribution source)
+        {
+            var neighbors = PostProcessingHelpers.BuildElementNeighbors(discretization);
+            var values = source.Conductivities;
+            var result = new Dictionary<int, double>(values.Count);
+
+            foreach (var kvp in values)
+            {
+                if (!neighbors.TryGetValue(kvp.Key, out var adjacent) || adjacent.Count == 0)
+                {
+                    result[kvp.Key] = kvp.Value;
+                    continue;
+                }
+
+                double sum = kvp.Value;
+                foreach (var id in adjacent)
+                    sum += values.TryGetValue(id, out var val) ? val : kvp.Value;
+
+                result[kvp.Key] = sum / (adjacent.Count + 1);
+            }
+
+            return new ConductivityDistribution(result);
+        }
+    }
+}

--- a/Utility/Classes/PostProcessing/PostProcessingGroup.cs
+++ b/Utility/Classes/PostProcessing/PostProcessingGroup.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Utility.Classes.PostProcessing
+{
+    public class PostProcessingGroup : ObservableCollection<IPostProcessing>
+    {
+        public string Title { get; }
+        public string Description { get; }
+
+        public PostProcessingGroup(string title, string description, IEnumerable<IPostProcessing> options) : base(options)
+        {
+            Title = title;
+            Description = description;
+        }
+    }
+}

--- a/Utility/Classes/PostProcessing/PostProcessingHelpers.cs
+++ b/Utility/Classes/PostProcessing/PostProcessingHelpers.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
+using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 
 namespace Utility.Classes.PostProcessing
 {
@@ -10,6 +11,9 @@ namespace Utility.Classes.PostProcessing
         {
             if (discretization is FEMMesh femMesh)
                 return BuildFemNeighbors(femMesh);
+
+            if (discretization is LBMGrid lbmGrid)
+                return BuildLbmNeighbors(lbmGrid);
 
             // Fallback: no topology information available
             return [];
@@ -54,6 +58,41 @@ namespace Utility.Classes.PostProcessing
                             adjacency.Add(otherId);
                     }
                 }
+            }
+
+            return neighbors;
+        }
+
+        private static Dictionary<int, List<int>> BuildLbmNeighbors(LBMGrid grid)
+        {
+            var neighbors = new Dictionary<int, List<int>>(grid.Nx * grid.Ny);
+
+            foreach (var element in grid.GetElements())
+            {
+                if (element is not LBMElement cell)
+                    continue;
+
+                var list = new List<int>();
+                var (x, y) = grid.ToLattice(cell.Id);
+
+                void TryAdd(int nx, int ny)
+                {
+                    if (nx < 0 || ny < 0 || nx >= grid.Nx || ny >= grid.Ny)
+                        return;
+
+                    var neighbor = grid.GetElementAt(nx, ny);
+                    if (neighbor.IsWall)
+                        return;
+
+                    list.Add(neighbor.Id);
+                }
+
+                TryAdd(x - 1, y);
+                TryAdd(x + 1, y);
+                TryAdd(x, y - 1);
+                TryAdd(x, y + 1);
+
+                neighbors[cell.Id] = list;
             }
 
             return neighbors;


### PR DESCRIPTION
## Summary
- add grouped post-processing options with new refinement filters and selection highlighting
- add a legend colorbar and improve history log visibility on the post-processing page
- expand neighbor-building support to LBM grids so refinement filters work across discretizations

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934b53d0b28833391ced0350a591ca1)