### PR TITLE
Preserve baseline conductivities in block FEM updates

### DIFF
--- a/ServiceLayer/BlockFemReconstructionService.cs
+++ b/ServiceLayer/BlockFemReconstructionService.cs
@@ -389,7 +389,8 @@ namespace ServiceLayer
             {
                 var optimizer = _runtimeContext.NumericOptimizers[0];
                 var gradient = optimizerGradients.Values.FirstOrDefault() ?? new ConductivityDistribution(new Dictionary<int, double>());
-                return optimizer.numericOptimizer.OptimizationStep(currentSigma, gradient, stepSize);
+                var candidate = optimizer.numericOptimizer.OptimizationStep(currentSigma, gradient, stepSize);
+                return MergeWithBaseline(currentSigma, candidate);
             }
 
             // Multiple optimizers case: compute each candidate update and form a weighted average by connection weight.
@@ -419,7 +420,21 @@ namespace ServiceLayer
 
             // Normalize by the total weight to get the final combined candidate.
             var combined = weightedSum.ToDictionary(kvp => kvp.Key, kvp => kvp.Value / totalWeight);
-            return new ConductivityDistribution(combined);
+            var combinedDistribution = new ConductivityDistribution(combined);
+            return MergeWithBaseline(currentSigma, combinedDistribution);
+        }
+
+        // Ensures that an updated conductivity distribution preserves any elements that were not explicitly
+        // produced by an optimizer (e.g., sparse updates). Missing keys would otherwise be interpreted as zero
+        // conductivity, causing the UI canvas to diverge from the solver state.
+        private static ConductivityDistribution MergeWithBaseline(ConductivityDistribution baseline,
+                                                                  ConductivityDistribution updated)
+        {
+            var merged = new Dictionary<int, double>(baseline.Conductivities);
+            foreach (var kvp in updated.Conductivities)
+                merged[kvp.Key] = kvp.Value;
+
+            return new ConductivityDistribution(merged);
         }
     }
 }


### PR DESCRIPTION
## Summary
- safeguard block FEM optimizer updates by merging candidate conductivities with the existing distribution
- ensure both single- and multi-optimizer paths retain untouched elements to keep reconstruction canvases aligned with solver state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f060c98c88333ae8c7c5d278d126c)