### PR TITLE
Improve post-processing hover, save, and comparison metrics

### DIFF
--- a/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
+++ b/ElectricalImpedanceTomography/ViewModels/PostProcessingPageViewModel.cs
@@ -15,6 +15,7 @@ using Utility.Classes.Discretizer;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
 using Utility.Classes.PostProcessing;
+using Utility.Classes.Reconstruction.Metrics;
 using Utility.Rendering;
 
 namespace ElectricalImpedanceTomography.ViewModels
@@ -69,6 +70,21 @@ namespace ElectricalImpedanceTomography.ViewModels
         [ObservableProperty]
         private string _statAvg = "0.000";
 
+        [ObservableProperty]
+        private string _metricCorrelation = "N/A";
+
+        [ObservableProperty]
+        private string _metricMae = "N/A";
+
+        [ObservableProperty]
+        private string _metricRmse = "N/A";
+
+        [ObservableProperty]
+        private string _metricSsim = "N/A";
+
+        [ObservableProperty]
+        private string _metricPsnr = "N/A";
+
         // Collections
         public ObservableCollection<string> ConsoleLogs { get; } = new();
         public ObservableCollection<string> HistoryLog { get; } = new();
@@ -86,6 +102,7 @@ namespace ElectricalImpedanceTomography.ViewModels
 
         // Events
         public event EventHandler? MeshUpdated;
+        public event EventHandler<PostProcessingImageSaveRequest>? ImageSaveRequested;
 
         // Internal state
         private IDiscretization? _discretization;
@@ -136,7 +153,9 @@ namespace ElectricalImpedanceTomography.ViewModels
                                                    Dictionary<int, double> Conductivities,
                                                    SavedFemMesh? Fem,
                                                    SavedLbmGrid? Lbm,
-                                                   string? Label);
+                                                   string? Label,
+                                                   List<string>? History,
+                                                   string? DisplayMode);
 
         public PostProcessingPageViewModel()
         {
@@ -299,6 +318,14 @@ namespace ElectricalImpedanceTomography.ViewModels
                 var json = JsonSerializer.Serialize(snapshot, options);
                 File.WriteAllText(jsonPath, json);
 
+                var historyPath = Path.Combine(exportDir, $"{name}_history.txt");
+                var historyLines = HistoryLog.Reverse().ToList();
+                if (historyLines.Count == 0)
+                {
+                    historyLines.Add("No post-processing steps recorded.");
+                }
+                File.WriteAllLines(historyPath, historyLines);
+
                 var csvPath = Path.Combine(exportDir, $"{name}.csv");
                 using (var writer = new StreamWriter(csvPath))
                 {
@@ -309,8 +336,11 @@ namespace ElectricalImpedanceTomography.ViewModels
                     }
                 }
 
+                var pngPath = Path.Combine(exportDir, $"{name}.png");
+                ImageSaveRequested?.Invoke(this, new PostProcessingImageSaveRequest(pngPath));
+
                 LastSavedPath = jsonPath;
-                Log($"Saved snapshot to {jsonPath} and CSV to {csvPath}.", "success");
+                Log($"Saved snapshot to {jsonPath}, CSV to {csvPath}, and history to {historyPath}.", "success");
                 AddToHistory($"Saved {name}");
             }
             catch (Exception ex)
@@ -322,7 +352,13 @@ namespace ElectricalImpedanceTomography.ViewModels
         private SavedPostProcessingSnapshot CreateSnapshot(string label)
         {
             if (_currentDistribution == null)
-                return new SavedPostProcessingSnapshot("None", new Dictionary<int, double>(), null, null, label);
+                return new SavedPostProcessingSnapshot("None",
+                                                       new Dictionary<int, double>(),
+                                                       null,
+                                                       null,
+                                                       label,
+                                                       HistoryLog.Reverse().ToList(),
+                                                       SelectedConductivityDisplayMode.ToString());
 
             SavedFemMesh? fem = null;
             SavedLbmGrid? lbm = null;
@@ -352,7 +388,13 @@ namespace ElectricalImpedanceTomography.ViewModels
 
             var conductivities = new Dictionary<int, double>(_currentDistribution.Conductivities);
             var type = FemMesh != null ? "FEM" : (LbmGrid != null ? "LBM" : "Unknown");
-            return new SavedPostProcessingSnapshot(type, conductivities, fem, lbm, label);
+            return new SavedPostProcessingSnapshot(type,
+                                                   conductivities,
+                                                   fem,
+                                                   lbm,
+                                                   label,
+                                                   HistoryLog.Reverse().ToList(),
+                                                   SelectedConductivityDisplayMode.ToString());
         }
 
         public void LoadFromFile(string path)
