### PR TITLE
Improve post-processing display controls

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
@@ -2,8 +2,12 @@ using BH.Engine.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DataAccessLayer;
+using Microsoft.Maui.Devices; // added for DevicePlatform
+using Microsoft.Maui.Storage; // added for FilePicker/FileSystem
+using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.IO; // added for File/Directory/Path
 using System.Text.Json;
 using Utility.Classes;
 using Utility.Classes.Application;
@@ -12,9 +16,6 @@ using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.PostProcessing;
 using Utility.Rendering;
-using Microsoft.Maui.Storage; // added for FilePicker/FileSystem
-using Microsoft.Maui.Devices; // added for DevicePlatform
-using System.IO; // added for File/Directory/Path
 
 namespace ElectricalImpedanceTomography.ViewModels
 {
@@ -75,9 +76,13 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         public ObservableCollection<IPostProcessing> PostProcessingOptions { get; } = new();
         public ObservableCollection<PostProcessingGroup> PostProcessingGroups { get; } = new();
+        public ObservableCollection<PostProcessingParameterOption> ParameterOptions { get; } = new();
 
         [ObservableProperty]
         private IPostProcessing? _selectedPostProcessor;
+
+        [ObservableProperty]
+        private bool _hasParameterOptions;
 
         // Events
         public event EventHandler? MeshUpdated;
@@ -191,6 +196,11 @@ namespace ElectricalImpedanceTomography.ViewModels
             }
 
             SelectedPostProcessor = PostProcessingOptions.FirstOrDefault();
+        }
+
+        partial void OnSelectedPostProcessorChanged(IPostProcessing? value)
+        {
+            UpdateParameterOptions(value);
         }
 
         // --- Loading logic ---
@@ -556,9 +566,6 @@ namespace ElectricalImpedanceTomography.ViewModels
                 return;
             }
 
-            if (SelectedPostProcessor is IWeightedPostProcessing weighted)
-                weighted.Weight = FilterStrength / 100.0;
-
             RunPostProcessor(SelectedPostProcessor);
         }
 
@@ -579,7 +586,11 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             UpdateStatistics();
             MeshUpdated?.Invoke(this, EventArgs.Empty);
-            AddToHistory($"Applied {processor.Name} ({FilterStrength:F0}% intensity)");
+
+            var summary = BuildParameterSummary();
+            AddToHistory(string.IsNullOrEmpty(summary)
+                ? $"Applied {processor.Name}"
+                : $"Applied {processor.Name} ({summary})");
             Log($"Applied {processor.Name}.", "success");
         }
 
@@ -629,6 +640,9 @@ namespace ElectricalImpedanceTomography.ViewModels
         }
 
         public double ProcessValue(double val)
+            => NormalizeValue(val).Normalized;
+
+        public ValueNormalization NormalizeValue(double val)
         {
             double working = val;
             if (IsLogScale)
@@ -640,7 +654,8 @@ namespace ElectricalImpedanceTomography.ViewModels
                 max = min + 1e-6;
 
             working = Math.Clamp(working, min, max);
-            return (working - min) / (max - min);
+            double normalized = (working - min) / (max - min);
+            return new ValueNormalization(working, normalized, min, max);
         }
 
         private void Log(string msg, string type = "normal")
@@ -650,5 +665,114 @@ namespace ElectricalImpedanceTomography.ViewModels
         }
 
         private void AddToHistory(string action) => HistoryLog.Insert(0, $"[{DateTime.Now:HH:mm:ss}] {action}");
