### PR TITLE
Fix block FEM weight handling

### DIFF
--- a/BusinessLayer/BlockFemReconstructionPersistence.cs
+++ b/BusinessLayer/BlockFemReconstructionPersistence.cs
@@ -784,28 +784,21 @@ namespace BusinessLayer
                     if (!adjointGradientsByBlock.TryGetValue(errorMetricId, out var adjointGradient))
                         continue;
 
-                    // Get the solver→errorMetric weight
-                    if (!_errorMetricMap.TryGetValue(errorMetricId, out var descriptor))
-                        continue;
-
-                    // Combined weight: (solver→errorMetric) × (errorMetric→optimizer connection)
-                    double weight = descriptor.weight * connection.Weight;
-
                     // Compute gradient contribution for each element in parallel
                     Parallel.ForEach(elements, element =>
                     {
                         // Get forward gradient ∇φ at this element
                         var gradPhi = forwardGradient.GetVector(element.Id);
-                        
+
                         // Get adjoint gradient ∇μ at this element
                         var gradMu = adjointGradient.GetVector(element.Id);
-                        
+
                         // Compute dot product weighted by element area: -(∇φ · ∇μ) * A
                         // This approximates the integral ∫_Ω_e ∇φ · ∇μ dΩ
                         double dotProduct = -(gradPhi.X * gradMu.X + gradPhi.Y * gradMu.Y) * element.Area;
-                        
-                        // Apply connection weight
-                        double weighted = weight * dotProduct;
+
+                        // Apply only the ErrorMetric→Optimizer weight in a dedicated helper.
+                        double weighted = ApplyErrorMetricToOptimizerWeight(errorMetricId, optimizerId, dotProduct, connection.Weight);
 
                         // Accumulate into this optimizer's gradient
                         lock (gradientAccumulator)
@@ -856,16 +849,9 @@ namespace BusinessLayer
             // Evaluate each regularizer in parallel
             Parallel.ForEach(_regularizerMap, kvp =>
             {
-                // Compute ∂R/∂σ for this regularizer
+                // Compute ∂R/∂σ for this regularizer. Regularizer→Optimizer weights are applied later
+                // during assembly to avoid scaling more than once.
                 var weighted = kvp.Value.regulizer.EvaluateGradient(_mesh, currentDistribution);
-
-                // Apply solver→regularizer connection weight
-                // This weight controls the relative importance of this regularizer
-                foreach (var elementId in weighted.IdValuePairs.Keys.ToList())
-                {
-                    double value = weighted.GetValue(elementId);
-                    weighted.SetValue(elementId, kvp.Value.weight * value);
-                }
 
                 lock (regularizations)
                 {
@@ -921,14 +907,14 @@ namespace BusinessLayer
                 {
                     var regId = connection.SourceId;
 
-                    // Get the pre-computed regularization gradient (already weighted by solver→regularizer)
+                    // Get the pre-computed regularization gradient (unweighted; connection scaling applied below)
                     if (!regularizerGradients.TryGetValue(regId, out var reg))
                         continue;
 
                     // Weight by regularizer→optimizer connection and accumulate
                     foreach (var kvp in reg.IdValuePairs)
                     {
-                        double weighted = connection.Weight * kvp.Value;
+                        double weighted = ApplyRegularizerToOptimizerWeight(regId, optimizerId, kvp.Value, connection.Weight);
 
                         if (accumulator.ContainsKey(kvp.Key))
                             accumulator[kvp.Key] += weighted;
@@ -970,19 +956,16 @@ namespace BusinessLayer
             // Accumulate weighted gradients
             foreach (var kvp in optimizerGradients)
             {
-                // Get optimizer→model weight
-                if (!_optimizerMap.TryGetValue(kvp.Key, out var optimizerDescriptor))
-                    continue;
-
-                totalWeight += optimizerDescriptor.weight;
+                var weight = GetOptimizerToModelWeight(kvp.Key);
+                totalWeight += weight;
 
                 // Add weighted contribution from this optimizer
                 foreach (var value in kvp.Value.IdValuePairs)
                 {
                     if (combined.ContainsKey(value.Key))
-                        combined[value.Key] += value.Value;
+                        combined[value.Key] += weight * value.Value;
                     else
-                        combined[value.Key] = value.Value;
+                        combined[value.Key] = weight * value.Value;
                 }
             }
 
@@ -1015,19 +998,16 @@ namespace BusinessLayer
             // Accumulate weighted regularizations
             foreach (var kvp in optimizerRegularizations)
             {
-                // Get optimizer→model weight
-                if (!_optimizerMap.TryGetValue(kvp.Key, out var optimizerDescriptor))
-                    continue;
-
-                totalWeight += optimizerDescriptor.weight;
+                var weight = GetOptimizerToModelWeight(kvp.Key);
+                totalWeight += weight;
 
                 // Add weighted contribution from this optimizer's regularization
                 foreach (var value in kvp.Value.IdValuePairs)
                 {
                     if (combined.ContainsKey(value.Key))
-                        combined[value.Key] += optimizerDescriptor.weight * value.Value;
+                        combined[value.Key] += weight * value.Value;
                     else
-                        combined[value.Key] = optimizerDescriptor.weight * value.Value;
+                        combined[value.Key] = weight * value.Value;
                 }
             }
 
@@ -1039,6 +1019,56 @@ namespace BusinessLayer
             }
 
             return new ConductivityDistribution(combined);
+        }
+
+        /// <summary>
+        /// Applies the configured ErrorMetric→Optimizer weight to a raw gradient contribution.
+        /// </summary>
+        private double ApplyErrorMetricToOptimizerWeight(string errorMetricId, string optimizerId, double value, double fallbackWeight = 1.0)
+        {
+            double weight = GetConnectionWeight(errorMetricId, optimizerId, BlockType.ErrorMetric, BlockType.Optimizer, fallbackWeight);
+            return weight * value;
+        }
+
+        /// <summary>
+        /// Applies the configured Regularizer→Optimizer weight to a regularization term.
+        /// </summary>
+        private double ApplyRegularizerToOptimizerWeight(string regularizerId, string optimizerId, double value, double fallbackWeight = 1.0)
+        {
+            double weight = GetConnectionWeight(regularizerId, optimizerId, BlockType.Regularizer, BlockType.Optimizer, fallbackWeight);
+            return weight * value;
+        }
+
+        /// <summary>
+        /// Retrieves the Optimizer→Model weight for the given optimizer block.
+        /// </summary>
+        private double GetOptimizerToModelWeight(string optimizerId)
+        {
+            var connectionWeight = _connections?
+                                        .FirstOrDefault(c => c.SourceId == optimizerId &&
+                                                             c.SourceType == BlockType.Optimizer &&
+                                                             c.TargetType == BlockType.Model)?.Weight;
+
+            if (connectionWeight.HasValue)
+                return connectionWeight.Value;
+
+            return _optimizerMap.TryGetValue(optimizerId, out var optimizerDescriptor)
+                ? optimizerDescriptor.weight
+                : 1.0;
+        }
+
+        /// <summary>
+        /// Looks up a connection weight between two block ids. Defaults to 1.0 when absent to avoid
+        /// accidental double-scaling and to keep legacy configurations functional.
+        /// </summary>
+        private double GetConnectionWeight(string sourceId, string targetId, BlockType sourceType, BlockType targetType, double fallbackWeight = 1.0)
+        {
+            return _connections?
+                       .FirstOrDefault(c => c.SourceId == sourceId &&
+                                            c.TargetId == targetId &&
+                                            c.SourceType == sourceType &&
+                                            c.TargetType == targetType)?.Weight
+                   ?? fallbackWeight;
         }
 
         /// <summary>

--- a/BusinessLayer/ReconstructionConfigurationMaterializer.cs
+++ b/BusinessLayer/ReconstructionConfigurationMaterializer.cs
@@ -73,10 +73,9 @@ namespace BusinessLayer
                 .Where(b => b.Type == BlockType.ErrorMetric)
                 .Select(block =>
                 {
-                    double weight = configuration.SolverToErrorMetricWeights
-                        .Where(c => c.TargetId == block.Id)
-                        .Sum(c => c.Weight);
-                    weight = weight == 0 ? 1.0 : weight;
+                    // Solver→ErrorMetric weights are no longer supported. Error metrics always contribute
+                    // with unit weight and are scaled exclusively by ErrorMetric→Optimizer connections.
+                    const double weight = 1.0;
                     return (block.Id, weight, ErrorMetricFactory.Create(ParseEnum<ErrorMetric>(GetParameterValue(block, "metric_type"))));
                 })
                 .ToList();
@@ -85,10 +84,9 @@ namespace BusinessLayer
                 .Where(b => b.Type == BlockType.Regularizer)
                 .Select(block =>
                 {
-                    double weight = configuration.SolverToRegularizerWeights
-                        .Where(c => c.TargetId == block.Id)
-                        .Sum(c => c.Weight);
-                    weight = weight == 0 ? 1.0 : weight;
+                    // Solver→Regularizer weights are deprecated. Regularizers are scaled exclusively
+                    // through their connections into optimizers.
+                    const double weight = 1.0;
                     var technique = ParseEnum<RegularizationTechnique>(GetParameterValue(block, "reg_tech"));
                     return (block.Id, weight, RegularizationFactory.Create(technique, mesh));
                 })

--- a/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/ReconstructionConfigurationPageViewModel.cs
@@ -586,8 +586,8 @@ namespace ElectricalImpedanceTomography.ViewModels
         }
 
         /// <summary>
-        /// Normalizes solver->error, error->regularizer, optimizer input, and optimizer->model weights so each compatible set sums to one.
-        /// Connections that are not meant to be weighted (e.g., measurement->error) are forced back to unity and disabled in the UI.
+        /// Normalizes error->optimizer, regularizer->optimizer, and optimizer->model weights so each compatible set sums to one.
+        /// Connections that are not meant to be weighted (e.g., measurement->error, solver->error, model->regularizer) are forced back to unity and disabled in the UI.
         /// </summary>
         private void NormalizeConnectionWeights(bool redistributeGroups = true)
         {
@@ -602,10 +602,16 @@ namespace ElectricalImpedanceTomography.ViewModels
 
                 foreach (var connection in Connections)
                     connection.RequiresWeight = false;
-                
+
                 foreach (var connection in Connections.Where(c => c.Source.Type == BlockType.Measurement && c.Target.Type == BlockType.ErrorMetric))
                     connection.Weight = 1.0;
-                
+
+                foreach (var connection in Connections.Where(c => c.Source.Type == BlockType.Solver && c.Target.Type == BlockType.ErrorMetric))
+                    connection.Weight = 1.0;
+
+                foreach (var connection in Connections.Where(c => c.Source.Type == BlockType.Model && c.Target.Type == BlockType.Regularizer))
+                    connection.Weight = 1.0;
+
                 foreach (var group in GetWeightedConnectionGroups())
                 {
                     foreach (var connection in group)
@@ -690,26 +696,19 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         private List<ReconstructionConnection> FindWeightedGroupForConnection(ReconstructionConnection connection)
         {
-            if (connection.Source.Type == BlockType.Solver && connection.Target.Type == BlockType.ErrorMetric)
-            {
-                return Connections
-                    .Where(c => c.Source == connection.Source && c.Target.Type == BlockType.ErrorMetric)
-                    .ToList();
-            }
-
-            if (connection.Source.Type == BlockType.Model && connection.Target.Type == BlockType.Regularizer)
-            {
-                return Connections
-                    .Where(c => c.Source == connection.Source && c.Target.Type == BlockType.Regularizer)
-                    .ToList();
-            }
-
             if (connection.Target.Type == BlockType.Optimizer &&
-                (connection.Source.Type == BlockType.ErrorMetric || connection.Source.Type == BlockType.Regularizer))
+                connection.Source.Type == BlockType.ErrorMetric)
             {
                 return Connections
                     .Where(c => c.Target == connection.Target &&
-                                (c.Source.Type == BlockType.ErrorMetric || c.Source.Type == BlockType.Regularizer))
+                                c.Source.Type == BlockType.ErrorMetric)
+                    .ToList();
+            }
+
+            if (connection.Target.Type == BlockType.Optimizer && connection.Source.Type == BlockType.Regularizer)
+            {
+                return Connections
+                    .Where(c => c.Target == connection.Target && c.Source.Type == BlockType.Regularizer)
                     .ToList();
             }
 
@@ -725,19 +724,13 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         private IEnumerable<IReadOnlyCollection<ReconstructionConnection>> GetWeightedConnectionGroups()
         {
-            var solverToError = Connections
-                .Where(c => c.Source.Type == BlockType.Solver && c.Target.Type == BlockType.ErrorMetric)
-                .GroupBy(c => c.Source)
+            var errorToOptimizer = Connections
+                .Where(c => c.Target.Type == BlockType.Optimizer && c.Source.Type == BlockType.ErrorMetric)
+                .GroupBy(c => c.Target)
                 .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
 
-            var modelToRegularizer = Connections
-                .Where(c => c.Source.Type == BlockType.Model && c.Target.Type == BlockType.Regularizer)
-                .GroupBy(c => c.Source)
-                .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
-
-            var optimizerInputs = Connections
-                .Where(c => c.Target.Type == BlockType.Optimizer &&
-                            (c.Source.Type == BlockType.ErrorMetric || c.Source.Type == BlockType.Regularizer))
+            var regularizerToOptimizer = Connections
+                .Where(c => c.Target.Type == BlockType.Optimizer && c.Source.Type == BlockType.Regularizer)
                 .GroupBy(c => c.Target)
                 .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
 
@@ -746,9 +739,8 @@ namespace ElectricalImpedanceTomography.ViewModels
                 .GroupBy(c => c.Target)
                 .Select(g => (IReadOnlyCollection<ReconstructionConnection>)g.ToList());
 
-            return solverToError
-                .Concat(modelToRegularizer)
-                .Concat(optimizerInputs)
+            return errorToOptimizer
+                .Concat(regularizerToOptimizer)
                 .Concat(optimizerToModel);
         }
 


### PR DESCRIPTION
## Summary
- remove solver and model connection weighting in block configuration UI while enforcing sums for error/regularizer optimizer inputs and optimizer-to-model links
- materialize block configurations without solver-linked weights and scale gradients/regularizations through dedicated persistence helpers
- apply optimizer-to-model weights consistently when blending optimizer outputs

## Testing
- dotnet build ElectricalImpedanceTomography.sln *(fails: dotnet is not available in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eeaacdee88333b86fcca5ded877f6)