@@ -506,6 +548,9 @@ namespace ElectricalImpedanceTomography.ViewModels
                 var distribution = BuildDistribution(mesh, snapshot.Conductivities);
                 mesh.SetConductivityDistribution(distribution);
                 LoadDiscretization(mesh, distribution, snapshot.Label ?? fallbackLabel);
+                RestoreHistory(snapshot.History);
+                if (snapshot.DisplayMode != null && Enum.TryParse(snapshot.DisplayMode, out ConductivityDisplayMode mode))
+                    SelectedConductivityDisplayMode = mode;
                 return;
             }
 
@@ -527,6 +572,9 @@ namespace ElectricalImpedanceTomography.ViewModels
                 var distribution = BuildDistribution(grid, snapshot.Conductivities);
                 grid.SetConductivityDistribution(distribution);
                 LoadDiscretization(grid, distribution, snapshot.Label ?? fallbackLabel);
+                RestoreHistory(snapshot.History);
+                if (snapshot.DisplayMode != null && Enum.TryParse(snapshot.DisplayMode, out ConductivityDisplayMode mode))
+                    SelectedConductivityDisplayMode = mode;
                 return;
             }
 
@@ -630,6 +678,7 @@ namespace ElectricalImpedanceTomography.ViewModels
             StatMin = _dataMin.ToString("F3");
             StatMax = _dataMax.ToString("F3");
             StatAvg = _currentDistribution.Conductivities.Values.Average().ToString("F3");
+            UpdateComparisonMetrics();
 
             if (resetCutoffs || !_cutoffsInitialized)
             {
@@ -663,6 +712,8 @@ namespace ElectricalImpedanceTomography.ViewModels
             string time = DateTime.Now.ToString("HH:mm:ss");
             ConsoleLogs.Add($"[{time}] {msg}");
         }
+
+        public void LogExternal(string msg, string type = "normal") => Log(msg, type);
 
         private void AddToHistory(string action) => HistoryLog.Insert(0, $"[{DateTime.Now:HH:mm:ss}] {action}");
 
@@ -702,6 +753,119 @@ namespace ElectricalImpedanceTomography.ViewModels
                 return string.Empty;
 
             return string.Join(", ", ParameterOptions.Select(p => $"{p.Name}={p.FormattedValue}"));