+
+        private void UpdateParameterOptions(IPostProcessing? processor)
+        {
+            ParameterOptions.Clear();
+
+            if (processor is IWeightedPostProcessing weighted)
+            {
+                ParameterOptions.Add(PostProcessingParameterOption.CreatePercentage(
+                    "Weight",
+                    "Adjusts the influence of the filter (0-100%).",
+                    weighted.Weight * 100.0,
+                    v => weighted.Weight = v / 100.0,
+                    0.5));
+            }
+
+            if (processor is SigmaClippingPostProcessing sigma)
+            {
+                ParameterOptions.Add(new PostProcessingParameterOption(
+                    "Sigma (σ)",
+                    "Standard deviation envelope for clipping.",
+                    0.5,
+                    5.0,
+                    0.1,
+                    sigma.Sigma,
+                    v => sigma.Sigma = v,
+                    unit: "σ"));
+            }
+
+            HasParameterOptions = ParameterOptions.Count > 0;
+        }
+
+        private string BuildParameterSummary()
+        {
+            if (!HasParameterOptions)
+                return string.Empty;
+
+            return string.Join(", ", ParameterOptions.Select(p => $"{p.Name}={p.FormattedValue}"));
+        }
+    }
+
+    public readonly record struct ValueNormalization(double Working, double Normalized, double Min, double Max);
+
+    public class PostProcessingParameterOption : ObservableObject
+    {
+        private readonly Action<double> _apply;
+        private double _value;
+
+        public PostProcessingParameterOption(
+            string name,
+            string description,
+            double minimum,
+            double maximum,
+            double step,
+            double initialValue,
+            Action<double> apply,
+            bool isPercentage = false,
+            string unit = "")
+        {
+            Name = name;
+            Description = description;
+            Minimum = minimum;
+            Maximum = maximum;
+            Step = step;
+            _value = initialValue;
+            _apply = apply;
+            IsPercentage = isPercentage;
+            Unit = unit;
+        }
+
+        public string Name { get; }
+        public string Description { get; }
+        public double Minimum { get; }
+        public double Maximum { get; }
+        public double Step { get; }
+        public bool IsPercentage { get; }
+        public string Unit { get; }
+
+        public double Value
+        {
+            get => _value;
+            set
+            {
+                if (SetProperty(ref _value, value))
+                {
+                    _apply(IsPercentage ? value / 100.0 : value);
+                    OnPropertyChanged(nameof(FormattedValue));
+                }
+            }
+        }
+
+        public string FormattedValue
+        {
+            get
+            {
+                if (IsPercentage)
+                    return $"{Value:0.#}%";
+
+                string suffix = string.IsNullOrWhiteSpace(Unit) ? string.Empty : Unit;
+                return $"{Value:0.###}{suffix}";
+            }
+        }
+
+        public static PostProcessingParameterOption CreatePercentage(
+            string name,
+            string description,
+            double initialPercent,
+            Action<double> apply,
+            double step = 1.0)
+            => new(name, description, 0, 100, step, initialPercent, apply, isPercentage: true);
     }
 }

--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
@@ -236,6 +236,45 @@
                                 </Border>
                             </Grid>
 
+                            <Border BackgroundColor="#0b0e12" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 8" Padding="12">
+                                <VerticalStackLayout Spacing="8">
+                                    <Label Text="Method Parameters" Style="{StaticResource HeaderLabel}" Margin="0,0,0,6"/>
+                                    <Label Text="{Binding SelectedPostProcessor.Name}" TextColor="{StaticResource TextPrimary}" FontAttributes="Bold" FontSize="14"/>
+                                    <CollectionView ItemsSource="{Binding ParameterOptions}" IsVisible="{Binding HasParameterOptions}" SelectionMode="None" ItemsLayout="VerticalList" HeightRequest="190">
+                                        <CollectionView.ItemTemplate>
+                                            <DataTemplate>
+                                                <VerticalStackLayout Spacing="6">
+                                                    <Label Text="{Binding Name}" TextColor="{StaticResource TextSecondary}" FontAttributes="Bold" FontSize="12"/>
+                                                    <Label Text="{Binding Description}" TextColor="{StaticResource TextMuted}" FontSize="11" LineBreakMode="WordWrap"/>
+                                                    <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8" VerticalOptions="Center">
+                                                        <Slider Grid.Column="0"
+                                                                Minimum="{Binding Minimum}"
+                                                                Maximum="{Binding Maximum}"
+                                                                Value="{Binding Value, Mode=TwoWay}"
+                                                                StepFrequency="{Binding Step}"
+                                                                ThumbColor="#06b6d4"
+                                                                MinimumTrackColor="#06b6d4"
+                                                                MaximumTrackColor="#1f2937" />
+                                                        <Label Grid.Column="1" Text="{Binding FormattedValue}" TextColor="{StaticResource TextPrimary}" FontAttributes="Bold" FontSize="12" />
+                                                    </Grid>
+                                                    <BoxView HeightRequest="1" Color="{StaticResource BorderColor}" />
+                                                </VerticalStackLayout>
+                                            </DataTemplate>
+                                        </CollectionView.ItemTemplate>
+                                        <CollectionView.EmptyView>
+                                            <Label Text="No adjustable parameters for this method." TextColor="{StaticResource TextMuted}" FontSize="12"/>
+                                        </CollectionView.EmptyView>
+                                    </CollectionView>
+                                    <Label Text="Select a method on the left to tune its parameters." TextColor="{StaticResource TextMuted}" FontSize="11">
+                                        <Label.Triggers>
+                                            <DataTrigger TargetType="Label" Binding="{Binding HasParameterOptions}" Value="True">
+                                                <Setter Property="IsVisible" Value="False" />
+                                            </DataTrigger>
+                                        </Label.Triggers>
+                                    </Label>
+                                </VerticalStackLayout>
+                            </Border>
+
 
                             <Border BackgroundColor="#0b0e12" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 8" Padding="12">
                                 <VerticalStackLayout Spacing="8">