+        }
+
+        private void RestoreHistory(IReadOnlyList<string>? history)
+        {
+            if (history == null || history.Count == 0)
+                return;
+
+            HistoryLog.Clear();
+            foreach (var line in history.Reverse())
+            {
+                HistoryLog.Add(line);
+            }
+        }
+
+        private void UpdateComparisonMetrics()
+        {
+            if (_currentDistribution == null || _originalDistribution == null || _currentDistribution.Conductivities.Count == 0)
+            {
+                MetricCorrelation = "N/A";
+                MetricMae = "N/A";
+                MetricRmse = "N/A";
+                MetricSsim = "N/A";
+                MetricPsnr = "N/A";
+                return;
+            }
+
+            var reconstructed = _currentDistribution.Conductivities;
+            var original = _originalDistribution.Conductivities;
+
+            double sumSq = 0.0;
+            double sumAbs = 0.0;
+            double maxAbs = 0.0;
+
+            var reconValues = new double[reconstructed.Count];
+            var origValues = new double[reconstructed.Count];
+            int index = 0;
+            foreach (var kv in reconstructed)
+            {
+                original.TryGetValue(kv.Key, out var origVal);
+                reconValues[index] = kv.Value;
+                origValues[index] = origVal;
+
+                double diff = kv.Value - origVal;
+                sumSq += diff * diff;
+                sumAbs += Math.Abs(diff);
+                maxAbs = Math.Max(maxAbs, Math.Max(Math.Abs(origVal), Math.Abs(kv.Value)));
+                index++;
+            }
+
+            int count = Math.Max(reconstructed.Count, 1);
+            double mse = sumSq / count;
+            double rmse = Math.Sqrt(mse);
+            double mae = sumAbs / count;
+            double psnr = mse <= 1e-12
+                ? double.PositiveInfinity
+                : 20.0 * Math.Log10((maxAbs <= 1e-12 ? 1.0 : maxAbs) / Math.Sqrt(mse));
+
+            double ssim = ComputeSsim(origValues, reconValues);
+            double correlation = ReconstructionStatistics.CalculateCorrelation(_currentDistribution, _originalDistribution, true);
+
+            MetricCorrelation = FormatMetric(correlation);
+            MetricMae = FormatMetric(mae);
+            MetricRmse = FormatMetric(rmse);
+            MetricSsim = FormatMetric(ssim);
+            MetricPsnr = double.IsPositiveInfinity(psnr) ? "∞" : FormatMetric(psnr);
+        }
+
+        private static string FormatMetric(double value)
+            => double.IsNaN(value) ? "N/A" : value.ToString("0.####", CultureInfo.InvariantCulture);
+
+        private static double ComputeSsim(IReadOnlyList<double> reference, IReadOnlyList<double> test)
+        {
+            if (reference.Count == 0 || reference.Count != test.Count)
+                return double.NaN;
+
+            double meanRef = 0.0;
+            double meanTest = 0.0;
+            for (int i = 0; i < reference.Count; i++)
+            {
+                meanRef += reference[i];
+                meanTest += test[i];
+            }
+
+            int n = reference.Count;
+            meanRef /= n;
+            meanTest /= n;
+
+            double varianceRef = 0.0;
+            double varianceTest = 0.0;
+            double covariance = 0.0;
+            for (int i = 0; i < reference.Count; i++)
+            {
+                double centeredRef = reference[i] - meanRef;
+                double centeredTest = test[i] - meanTest;
+                varianceRef += centeredRef * centeredRef;
+                varianceTest += centeredTest * centeredTest;
+                covariance += centeredRef * centeredTest;
+            }
+
+            varianceRef /= n;
+            varianceTest /= n;
+            covariance /= n;
+
+            const double c1 = 0.01 * 0.01;
+            const double c2 = 0.03 * 0.03;
+
+            double numerator = (2 * meanRef * meanTest + c1) * (2 * covariance + c2);
+            double denominator = (meanRef * meanRef + meanTest * meanTest + c1) * (varianceRef + varianceTest + c2);
+
+            if (denominator <= 1e-12)
+                return double.NaN;
+
+            return numerator / denominator;
         }
     }
 
@@ -775,4 +939,6 @@ namespace ElectricalImpedanceTomography.ViewModels
             double step = 1.0)
             => new(name, description, 0, 100, step, initialPercent, apply, isPercentage: true);
     }
+
+    public readonly record struct PostProcessingImageSaveRequest(string Path);
 }

--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml
@@ -175,6 +175,8 @@
                                     <skia:SKCanvasView Grid.Column="0" x:Name="PostProcessingCanvas"
                                                        PaintSurface="OnCanvasViewPaintSurface"
                                                        IgnorePixelScaling="True"
+                                                       EnableTouchEvents="True"
+                                                       Touch="OnPostProcessingCanvasTouch"
                                                        HorizontalOptions="Fill"
                                                        VerticalOptions="Fill" />
 
@@ -240,9 +242,9 @@
                                 <VerticalStackLayout Spacing="8">
                                     <Label Text="Method Parameters" Style="{StaticResource HeaderLabel}" Margin="0,0,0,6"/>
                                     <Label Text="{Binding SelectedPostProcessor.Name}" TextColor="{StaticResource TextPrimary}" FontAttributes="Bold" FontSize="14"/>
-                                    <CollectionView ItemsSource="{Binding ParameterOptions}" IsVisible="{Binding HasParameterOptions}" SelectionMode="None" ItemsLayout="VerticalList" HeightRequest="190">
+                                        <CollectionView ItemsSource="{Binding ParameterOptions}" IsVisible="{Binding HasParameterOptions}" SelectionMode="None" ItemsLayout="VerticalList" HeightRequest="190">
                                         <CollectionView.ItemTemplate>
-                                            <DataTemplate x:DataType="post:IPostProcessing">
+                                            <DataTemplate x:DataType="viewmodels:PostProcessingParameterOption">
                                                 <VerticalStackLayout Spacing="6">
                                                     <Label Text="{Binding Name}" TextColor="{StaticResource TextSecondary}" FontAttributes="Bold" FontSize="12"/>
                                                     <Label Text="{Binding Description}" TextColor="{StaticResource TextMuted}" FontSize="11" LineBreakMode="WordWrap"/>
@@ -291,6 +293,44 @@
                                         </CollectionView.EmptyView>
                                     </CollectionView>
                                     <Button Text="Export" Command="{Binding ExportDataCommand}" Style="{StaticResource ToolbarBtn}"/>
+                                </VerticalStackLayout>
+                            </Border>
+
+                            <Border BackgroundColor="#0b0e12" Stroke="{StaticResource BorderColor}" StrokeShape="RoundRectangle 8" Padding="12">
+                                <VerticalStackLayout Spacing="8">
+                                    <Label Text="Comparison to Original" Style="{StaticResource HeaderLabel}" Margin="0,0,0,6"/>
+                                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="8" RowSpacing="8">
+                                        <Border Style="{StaticResource StatCard}">
+                                            <VerticalStackLayout>
+                                                <Label Text="Pearson" TextColor="{StaticResource TextSecondary}" FontSize="10"/>
+                                                <Label Text="{Binding MetricCorrelation}" TextColor="{StaticResource TextPrimary}" FontAttributes="Bold" FontSize="14"/>
+                                            </VerticalStackLayout>
+                                        </Border>
+                                        <Border Grid.Column="1" Style="{StaticResource StatCard}">
+                                            <VerticalStackLayout>
+                                                <Label Text="MAE" TextColor="{StaticResource TextSecondary}" FontSize="10"/>
+                                                <Label Text="{Binding MetricMae}" TextColor="{StaticResource TextPrimary}" FontAttributes="Bold" FontSize="14"/>
+                                            </VerticalStackLayout>
+                                        </Border>
+                                        <Border Grid.Row="1" Style="{StaticResource StatCard}">
+                                            <VerticalStackLayout>
+                                                <Label Text="RMSE" TextColor="{StaticResource TextSecondary}" FontSize="10"/>
+                                                <Label Text="{Binding MetricRmse}" TextColor="{StaticResource TextPrimary}" FontAttributes="Bold" FontSize="14"/>
+                                            </VerticalStackLayout>
+                                        </Border>
+                                        <Border Grid.Row="1" Grid.Column="1" Style="{StaticResource StatCard}">
+                                            <VerticalStackLayout>
+                                                <Label Text="SSIM" TextColor="{StaticResource TextSecondary}" FontSize="10"/>
+                                                <Label Text="{Binding MetricSsim}" TextColor="{StaticResource TextPrimary}" FontAttributes="Bold" FontSize="14"/>
+                                            </VerticalStackLayout>
+                                        </Border>
+                                        <Border Grid.Row="2" Grid.ColumnSpan="2" Style="{StaticResource StatCard}">
+                                            <VerticalStackLayout>
+                                                <Label Text="PSNR" TextColor="{StaticResource TextSecondary}" FontSize="10"/>
+                                                <Label Text="{Binding MetricPsnr}" TextColor="{StaticResource TextPrimary}" FontAttributes="Bold" FontSize="14"/>
+                                            </VerticalStackLayout>
+                                        </Border>
+                                    </Grid>
                                 </VerticalStackLayout>
                             </Border>
                         </VerticalStackLayout>