--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
@@ -1,8 +1,9 @@
 using ElectricalImpedanceTomography.ViewModels;
 using SkiaSharp;
+using System.Linq;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
-using System.Linq;
+using Utility.Rendering;
 
 namespace ElectricalImpedanceTomography.Views
 {
@@ -24,6 +25,91 @@ namespace ElectricalImpedanceTomography.Views
 
         private float _scale, _marginX, _marginY, _minX, _minY, _meshWidth, _meshHeight;
 
+        private static readonly (double Position, SKColor Color)[] EnhancedDivergingPalette =
+        {
+            (0.0, SKColor.Parse("#2B83BA")),
+            (0.17, SKColor.Parse("#74ADD1")),
+            (0.33, SKColor.Parse("#E0F3F8")),
+            (0.5, SKColor.Parse("#FFFFBF")),
+            (0.67, SKColor.Parse("#FEE08B")),
+            (0.83, SKColor.Parse("#FC8D59")),
+            (1.0, SKColor.Parse("#D53E4F"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] MatlabJetPalette =
+        {
+            (0.0, SKColor.Parse("#00007F")),
+            (0.125, SKColor.Parse("#0000FF")),
+            (0.375, SKColor.Parse("#00FFFF")),
+            (0.625, SKColor.Parse("#FFFF00")),
+            (0.875, SKColor.Parse("#FF0000")),
+            (1.0, SKColor.Parse("#7F0000"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] ParulaPalette =
+        {
+            (0.0, SKColor.Parse("#352A87")),
+            (0.16, SKColor.Parse("#2462BE")),
+            (0.33, SKColor.Parse("#1F9AD6")),
+            (0.5, SKColor.Parse("#3BB6A5")),
+            (0.66, SKColor.Parse("#74C476")),
+            (0.83, SKColor.Parse("#B6D051")),
+            (1.0, SKColor.Parse("#FDE724"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] ViridisPalette =
+        {
+            (0.0, SKColor.Parse("#440154")),
+            (0.2, SKColor.Parse("#414487")),
+            (0.4, SKColor.Parse("#2A788E")),
+            (0.6, SKColor.Parse("#22A884")),
+            (0.8, SKColor.Parse("#7AD151")),
+            (1.0, SKColor.Parse("#FDE725"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] PlasmaPalette =
+        {
+            (0.0, SKColor.Parse("#0D0887")),
+            (0.16, SKColor.Parse("#5B02A3")),
+            (0.33, SKColor.Parse("#9A179B")),
+            (0.5, SKColor.Parse("#CB4679")),
+            (0.66, SKColor.Parse("#ED7953")),
+            (0.83, SKColor.Parse("#FDB42F")),
+            (1.0, SKColor.Parse("#F0F921"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] MagmaPalette =
+        {
+            (0.0, SKColor.Parse("#000004")),
+            (0.16, SKColor.Parse("#1C1044")),
+            (0.33, SKColor.Parse("#4F0C6B")),
+            (0.5, SKColor.Parse("#822681")),
+            (0.66, SKColor.Parse("#B73779")),
+            (0.83, SKColor.Parse("#F1605D")),
+            (1.0, SKColor.Parse("#FCFDBF"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] CividisPalette =
+        {
+            (0.0, SKColor.Parse("#00204C")),
+            (0.2, SKColor.Parse("#00366F")),
+            (0.4, SKColor.Parse("#39558C")),
+            (0.6, SKColor.Parse("#7B7B78")),
+            (0.8, SKColor.Parse("#B8B972")),
+            (1.0, SKColor.Parse("#FAF976"))
+        };
+
+        private static readonly (double Position, SKColor Color)[] CoolWarmPalette =
+        {
+            (0.0, SKColor.Parse("#3B4CC0")),
+            (0.16, SKColor.Parse("#5C86C5")),
+            (0.33, SKColor.Parse("#93B5D7")),
+            (0.5, SKColor.Parse("#E6E6E6")),
+            (0.66, SKColor.Parse("#E5B08A")),
+            (0.83, SKColor.Parse("#D25C4D")),
+            (1.0, SKColor.Parse("#8B1A1A"))
+        };
+
         public PostProcessingPage()
         {
             InitializeComponent();
@@ -36,9 +122,11 @@ namespace ElectricalImpedanceTomography.Views
                 if (args.PropertyName == nameof(PostProcessingPageViewModel.MinCutoff)
                     || args.PropertyName == nameof(PostProcessingPageViewModel.MaxCutoff)
                     || args.PropertyName == nameof(PostProcessingPageViewModel.IsLogScale)
-                    || args.PropertyName == nameof(PostProcessingPageViewModel.HasMesh))
+                    || args.PropertyName == nameof(PostProcessingPageViewModel.HasMesh)
+                    || args.PropertyName == nameof(PostProcessingPageViewModel.SelectedConductivityDisplayMode))
                 {
                     ColorBarCanvas?.InvalidateSurface();
+                    PostProcessingCanvas?.InvalidateSurface();
                 }
             };
         }
@@ -101,7 +189,8 @@ namespace ElectricalImpedanceTomography.Views
                 var (x, y) = grid.ToLattice(el.Id);
                 var rect = SKRect.Create(x * cellW, y * cellH, cellW, cellH);
                 double sigma = _viewModel.GetConductivityValue(el.Id, el.Conductivity);
-                var color = ColorForValue(_viewModel.ProcessValue(sigma));
+                var normalized = _viewModel.NormalizeValue(sigma);
+                var color = GetConductivityColor(normalized.Working, normalized.Normalized, normalized.Min, normalized.Max);
 
                 using var fill = new SKPaint { Style = SKPaintStyle.Fill, Color = color, IsAntialias = true };
                 canvas.DrawRect(rect, fill);
@@ -142,7 +231,8 @@ namespace ElectricalImpedanceTomography.Views
                 path.Close();
 
                 double sigma = _viewModel.GetConductivityValue(el.Id, el.Conductivity);
-                _femFill.Color = ColorForValue(_viewModel.ProcessValue(sigma));
+                var normalized = _viewModel.NormalizeValue(sigma);
+                _femFill.Color = GetConductivityColor(normalized.Working, normalized.Normalized, normalized.Min, normalized.Max);
                 canvas.DrawPath(path, _femFill);
                 canvas.DrawPath(path, _femStroke);
             }
@@ -150,12 +240,69 @@ namespace ElectricalImpedanceTomography.Views
 
         private SKPoint ToCanvas(FEMVertex v) => new((float)(v.X - _minX) * _scale + _marginX, PostProcessingCanvas.CanvasSize.Height - ((float)(v.Y - _minY) * _scale + _marginY));
 
-        private SKColor ColorForValue(double normalized)
+        private static SKColor Lerp(SKColor a, SKColor b, double t)
         {
-            float t = (float)Math.Clamp(normalized, 0, 1);
-            byte r = (byte)(255 * t);
-            byte b = (byte)(255 * (1 - t));
-            return new SKColor(r, 20, b, 255);
+            byte r = (byte)Math.Round(a.Red + (b.Red - a.Red) * t);
+            byte g = (byte)Math.Round(a.Green + (b.Green - a.Green) * t);
+            byte bl = (byte)Math.Round(a.Blue + (b.Blue - a.Blue) * t);
+            byte al = (byte)Math.Round(a.Alpha + (b.Alpha - a.Alpha) * t);
+            return new SKColor(r, g, bl, al);
+        }
+
+        private static SKColor InterpolatePalette((double Position, SKColor Color)[] palette, double t)
+        {
+            t = Math.Clamp(t, 0.0, 1.0);
+            for (int i = 0; i < palette.Length - 1; i++)
+            {
+                var (p0, c0) = palette[i];
+                var (p1, c1) = palette[i + 1];
+                if (t >= p0 && t <= p1)
+                {
+                    double localT = (t - p0) / (p1 - p0);
+                    return Lerp(c0, c1, localT);
+                }
+            }
+
+            return palette[^1].Color;
+        }
+
+        private SKColor ColorForValue(double val, double min, double max)
+        {
+            double mid = (min + max) * 0.5;
+            if (val >= mid)
+            {
+                float t = (float)((val - mid) / (max - mid));
+                t = Math.Clamp(t, 0f, 1f);
+                byte r = (byte)(255 * t);
+                return new SKColor(r, 0, 0);
+            }
+            else
+            {
+                float t = (float)((mid - val) / (mid - min));
+                t = Math.Clamp(t, 0f, 1f);
+                byte b = (byte)(255 * t);
+                return new SKColor(0, 0, b);
+            }
+        }
+
+        private SKColor GetConductivityColor(double workingVal, double normalized, double min, double max)
+        {
+            double norm = Math.Clamp(normalized, 0.0, 1.0);
+
+            return _viewModel.SelectedConductivityDisplayMode switch
+            {
+                ConductivityDisplayMode.Classic => ColorForValue(workingVal, min, max),
+                ConductivityDisplayMode.EnhancedDiverging => InterpolatePalette(EnhancedDivergingPalette, norm),
+                ConductivityDisplayMode.Rainbow => SKColor.FromHsv((float)(240.0 * (1.0 - norm)), 90f, 100f),
+                ConductivityDisplayMode.MatlabJet => InterpolatePalette(MatlabJetPalette, norm),
+                ConductivityDisplayMode.Parula => InterpolatePalette(ParulaPalette, norm),
+                ConductivityDisplayMode.Viridis => InterpolatePalette(ViridisPalette, norm),
+                ConductivityDisplayMode.Plasma => InterpolatePalette(PlasmaPalette, norm),
+                ConductivityDisplayMode.Magma => InterpolatePalette(MagmaPalette, norm),
+                ConductivityDisplayMode.Cividis => InterpolatePalette(CividisPalette, norm),
+                ConductivityDisplayMode.CoolWarm => InterpolatePalette(CoolWarmPalette, norm),
+                _ => ColorForValue(workingVal, min, max)
+            };
         }
 
         private void DrawPlaceholder(SKCanvas canvas, SKImageInfo info, string message)
@@ -176,11 +323,29 @@ namespace ElectricalImpedanceTomography.Views
                 return;
 
             var barRect = SKRect.Create(info.Width * 0.25f, 10, info.Width * 0.35f, info.Height - 30);
+            const int steps = 96;
+            var colors = new SKColor[steps];
+            var positions = new float[steps];
+
+            double min = _viewModel.MinCutoff;
+            double max = _viewModel.MaxCutoff;
+            if (max <= min)
+                max = min + 1e-6;
+
+            for (int i = 0; i < steps; i++)
+            {
+                double t = i / (double)(steps - 1);
+                double value = min + (max - min) * t;
+                var normalized = _viewModel.NormalizeValue(value);
+                colors[i] = GetConductivityColor(normalized.Working, normalized.Normalized, normalized.Min, normalized.Max);
+                positions[i] = (float)t;
+            }
+
             using var shader = SKShader.CreateLinearGradient(
                 new SKPoint(barRect.Left, barRect.Bottom),
                 new SKPoint(barRect.Left, barRect.Top),
-                new[] { ColorForValue(0), ColorForValue(1) },
-                null,
+                colors,
+                positions,
                 SKShaderTileMode.Clamp);
 
             using var fill = new SKPaint { Shader = shader, Style = SKPaintStyle.Fill, IsAntialias = true };


### PR DESCRIPTION
## Summary
- apply conductivity display mode palettes to post-processing visualization and color bar
- surface adjustable parameters for post-processing methods in the right-side panel

## Testing
- not run (dotnet CLI not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934b9a57994833385619a9d810d80eb)