--- a/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
+++ b/ElectricalImpedanceTomography/Views/PostProcessingPage.xaml.cs
@@ -1,5 +1,7 @@
 using ElectricalImpedanceTomography.ViewModels;
 using SkiaSharp;
+using SkiaSharp.Views.Maui;
+using SkiaSharp.Views.Maui.Controls;
 using System.Linq;
 using Utility.Classes.Discretizer.FiniteElementMesh;
 using Utility.Classes.Discretizer.LatticeBoltzmannGrid;
@@ -23,7 +25,9 @@ namespace ElectricalImpedanceTomography.Views
             TextAlign = SKTextAlign.Center
         };
 
-        private float _scale, _marginX, _marginY, _minX, _minY, _meshWidth, _meshHeight;
+        private float _scale, _marginX, _marginY, _minX, _minY, _meshWidth, _meshHeight, _canvasHeight;
+        private string[]? _hoverLines;
+        private SKPoint? _hoverPoint;
 
         private static readonly (double Position, SKColor Color)[] EnhancedDivergingPalette =
         {
@@ -117,6 +121,7 @@ namespace ElectricalImpedanceTomography.Views
             BindingContext = _viewModel;
 
             _viewModel.MeshUpdated += (_, _) => PostProcessingCanvas?.InvalidateSurface();
+            _viewModel.ImageSaveRequested += (_, args) => SavePostProcessingImage(args);
             _viewModel.PropertyChanged += (_, args) =>
             {
                 if (args.PropertyName == nameof(PostProcessingPageViewModel.MinCutoff)
@@ -196,25 +201,13 @@ namespace ElectricalImpedanceTomography.Views
                 canvas.DrawRect(rect, fill);
                 canvas.DrawRect(rect, _lbmStroke);
             }
+
+            DrawHoverInfo(canvas, info, _hoverLines, _hoverPoint);
         }
 
         private void DrawFemMesh(SKCanvas canvas, SKImageInfo info, FEMMesh mesh)
         {
-            const float pad = 10f;
-            float availW = info.Width - 2 * pad;
-            float availH = info.Height - 2 * pad;
-            var verts = mesh.Vertices;
-            _minX = (float)verts.Min(v => v.X);
-            _minY = (float)verts.Min(v => v.Y);
-            var maxX = (float)verts.Max(v => v.X);
-            var maxY = (float)verts.Max(v => v.Y);
-            _meshWidth = maxX - _minX;
-            _meshHeight = maxY - _minY;
-            _scale = Math.Min(availW / _meshWidth, availH / _meshHeight);
-            float usedW = _meshWidth * _scale;
-            float usedH = _meshHeight * _scale;
-            _marginX = pad + (availW - usedW) / 2f;
-            _marginY = pad + (availH - usedH) / 2f;
+            ComputeFemTransform(mesh, info);
 
             using var path = new SKPath();
 
@@ -236,9 +229,53 @@ namespace ElectricalImpedanceTomography.Views
                 canvas.DrawPath(path, _femFill);
                 canvas.DrawPath(path, _femStroke);
             }
+
+            DrawHoverInfo(canvas, info, _hoverLines, _hoverPoint);
         }
 
-        private SKPoint ToCanvas(FEMVertex v) => new((float)(v.X - _minX) * _scale + _marginX, PostProcessingCanvas.CanvasSize.Height - ((float)(v.Y - _minY) * _scale + _marginY));
+        private void ComputeFemTransform(FEMMesh mesh, SKImageInfo info)
+        {
+            const float pad = 10f;
+            float availW = info.Width - 2 * pad;
+            float availH = info.Height - 2 * pad;
+            var verts = mesh.Vertices;
+            _minX = (float)verts.Min(v => v.X);
+            _minY = (float)verts.Min(v => v.Y);
+            var maxX = (float)verts.Max(v => v.X);
+            var maxY = (float)verts.Max(v => v.Y);
+            _meshWidth = maxX - _minX;
+            _meshHeight = maxY - _minY;
+            _scale = Math.Min(availW / _meshWidth, availH / _meshHeight);
+            float usedW = _meshWidth * _scale;
+            float usedH = _meshHeight * _scale;
+            _marginX = pad + (availW - usedW) / 2f;
+            _marginY = pad + (availH - usedH) / 2f;
+            _canvasHeight = info.Height;
+        }
+
+        private SKPoint ToCanvas(FEMVertex v)
+            => new((float)(v.X - _minX) * _scale + _marginX,
+                   _canvasHeight - ((float)(v.Y - _minY) * _scale + _marginY));
+
+        private float Dot(SKPoint a, SKPoint b) => a.X * b.X + a.Y * b.Y;
+
+        private bool PointInTriangle(SKPoint p, SKPoint a, SKPoint b, SKPoint c,
+                                     out float u, out float v, out float w)
+        {
+            var v0 = b - a;
+            var v1 = c - a;
+            var v2 = p - a;
+            float d00 = Dot(v0, v0);
+            float d01 = Dot(v0, v1);
+            float d11 = Dot(v1, v1);
+            float d20 = Dot(v2, v0);
+            float d21 = Dot(v2, v1);
+            float denom = d00 * d11 - d01 * d01;
+            v = (d11 * d20 - d01 * d21) / denom;
+            w = (d00 * d21 - d01 * d20) / denom;
+            u = 1 - v - w;
+            return (u >= 0) && (v >= 0) && (w >= 0);
+        }
 
         private static SKColor Lerp(SKColor a, SKColor b, double t)
         {
@@ -313,6 +350,31 @@ namespace ElectricalImpedanceTomography.Views
                             _placeholderText);
         }
 
+        private void DrawHoverInfo(SKCanvas canvas, SKImageInfo info, string[]? lines, SKPoint? pt)
+        {
+            if (lines == null || !pt.HasValue)
+                return;
+
+            using var txt = new SKPaint { IsAntialias = true, Color = SKColors.White };
+            using var font = new SKFont(SKTypeface.Default, 14);
+            float w = lines.Max(l => font.MeasureText(l)) + 8;
+            float h = lines.Length * (font.Size + 4) + 4;
+            var center = new SKPoint(info.Width / 2f, info.Height / 2f);
+            var dir = new SKPoint(center.X - pt.Value.X, center.Y - pt.Value.Y);
+            const float off = 8f;
+            float x = dir.X > 0 ? pt.Value.X + off : pt.Value.X - off - w;
+            float y = dir.Y > 0 ? pt.Value.Y + off : pt.Value.Y - off - h;
+            var box = new SKRect(x, y, x + w, y + h);
+            using var bg = new SKPaint { Color = new SKColor(0, 0, 0, 200), IsAntialias = true };
+            canvas.DrawRoundRect(box, 4, 4, bg);
+            float ty = box.Top + font.Size + 2;
+            foreach (var line in lines)
+            {
+                canvas.DrawText(line, box.Left + 4, ty, SKTextAlign.Left, font, txt);
+                ty += font.Size + 4;
+            }
+        }
+
         private void OnColorBarPaintSurface(object? sender, SkiaSharp.Views.Maui.SKPaintSurfaceEventArgs e)
         {
             var canvas = e.Surface.Canvas;
@@ -360,6 +422,113 @@ namespace ElectricalImpedanceTomography.Views
             canvas.DrawText(maxText, labelX, barRect.Top + _legendText.TextSize, _legendText);
             canvas.DrawText(midText, labelX, barRect.MidY + _legendText.TextSize * 0.35f, _legendText);
             canvas.DrawText(minText, labelX, barRect.Bottom, _legendText);
+        }
+
+        private void OnPostProcessingCanvasTouch(object sender, SKTouchEventArgs e)
+        {
+            if (!_viewModel.HasMesh)
+                return;
+
+            if (e.ActionType == SKTouchAction.Released || e.ActionType == SKTouchAction.Cancelled)
+            {
+                _hoverLines = null;
+                _hoverPoint = null;
+                ((SKCanvasView)sender).InvalidateSurface();
+                e.Handled = true;
+                return;
+            }
+
+            var view = (SKCanvasView)sender;
+            if (_viewModel.FemMesh is FEMMesh fem)
+            {
+                ComputeFemTransform(fem, new SKImageInfo((int)view.CanvasSize.Width, (int)view.CanvasSize.Height));
+                _hoverLines = null;
+                _hoverPoint = null;
+                foreach (var elem in fem.GetElements().Cast<FEMElement>())
+                {
+                    var c0 = ToCanvas(elem.Vertices[0]);
+                    var c1 = ToCanvas(elem.Vertices[1]);
+                    var c2 = ToCanvas(elem.Vertices[2]);
+                    if (PointInTriangle(e.Location, c0, c1, c2, out _, out _, out _))
+                    {
+                        double val = _viewModel.GetConductivityValue(elem.Id, elem.Conductivity);
+                        _hoverLines = new[] { $"Elem: {elem.Id}", $"σ: {val:F3}" };
+                        _hoverPoint = e.Location;
+                        break;
+                    }
+                }
+
+                view.InvalidateSurface();
+                e.Handled = true;
+                return;
+            }
+
+            if (_viewModel.LbmGrid is LBMGrid lbm)
+            {
+                float cw = view.CanvasSize.Width / lbm.Nx;
+                float ch = view.CanvasSize.Height / lbm.Ny;
+                int col = (int)(e.Location.X / cw);
+                int row = (int)(e.Location.Y / ch);
+                col = Math.Clamp(col, 0, lbm.Nx - 1);
+                row = Math.Clamp(row, 0, lbm.Ny - 1);
+                var el = lbm.GetElementAt(col, row);
+                double val = _viewModel.GetConductivityValue(el.Id, el.Conductivity);
+                _hoverLines = new[] { $"ID: {el.Id}", $"σ: {val:F3}" };
+                _hoverPoint = e.Location;
+                view.InvalidateSurface();
+                e.Handled = true;
+            }
+        }
+
+        private void SavePostProcessingImage(PostProcessingImageSaveRequest request)
+        {
+            var previousHoverLines = _hoverLines;
+            var previousHoverPoint = _hoverPoint;
+            _hoverLines = null;
+            _hoverPoint = null;
+
+            try
+            {
+                int width = (int)PostProcessingCanvas.CanvasSize.Width;
+                int height = (int)PostProcessingCanvas.CanvasSize.Height;
+                if (width <= 0 || height <= 0)
+                {
+                    width = 900;
+                    height = 900;
+                }
+
+                using var surface = SKSurface.Create(new SKImageInfo(width, height));
+                var canvas = surface.Canvas;
+                canvas.Clear(SKColors.Transparent);
+
+                if (_viewModel.LbmGrid is LBMGrid lbm)
+                {
+                    DrawLbmGrid(canvas, new SKImageInfo(width, height), lbm);
+                }
+                else if (_viewModel.FemMesh is FEMMesh fem)
+                {
+                    DrawFemMesh(canvas, new SKImageInfo(width, height), fem);
+                }
+                else
+                {
+                    return;
+                }
+
+                using var image = surface.Snapshot();
+                using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+                using var stream = System.IO.File.OpenWrite(request.Path);
+                data.SaveTo(stream);
+                _viewModel.LogExternal($"Saved post-processing image to {request.Path}.", "success");
+            }
+            catch (Exception ex)
+            {
+                _viewModel.LogExternal($"Failed to save post-processing image: {ex.Message}", "error");
+            }
+            finally
+            {
+                _hoverLines = previousHoverLines;
+                _hoverPoint = previousHoverPoint;
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Mirror the reconstruction page UX by showing conductivity values when hovering elements on the post-processing canvas. 
- Restore and surface method parameter controls and action history in the right-hand panel so users can tune and inspect post-processing steps. 
- Provide a save/export workflow that persists the current post-processed state (image, discretization, conductivities and a history description) so the result can be reloaded and refined later. 
- Give users immediate quantitative feedback by computing similarity/error metrics between the current post-processed distribution and the original distribution.

### Description
- Add touch handlers and hover tooltip rendering to `PostProcessingCanvas` by wiring `EnableTouchEvents`/`Touch=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fb8a2ed308333ace7aaee818ffdb6)